### PR TITLE
Correct pointcloud topic in global_planner rviz config

### DIFF
--- a/global_planner/resource/global_planner.rviz
+++ b/global_planner/resource/global_planner.rviz
@@ -193,7 +193,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.100000001
       Style: Flat Squares
-      Topic: /stereo/points2
+      Topic: /camera/depth/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true


### PR DESCRIPTION
Default pointcloud2 topic in rviz is empty. I have fixed it according to #84 etc.