### PR TITLE
Introduce yaw goal

### DIFF
--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -139,7 +139,7 @@ class LocalPlanner {
   geometry_msgs::PoseStamped pose_;
   geometry_msgs::Point min_box_, max_box_, pose_stop_;
   geometry_msgs::Point min_groundbox_, max_groundbox_;
-  geometry_msgs::Point goal_;
+  geometry_msgs::PoseStamped goal_;
   geometry_msgs::Point back_off_point_;
   geometry_msgs::Point back_off_start_point_;
   geometry_msgs::PoseStamped offboard_pose_;

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -200,6 +200,7 @@ class LocalPlanner {
   double goal_x_param_;
   double goal_y_param_;
   double goal_z_param_;
+  double goal_yaw_param_;
   double pointcloud_timeout_hover_;
   double pointcloud_timeout_land_;
   double local_planner_mode_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -115,6 +115,7 @@ void LocalPlannerNode::updatePlannerInfo() {
     local_planner_.goal_x_param_ = goal_msg_.pose.position.x;
     local_planner_.goal_y_param_ = goal_msg_.pose.position.y;
     local_planner_.goal_z_param_ = goal_msg_.pose.position.z;
+    local_planner_.goal_yaw_param_ = tf::getYaw(goal_msg_.pose.orientation);
     local_planner_.setGoal();
     new_goal_ = false;
   }
@@ -618,6 +619,13 @@ void LocalPlannerNode::fcuInputGoalCallback(
     goal_msg_.pose.position.x = msg.point_2.position.x;
     goal_msg_.pose.position.y = msg.point_2.position.y;
     goal_msg_.pose.position.z = msg.point_2.position.z;
+
+    tf::Quaternion q;
+    q.setRPY(0.0, 0.0, msg.point_2.yaw);
+    goal_msg_.pose.orientation.w = q.getW();
+    goal_msg_.pose.orientation.x = q.getX();
+    goal_msg_.pose.orientation.y = q.getY();
+    goal_msg_.pose.orientation.z = q.getZ();
   }
 }
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -33,8 +33,8 @@ void StarPlanner::setBoxSize(Box histogram_box_size) {
   histogram_box_size_ = histogram_box_size;
 }
 
-void StarPlanner::setGoal(geometry_msgs::Point goal) {
-  goal_ = goal;
+void StarPlanner::setGoal(geometry_msgs::PoseStamped goal) {
+  goal_ = goal.pose.position;
   tree_age_ = 1000;
 }
 

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -111,7 +111,7 @@ class StarPlanner {
                      double height_change_cost_param);
   void setPose(geometry_msgs::PoseStamped pose);
   void setBoxSize(Box histogram_box_size);
-  void setGoal(geometry_msgs::Point pose);
+  void setGoal(geometry_msgs::PoseStamped pose);
   void setCloud(pcl::PointCloud<pcl::PointXYZ> complete_cloud);
   double treeCostFunction(int node_number);
   double treeHeuristicFunction(int node_number);


### PR DESCRIPTION
For the navigator to check off a mission item, the avoidance needs to be able to assume a defined yaw once it has reached the goal radius. This PR adds functionality for the local planner to do so