### PR TITLE
Fix point cloud callback

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,8 +7,6 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("callback_topic",    str_t,    0, "pointcloud callback topic",  "/camera/depth/points")
-                     
 gen.add("min_box_x_",    double_t,    0, "Minimum box extension in x direction", 5,  0, 20)
 gen.add("max_box_x_",    double_t,    0, "Maximum box extension in x direction", 5,  0, 20)
 gen.add("min_box_y_",    double_t,    0, "Minimum box extension in y direction", 5,  0, 20)

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -808,9 +808,6 @@ void LocalPlannerNode::publishAll() {
 void LocalPlannerNode::dynamicReconfigureCallback(
     avoidance::LocalPlannerNodeConfig &config, uint32_t level) {
   local_planner_.dynamicReconfigureSetParams(config, level);
-  depth_points_topic_ = config.callback_topic;
-  pointcloud_sub_ = nh_.subscribe<sensor_msgs::PointCloud2>(
-      depth_points_topic_, 1, &LocalPlannerNode::pointCloudCallback, this);
 }
 
 void LocalPlannerNode::threadFunction() {


### PR DESCRIPTION
Fix for #82 

The point cloud topic is set in the launch file such that each model is started with the correct subscription.
Having a duplicate subscription with the parameter configured through rqt reconfigure breaks this logic since all models are started to the same default point cloud topic. 