### PR TITLE
Update interface to fcu

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -12,7 +12,10 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   tf
   pcl_ros
+  mavros
+  mavros_extras
   mavros_msgs
+  mavlink
 )
 find_package(PCL 1.7 REQUIRED)
 find_package(OpenCV REQUIRED)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -41,6 +41,7 @@ gen.add("use_back_off_", bool_t, 0, "Enable functionality to move backwards if a
 gen.add("use_avoid_sphere_", bool_t, 0, "Move in void_radius around close points", True)
 gen.add("use_VFH_star_", bool_t, 0, "Build lookahead-tree", True)
 gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, allow rising", True)
+gen.add("send_obstacles_fcu_", bool_t, 0, "Send 2D obstacle representation to the FCU", False)
 
 # star_planner
 gen.add("childs_per_node_",    int_t,    0, "Branching factor of the search tree", 10,  0, 100)

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -28,7 +28,6 @@ void LocalPlanner::setPose(const geometry_msgs::PoseStamped msg) {
   }
 
   if (!offboard_) {
-    reach_altitude_ = false;
     offboard_pose_.header = msg.header;
     offboard_pose_.pose.position = msg.pose.position;
     offboard_pose_.pose.orientation = msg.pose.orientation;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -75,6 +75,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
   use_back_off_ = config.use_back_off_;
   use_VFH_star_ = config.use_VFH_star_;
   adapt_cost_params_ = config.adapt_cost_params_;
+  send_obstacles_fcu_ = config.send_obstacles_fcu_;
 
   ROS_DEBUG("Dynamic reconfigure call");
   star_planner_.dynamicReconfigureSetStarParams(config, level);
@@ -164,6 +165,31 @@ void LocalPlanner::runPlanner() {
   determineStrategy();
 }
 
+void LocalPlanner::create2DObstacleRepresentation(const bool need_histogram,
+                                                  const bool send_to_fcu) {
+  // construct histogram if it is needed for the current local_planner_mode_
+  // or if it is required by the FCU
+  if (need_histogram || send_to_fcu) {
+    reprojectPoints(polar_histogram_);
+    Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
+    Histogram new_histogram = Histogram(ALPHA_RES);
+    to_fcu_histogram_.setZero();
+
+    propagateHistogram(propagated_histogram, reprojected_points_,
+                       reprojected_points_age_, reprojected_points_dist_,
+                       pose_);
+    generateNewHistogram(new_histogram, final_cloud_, pose_);
+    combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,
+                      waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_,
+                      e_FOV_max_);
+    if (send_to_fcu) {
+      compressHistogramElevation(to_fcu_histogram_, new_histogram);
+      updateObstacleDistanceMsg(to_fcu_histogram_);
+    }
+    polar_histogram_ = new_histogram;
+  }
+}
+
 void LocalPlanner::determineStrategy() {
   star_planner_.tree_age_++;
   tree_time_.push_back(0);
@@ -173,12 +199,14 @@ void LocalPlanner::determineStrategy() {
              starting_height_);
     local_planner_mode_ = 0;
     goFast();
+    create2DObstacleRepresentation(false, send_obstacles_fcu_);
   } else if (final_cloud_.points.size() > min_cloud_size_ && stop_in_front_ &&
              reach_altitude_) {
     obstacle_ = true;
     ROS_INFO("\033[1;32m There is an Obstacle Ahead stop in front\n \033[0m");
     local_planner_mode_ = 3;
     stopInFrontObstacles();
+    create2DObstacleRepresentation(false, send_obstacles_fcu_);
   } else {
     if (((counter_close_points_backoff_ > 20 &&
           final_cloud_.points.size() > min_cloud_size_) ||
@@ -192,10 +220,10 @@ void LocalPlanner::determineStrategy() {
         back_off_ = true;
       }
       backOff();
+      create2DObstacleRepresentation(false, send_obstacles_fcu_);
 
     } else {
       evaluateProgressRate();
-      reprojectPoints(polar_histogram_);
 
       tf::Quaternion q(pose_.pose.orientation.x, pose_.pose.orientation.y,
                        pose_.pose.orientation.z, pose_.pose.orientation.w);
@@ -217,21 +245,7 @@ void LocalPlanner::determineStrategy() {
         }
       }
 
-      Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
-      Histogram new_histogram = Histogram(ALPHA_RES);
-      to_fcu_histogram_.setZero();
-
-      propagateHistogram(propagated_histogram, reprojected_points_,
-                         reprojected_points_age_, reprojected_points_dist_,
-                         pose_);
-      generateNewHistogram(new_histogram, final_cloud_, pose_);
-      combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,
-                        waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_,
-                        e_FOV_max_);
-      compressHistogramElevation(to_fcu_histogram_, new_histogram);
-      updateObstacleDistanceMsg(to_fcu_histogram_);
-
-      polar_histogram_ = new_histogram;
+      create2DObstacleRepresentation(true, send_obstacles_fcu_);
 
       // decide how to proceed
       if (hist_is_empty_) {

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -225,15 +225,11 @@ void LocalPlanner::determineStrategy() {
                          reprojected_points_age_, reprojected_points_dist_,
                          pose_);
       generateNewHistogram(new_histogram, final_cloud_, pose_);
-<<<<<<< b020ac50aeb5fedef1c6432ca8170315588d2f4b
       combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,
                         waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_,
                         e_FOV_max_);
-=======
-      combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram, waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_);
       compressHistogramElevation(to_fcu_histogram_, new_histogram);
       updateObstacleDistanceMsg(to_fcu_histogram_);
->>>>>>> local_planner: create histogram to send distance from obstacles to the fcu
 
       polar_histogram_ = new_histogram;
 
@@ -363,8 +359,8 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
   }
 
   for (int idx = 0; idx < GRID_LENGTH_Z; idx++) {
-
-    if (std::find(z_FOV_idx_north.begin(), z_FOV_idx_north.end(), idx) == z_FOV_idx_north.end()) {
+    if (std::find(z_FOV_idx_north.begin(), z_FOV_idx_north.end(), idx) ==
+        z_FOV_idx_north.end()) {
       msg.ranges.push_back(UINT16_MAX);
       continue;
     }
@@ -967,6 +963,7 @@ void LocalPlanner::getWaypoints(geometry_msgs::Vector3Stamped &waypt,
   waypt_smoothed = waypt_smoothed_;
 }
 
-void LocalPlanner::sendObstacleDistanceDataToFcu(sensor_msgs::LaserScan &obstacle_distance) {
+void LocalPlanner::sendObstacleDistanceDataToFcu(
+    sensor_msgs::LaserScan &obstacle_distance) {
   obstacle_distance = distance_data_;
 }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -353,26 +353,26 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
   std::vector<int> z_FOV_idx_north;
 
   for (int i = 0; i < z_FOV_idx_.size(); i++) {
-    int new_idx = z_FOV_idx_[i] + grid_length_z / 2;
+    int new_idx = z_FOV_idx_[i] + GRID_LENGTH_Z / 2;
 
-    if (new_idx >= grid_length_z) {
-      new_idx = new_idx - grid_length_z;
+    if (new_idx >= GRID_LENGTH_Z) {
+      new_idx = new_idx - GRID_LENGTH_Z;
     }
 
     z_FOV_idx_north.push_back(new_idx);
   }
 
-  for (int idx = 0; idx < grid_length_z; idx++) {
+  for (int idx = 0; idx < GRID_LENGTH_Z; idx++) {
 
     if (std::find(z_FOV_idx_north.begin(), z_FOV_idx_north.end(), idx) == z_FOV_idx_north.end()) {
       msg.ranges.push_back(UINT16_MAX);
       continue;
     }
 
-    int hist_idx = idx - grid_length_z / 2;
+    int hist_idx = idx - GRID_LENGTH_Z / 2;
 
     if (hist_idx < 0) {
-      hist_idx = hist_idx + grid_length_z;
+      hist_idx = hist_idx + GRID_LENGTH_Z;
     }
 
     if (hist.get_dist(0, hist_idx) == 0.0) {

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -350,6 +350,38 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
   msg.range_min = 0.2f;
   msg.range_max = 20.0f;
 
+  // turn idxs 180 degress to point to local north instead of south
+  std::vector<int> z_FOV_idx_north;
+
+  for (int i = 0; i < z_FOV_idx_.size(); i++) {
+    int new_idx = z_FOV_idx_[i] + grid_length_z / 2;
+
+    if (new_idx >= grid_length_z) {
+      new_idx = new_idx - grid_length_z;
+    }
+
+    z_FOV_idx_north.push_back(new_idx);
+  }
+
+  for (int idx = 0; idx < grid_length_z; idx++) {
+
+    if (std::find(z_FOV_idx_north.begin(), z_FOV_idx_north.end(), idx) == z_FOV_idx_north.end()) {
+      msg.ranges.push_back(UINT16_MAX);
+      continue;
+    }
+
+    int hist_idx = idx - grid_length_z / 2;
+
+    if (hist_idx < 0) {
+      hist_idx = hist_idx + grid_length_z;
+    }
+
+    if (hist.get_dist(0, hist_idx) == 0.0) {
+      msg.ranges.push_back(msg.range_max + 1.0f);
+    } else {
+      msg.ranges.push_back(hist.get_dist(0, hist_idx));
+    }
+  }
 
   distance_data_ = msg;
 }
@@ -361,6 +393,7 @@ void LocalPlanner::updateObstacleDistanceMsg() {
   msg.angle_increment = ALPHA_RES * M_PI / 180.0f;
   msg.range_min = 0.2f;
   msg.range_max = 20.0f;
+
   distance_data_ = msg;
 }
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -220,14 +220,21 @@ void LocalPlanner::determineStrategy() {
 
       Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
       Histogram new_histogram = Histogram(ALPHA_RES);
+      to_fcu_histogram_.setZero();
 
       propagateHistogram(propagated_histogram, reprojected_points_,
                          reprojected_points_age_, reprojected_points_dist_,
                          pose_);
       generateNewHistogram(new_histogram, final_cloud_, pose_);
+<<<<<<< b020ac50aeb5fedef1c6432ca8170315588d2f4b
       combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,
                         waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_,
                         e_FOV_max_);
+=======
+      combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram, waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_);
+      compressHistogramElevation(to_fcu_histogram_, new_histogram);
+      updateObstacleDistanceMsg(to_fcu_histogram_);
+>>>>>>> local_planner: create histogram to send distance from obstacles to the fcu
 
       polar_histogram_ = new_histogram;
 
@@ -333,6 +340,28 @@ void LocalPlanner::determineStrategy() {
       first_brake_ = true;
     }
   }
+}
+
+void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
+  sensor_msgs::LaserScan msg = {};
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "world";
+  msg.angle_increment = ALPHA_RES * M_PI / 180.0f;
+  msg.range_min = 0.2f;
+  msg.range_max = 20.0f;
+
+
+  distance_data_ = msg;
+}
+
+void LocalPlanner::updateObstacleDistanceMsg() {
+  sensor_msgs::LaserScan msg = {};
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "world";
+  msg.angle_increment = ALPHA_RES * M_PI / 180.0f;
+  msg.range_min = 0.2f;
+  msg.range_max = 20.0f;
+  distance_data_ = msg;
 }
 
 // get 3D points from old histogram
@@ -904,4 +933,8 @@ void LocalPlanner::getWaypoints(geometry_msgs::Vector3Stamped &waypt,
   waypt = waypt_;
   waypt_adapted = waypt_adapted_;
   waypt_smoothed = waypt_smoothed_;
+}
+
+void LocalPlanner::sendObstacleDistanceDataToFcu(sensor_msgs::LaserScan &obstacle_distance) {
+  obstacle_distance = distance_data_;
 }

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -40,6 +40,7 @@
 #include <tf/transform_listener.h>
 
 #include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/LaserScan.h>
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -163,6 +164,7 @@ class LocalPlanner {
   nav_msgs::GridCells path_waypoints_;
 
   Histogram polar_histogram_ = Histogram(ALPHA_RES);
+  Histogram to_fcu_histogram_ = Histogram(ALPHA_RES);
 
   void logData();
   void fitPlane();
@@ -178,6 +180,8 @@ class LocalPlanner {
   void getDirectionFromCostMap();
   void adaptSpeed();
   void stopInFrontObstacles();
+  void updateObstacleDistanceMsg(Histogram hist);
+  void updateObstacleDistanceMsg();
   geometry_msgs::Vector3Stamped smoothWaypoint(
       geometry_msgs::Vector3Stamped wp);
 
@@ -199,6 +203,8 @@ class LocalPlanner {
   double starting_height_ = 0.0;
 
   geometry_msgs::PoseStamped take_off_pose_;
+
+  sensor_msgs::LaserScan distance_data_ = {};
 
   Box histogram_box_size_;
 
@@ -238,6 +244,7 @@ class LocalPlanner {
   void getWaypoints(geometry_msgs::Vector3Stamped &waypt,
                     geometry_msgs::Vector3Stamped &waypt_adapted,
                     geometry_msgs::Vector3Stamped &waypt_smoothed);
+  void sendObstacleDistanceDataToFcu(sensor_msgs::LaserScan &obstacle_distance);
   void runPlanner();
 };
 

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -184,8 +184,7 @@ class LocalPlanner {
   void updateObstacleDistanceMsg();
   geometry_msgs::Vector3Stamped smoothWaypoint(
       geometry_msgs::Vector3Stamped wp);
-  void create2DObstacleRepresentation(const bool need_histogram,
-                                      const bool send_to_fcu);
+  void create2DObstacleRepresentation(const bool send_to_fcu);
 
  public:
   GroundDetector ground_detector_;

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -39,8 +39,8 @@
 
 #include <tf/transform_listener.h>
 
-#include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/PointCloud2.h>
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -184,6 +184,8 @@ class LocalPlanner {
   void updateObstacleDistanceMsg();
   geometry_msgs::Vector3Stamped smoothWaypoint(
       geometry_msgs::Vector3Stamped wp);
+  void create2DObstacleRepresentation(const bool need_histogram,
+                                      const bool send_to_fcu);
 
  public:
   GroundDetector ground_detector_;
@@ -191,6 +193,7 @@ class LocalPlanner {
   bool currently_armed_ = false;
   bool offboard_ = false;
   bool smooth_waypoints_ = true;
+  bool send_obstacles_fcu_ = false;
 
   std::vector<float> algorithm_total_time_;
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -24,7 +24,7 @@ LocalPlannerNode::LocalPlannerNode() {
   clicked_goal_sub_ =
       nh_.subscribe("/move_base_simple/goal", 1,
                     &LocalPlannerNode::clickedGoalCallback, this);
-  fcu_input_sub_ = nh_.subscribe("/mavros/obstacle/input_pose", 1, &LocalPlannerNode::fcuInputGoalCallback, this); 
+  fcu_input_sub_ = nh_.subscribe("/mavros/avoidance/input", 1, &LocalPlannerNode::fcuInputGoalCallback, this);
 
   local_pointcloud_pub_ =
       nh_.advertise<pcl::PointCloud<pcl::PointXYZ>>("/local_pointcloud", 1);
@@ -34,7 +34,6 @@ LocalPlannerNode::LocalPlannerNode() {
       nh_.advertise<pcl::PointCloud<pcl::PointXYZ>>("/reprojected_points", 1);
   bounding_box_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/bounding_box", 1);
-
   groundbox_pub_ = nh_.advertise<visualization_msgs::Marker>("/ground_box", 1);
   avoid_sphere_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/avoid_sphere", 1);
@@ -70,7 +69,7 @@ LocalPlannerNode::LocalPlannerNode() {
       nh_.advertise<visualization_msgs::Marker>("/bounding_box", 1);
   mavros_waypoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
       "/mavros/setpoint_position/local", 10);
-  mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::ObstacleAvoidance>("/mavros/obstacle/anchor_point", 10);
+ mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::ObstacleAvoidance>("/mavros/avoidance/output", 10);
   mavros_obstacle_distance_pub_ = nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
   current_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/current_setpoint", 1);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -24,7 +24,8 @@ LocalPlannerNode::LocalPlannerNode() {
   clicked_goal_sub_ =
       nh_.subscribe("/move_base_simple/goal", 1,
                     &LocalPlannerNode::clickedGoalCallback, this);
-  fcu_input_sub_ = nh_.subscribe("/mavros/trajectory/desired", 1, &LocalPlannerNode::fcuInputGoalCallback, this);
+  fcu_input_sub_ = nh_.subscribe("/mavros/trajectory/desired", 1,
+                                 &LocalPlannerNode::fcuInputGoalCallback, this);
 
   local_pointcloud_pub_ =
       nh_.advertise<pcl::PointCloud<pcl::PointXYZ>>("/local_pointcloud", 1);
@@ -69,8 +70,10 @@ LocalPlannerNode::LocalPlannerNode() {
       nh_.advertise<visualization_msgs::Marker>("/bounding_box", 1);
   mavros_waypoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
       "/mavros/setpoint_position/local", 10);
-  mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::Trajectory>("/mavros/trajectory/generated", 10);
-  mavros_obstacle_distance_pub_ = nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
+  mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::Trajectory>(
+      "/mavros/trajectory/generated", 10);
+  mavros_obstacle_distance_pub_ =
+      nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
   current_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/current_setpoint", 1);
   log_name_pub_ = nh_.advertise<std_msgs::String>("/log_name", 1);
@@ -590,10 +593,11 @@ void LocalPlannerNode::clickedGoalCallback(
   goal_msg_ = msg;
 }
 
-void LocalPlannerNode::fcuInputGoalCallback(const mavros_msgs::Trajectory &msg) {
-  
-  if (msg.point_valid[1] == true && (std::fabs(goal_msg_.pose.position.x - msg.point_2.position.x) > 0.001) &&
-   (std::fabs(goal_msg_.pose.position.y - msg.point_2.position.y) > 0.001) ){
+void LocalPlannerNode::fcuInputGoalCallback(
+    const mavros_msgs::Trajectory &msg) {
+  if (msg.point_valid[1] == true &&
+      (std::fabs(goal_msg_.pose.position.x - msg.point_2.position.x) > 0.001) &&
+      (std::fabs(goal_msg_.pose.position.y - msg.point_2.position.y) > 0.001)) {
     new_goal_ = true;
     goal_msg_.pose.position.x = msg.point_2.position.x;
     goal_msg_.pose.position.y = msg.point_2.position.y;
@@ -689,7 +693,8 @@ void LocalPlannerNode::publishSetpoint(const geometry_msgs::PoseStamped wp,
   current_waypoint_pub_.publish(setpoint);
 }
 
-void LocalPlannerNode::fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point) {
+void LocalPlannerNode::fillUnusedTrajectoryPoint(
+    mavros_msgs::PositionTarget &point) {
   point.position.x = NAN;
   point.position.y = NAN;
   point.position.z = NAN;
@@ -703,10 +708,10 @@ void LocalPlannerNode::fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &po
   point.yaw_rate = NAN;
 }
 
-void LocalPlannerNode::transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid, geometry_msgs::PoseStamped pose) {
-
+void LocalPlannerNode::transformPoseToTrajectory(
+    mavros_msgs::Trajectory &obst_avoid, geometry_msgs::PoseStamped pose) {
   obst_avoid.header = pose.header;
-  obst_avoid.type = 0; //MAV_TRAJECTORY_REPRESENTATION::WAYPOINTS
+  obst_avoid.type = 0;  // MAV_TRAJECTORY_REPRESENTATION::WAYPOINTS
   obst_avoid.point_1.position.x = pose.pose.position.x;
   obst_avoid.point_1.position.y = pose.pose.position.y;
   obst_avoid.point_1.position.z = pose.pose.position.z;
@@ -983,7 +988,8 @@ int main(int argc, char **argv) {
           NodePtr->local_planner_.getPosition(drone_pos);
           NodePtr->publishSetpoint(drone_pos, 5);
           mavros_msgs::Trajectory obst_free_path = {};
-          NodePtr->transformPoseToTrajectory(obst_free_path, NodePtr->newest_pose_);
+          NodePtr->transformPoseToTrajectory(obst_free_path,
+                                             NodePtr->newest_pose_);
           NodePtr->fillUnusedTrajectoryPoint(obst_free_path.point_2);
           NodePtr->fillUnusedTrajectoryPoint(obst_free_path.point_3);
           NodePtr->fillUnusedTrajectoryPoint(obst_free_path.point_4);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -783,9 +783,11 @@ void LocalPlannerNode::publishAll() {
       path_candidates, path_selected, path_rejected, path_blocked, FOV_cells,
       path_ground);
 
-  sensor_msgs::LaserScan distance_data_to_fcu;
-  local_planner_.sendObstacleDistanceDataToFcu(distance_data_to_fcu);
-  mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
+  if (local_planner_.send_obstacles_fcu_) {
+    sensor_msgs::LaserScan distance_data_to_fcu;
+    local_planner_.sendObstacleDistanceDataToFcu(distance_data_to_fcu);
+    mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
+  }
 
   publishMarkerCandidates(path_candidates);
   publishMarkerSelected(path_selected);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -71,6 +71,7 @@ LocalPlannerNode::LocalPlannerNode() {
   mavros_waypoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
       "/mavros/setpoint_position/local", 10);
   mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::ObstacleAvoidance>("/mavros/obstacle/anchor_point", 10);
+  mavros_obstacle_distance_pub_ = nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
   current_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/current_setpoint", 1);
   log_name_pub_ = nh_.advertise<std_msgs::String>("/log_name", 1);
@@ -755,6 +756,10 @@ void LocalPlannerNode::publishAll() {
   local_planner_.getCandidateDataForVisualization(
       path_candidates, path_selected, path_rejected, path_blocked, FOV_cells,
       path_ground);
+
+  sensor_msgs::LaserScan distance_data_to_fcu;
+  local_planner_.sendObstacleDistanceDataToFcu(distance_data_to_fcu);
+  mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
 
   publishMarkerCandidates(path_candidates);
   publishMarkerSelected(path_selected);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -691,6 +691,7 @@ void LocalPlannerNode::publishSetpoint(const geometry_msgs::PoseStamped wp,
 
 void LocalPlannerNode::transformPoseToObstacleAvoidance(mavros_msgs::ObstacleAvoidance &obst_avoid, geometry_msgs::PoseStamped pose) {
 
+  obst_avoid.header = pose.header;
   obst_avoid.type = 0;
   obst_avoid.point_1.position.x = pose.pose.position.x;
   obst_avoid.point_1.position.y = pose.pose.position.y;

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -12,6 +12,7 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <mavros_msgs/SetMode.h>
 #include <mavros_msgs/State.h>
+#include <mavros_msgs/ObstacleAvoidance.h>
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
 #include <pcl_conversions/pcl_conversions.h>  // fromROSMsg
@@ -62,6 +63,7 @@ class LocalPlannerNode {
   ros::Publisher log_name_pub_;
   ros::Publisher current_waypoint_pub_;
   ros::Publisher mavros_waypoint_pub_;
+  ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher waypoint_pub_;
   ros::ServiceClient mavros_set_mode_client_;
   tf::TransformListener tf_listener_;
@@ -73,6 +75,7 @@ class LocalPlannerNode {
   void threadFunction();
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp);
   void updatePlannerInfo();
+  void transformPoseToObstacleAvoidance(mavros_msgs::ObstacleAvoidance &obst_avoid, geometry_msgs::PoseStamped pose);
 
  private:
   ros::NodeHandle nh_;
@@ -90,6 +93,7 @@ class LocalPlannerNode {
   ros::Subscriber state_sub_;
   ros::Subscriber clicked_point_sub_;
   ros::Subscriber clicked_goal_sub_;
+  ros::Subscriber fcu_input_sub_;
 
   // Publishers
   ros::Publisher local_pointcloud_pub_;
@@ -148,6 +152,7 @@ class LocalPlannerNode {
   void publishMarkerFOV(nav_msgs::GridCells FOV_cells);
   void clickedPointCallback(const geometry_msgs::PointStamped &msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped &msg);
+  void fcuInputGoalCallback(const mavros_msgs::ObstacleAvoidance &msg);
   void printPointInfo(double x, double y, double z);
   void publishGoal();
   void publishBox();

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -64,6 +64,7 @@ class LocalPlannerNode {
   ros::Publisher current_waypoint_pub_;
   ros::Publisher mavros_waypoint_pub_;
   ros::Publisher mavros_obstacle_free_path_pub_;
+  ros::Publisher mavros_obstacle_distance_pub_;
   ros::Publisher waypoint_pub_;
   ros::ServiceClient mavros_set_mode_client_;
   tf::TransformListener tf_listener_;

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -77,6 +77,7 @@ class LocalPlannerNode {
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp);
   void updatePlannerInfo();
   void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid, geometry_msgs::PoseStamped pose);
+  void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point);
 
  private:
   ros::NodeHandle nh_;

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -12,7 +12,7 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <mavros_msgs/SetMode.h>
 #include <mavros_msgs/State.h>
-#include <mavros_msgs/ObstacleAvoidance.h>
+#include <mavros_msgs/Trajectory.h>
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
 #include <pcl_conversions/pcl_conversions.h>  // fromROSMsg
@@ -76,7 +76,7 @@ class LocalPlannerNode {
   void threadFunction();
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp);
   void updatePlannerInfo();
-  void transformPoseToObstacleAvoidance(mavros_msgs::ObstacleAvoidance &obst_avoid, geometry_msgs::PoseStamped pose);
+  void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid, geometry_msgs::PoseStamped pose);
 
  private:
   ros::NodeHandle nh_;
@@ -153,7 +153,7 @@ class LocalPlannerNode {
   void publishMarkerFOV(nav_msgs::GridCells FOV_cells);
   void clickedPointCallback(const geometry_msgs::PointStamped &msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped &msg);
-  void fcuInputGoalCallback(const mavros_msgs::ObstacleAvoidance &msg);
+  void fcuInputGoalCallback(const mavros_msgs::Trajectory &msg);;
   void printPointInfo(double x, double y, double z);
   void publishGoal();
   void publishBox();

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -76,7 +76,8 @@ class LocalPlannerNode {
   void threadFunction();
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp);
   void updatePlannerInfo();
-  void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid, geometry_msgs::PoseStamped pose);
+  void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid,
+                                 geometry_msgs::PoseStamped pose);
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point);
 
  private:
@@ -154,7 +155,8 @@ class LocalPlannerNode {
   void publishMarkerFOV(nav_msgs::GridCells FOV_cells);
   void clickedPointCallback(const geometry_msgs::PointStamped &msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped &msg);
-  void fcuInputGoalCallback(const mavros_msgs::Trajectory &msg);;
+  void fcuInputGoalCallback(const mavros_msgs::Trajectory &msg);
+  ;
   void printPointInfo(double x, double y, double z);
   void publishGoal();
   void publishBox();

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -345,6 +345,20 @@ double costFunction(int e, int z, nav_msgs::GridCells path_waypoints,
   return cost;
 }
 
+void compressHistogramElevation(Histogram &new_hist, Histogram input_hist) {
+
+  for (int e = 0; e < GRID_LENGTH_E; e++) {
+    for (int z = 0; z < GRID_LENGTH_Z; z++) {
+
+      if (input_hist.get_bin(e, z) > 0) {
+        new_hist.set_bin(0, z, new_hist.get_bin(0, z) + 1);
+        if (input_hist.get_dist(e, z) < new_hist.get_dist(0, z) || (new_hist.get_dist(0, z) == 0.0)) 
+          new_hist.set_dist(0, z, input_hist.get_dist(e, z));
+      }
+    }
+  }
+}
+
 // search for free directions in the 2D polar histogram with a moving window
 // approach
 void findFreeDirections(

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -346,13 +346,12 @@ double costFunction(int e, int z, nav_msgs::GridCells path_waypoints,
 }
 
 void compressHistogramElevation(Histogram &new_hist, Histogram input_hist) {
-
   for (int e = 0; e < GRID_LENGTH_E; e++) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
-
       if (input_hist.get_bin(e, z) > 0) {
         new_hist.set_bin(0, z, new_hist.get_bin(0, z) + 1);
-        if (input_hist.get_dist(e, z) < new_hist.get_dist(0, z) || (new_hist.get_dist(0, z) == 0.0)) 
+        if (input_hist.get_dist(e, z) < new_hist.get_dist(0, z) ||
+            (new_hist.get_dist(0, z) == 0.0))
           new_hist.set_dist(0, z, input_hist.get_dist(e, z));
       }
     }

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -71,6 +71,7 @@ void combinedHistogram(bool &hist_empty, Histogram &new_hist,
                        Histogram propagated_hist, bool waypoint_outside_FOV,
                        std::vector<int> z_FOV_idx, int e_FOV_min,
                        int e_FOV_max);
+void compressHistogramElevation(Histogram &new_hist, Histogram input_hist);
 double costFunction(int e, int z, nav_msgs::GridCells path_waypoints,
                     geometry_msgs::Point goal,
                     geometry_msgs::PoseStamped position,


### PR DESCRIPTION
Enables:
- sending OBSTACLE_DISTANCE message to the FCU
- receiving a planned path from the FCU e.g. mission from `/mavros/trajectory/desired`
- sending a collision free path to the FCU with `/mavros/trajectory/generated` in any mode
- still support old offboard interface

To do:
- [ ] ~~send message to FCU when a waypoint is not reachable~~
- [x] send obstacle_distance to the FCU even when the local planner doesn't calculate the polar histogram e.g. backoff from obstacles