### PR TITLE
Architecture change rebased

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -121,6 +121,7 @@ include_directories(
 # )
 add_library(local_planner
   src/nodes/local_planner.cpp
+  src/nodes/waypoint_generator.cpp
   src/nodes/histogram.cpp
   src/nodes/tree_node.cpp
   src/nodes/box.cpp

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -37,6 +37,7 @@ gen.add("relevance_margin_e_degree_", double_t, 0, "obstacles at more than this 
 gen.add("relevance_margin_z_degree_", double_t, 0, "obstacles at more than this angle from goal direction are ignored", 40, 0, 180)
 gen.add("velocity_sigmoid_slope_", double_t, 0, "the bigger the bigger the acceleration", 1, 0, 10)
 
+gen.add("use_vel_setpoints_", bool_t, 0, "Enable velocity setpoints (if false, position setpoints are used)", False)
 gen.add("stop_in_front_", bool_t, 0, "Enable stop in front of the obstacle", False)
 gen.add("use_ground_detection_", bool_t, 0, "Enable ground detection and height control", False)
 gen.add("use_back_off_", bool_t, 0, "Enable functionality to move backwards if an obstacle is too close", True)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -34,6 +34,7 @@ gen.add("pointcloud_timeout_land_", double_t, 0, "after this timeout the control
 gen.add("reproj_age_", int_t, 0, "maximum age of a reprojected point", 50, 0, 1000)
 gen.add("relevance_margin_e_degree_", double_t, 0, "obstacles at more than this angle from goal direction are ignored", 25, 0, 90)
 gen.add("relevance_margin_z_degree_", double_t, 0, "obstacles at more than this angle from goal direction are ignored", 40, 0, 180)
+gen.add("velocity_sigmoid_slope_", double_t, 0, "the bigger the bigger the acceleration", 1, 0, 10)
 
 gen.add("stop_in_front_", bool_t, 0, "Enable stop in front of the obstacle", False)
 gen.add("use_ground_detection_", bool_t, 0, "Enable ground detection and height control", False)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -26,6 +26,7 @@ gen.add("ground_inlier_angle_threshold_", double_t, 0, "Angular distance to hori
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_cloud_size_", double_t, 0, "Discard pointclouds smaller than this value", 200, 0, 5000)
 gen.add("min_plane_points_", double_t, 0, "Discard planefits with less inliers", 160, 0, 5000)
+gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
 gen.add("min_plane_percentage_", double_t, 0, "Discard planefits with less inliers", 0.7, 0, 1)
 gen.add("avoid_radius_", double_t, 0, "min dist before absolutely avoiding", 2.5, 0, 10)
 gen.add("min_dist_backoff_", double_t, 0, "min dist before backing off", 1.5, 0, 10)

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -142,6 +142,14 @@ double velocitySigmoid(double max_vel, double min_vel, double slope, double v_ol
   return speed;
 }
 
+double velocityLinear(double max_vel, double min_vel, double slope, double v_old, double elapsed) {
+  v_old -= min_vel;
+  double t_old = v_old/slope;
+  double t_new = t_old + elapsed;
+  double speed = min_vel + t_new*slope;
+  return speed;
+}
+
 double getAngularVelocity(double new_yaw, double curr_yaw) {
   while (new_yaw > M_PI){
 	  new_yaw -= M_PI;
@@ -171,6 +179,6 @@ double getAngularVelocity(double new_yaw, double curr_yaw) {
 	  vel = yaw_vel2;
   }
 
-  return 0.3 * vel * std::abs(vel);
+  return vel;
 
 }

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -133,8 +133,8 @@ void normalize(geometry_msgs::Point &p) {
 }
 
 double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed) {
-  max_vel+=0.01;
-  min_vel-=0.01;
+  max_vel+=0.05;
+  min_vel-=0.05;
   v_old -= min_vel;
   double t_old = - 1.0/slope *log((max_vel - min_vel)/v_old - 1.0);
   double t_new = t_old + elapsed;

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -132,53 +132,54 @@ void normalize(geometry_msgs::Point &p) {
   }
 }
 
-double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed) {
-  max_vel+=0.05;
-  min_vel-=0.05;
+double velocitySigmoid(double max_vel, double min_vel, double slope,
+                       double v_old, double elapsed) {
+  max_vel += 0.05;
+  min_vel -= 0.05;
   v_old -= min_vel;
-  double t_old = - 1.0/slope *log((max_vel - min_vel)/v_old - 1.0);
+  double t_old = -1.0 / slope * log((max_vel - min_vel) / v_old - 1.0);
   double t_new = t_old + elapsed;
-  double speed = min_vel + (max_vel - min_vel)/(1.0 + exp(-slope * t_new ));
+  double speed = min_vel + (max_vel - min_vel) / (1.0 + exp(-slope * t_new));
   return speed;
 }
 
-double velocityLinear(double max_vel, double min_vel, double slope, double v_old, double elapsed) {
+double velocityLinear(double max_vel, double min_vel, double slope,
+                      double v_old, double elapsed) {
   v_old -= min_vel;
-  double t_old = v_old/slope;
+  double t_old = v_old / slope;
   double t_new = t_old + elapsed;
-  double speed = min_vel + t_new*slope;
+  double speed = min_vel + t_new * slope;
   return speed;
 }
 
 double getAngularVelocity(double new_yaw, double curr_yaw) {
-  while (new_yaw > M_PI){
-	  new_yaw -= M_PI;
+  while (new_yaw > M_PI) {
+    new_yaw -= M_PI;
   }
-  while (new_yaw < -M_PI){
-  	  new_yaw += M_PI;
+  while (new_yaw < -M_PI) {
+    new_yaw += M_PI;
   }
-  while (curr_yaw > M_PI){
-	  curr_yaw -= M_PI;
+  while (curr_yaw > M_PI) {
+    curr_yaw -= M_PI;
   }
-  while (curr_yaw < -M_PI){
-	  curr_yaw += M_PI;
+  while (curr_yaw < -M_PI) {
+    curr_yaw += M_PI;
   }
 
   double yaw_vel1 = new_yaw - curr_yaw;
   double yaw_vel2;
-  if (yaw_vel1 > 0){
-	  yaw_vel2 = -(2*M_PI - yaw_vel1);
-  }else{
-	  yaw_vel2 = 2*M_PI + yaw_vel1;
+  if (yaw_vel1 > 0) {
+    yaw_vel2 = -(2 * M_PI - yaw_vel1);
+  } else {
+    yaw_vel2 = 2 * M_PI + yaw_vel1;
   }
 
   double vel;
-  if (std::abs(yaw_vel1)<std::abs(yaw_vel2)){
-	  vel = yaw_vel1;
-  }else{
-	  vel = yaw_vel2;
+  if (std::abs(yaw_vel1) < std::abs(yaw_vel2)) {
+    vel = yaw_vel1;
+  } else {
+    vel = yaw_vel2;
   }
 
-  return vel;
-
+  return 0.5 * vel;
 }

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -171,6 +171,6 @@ double getAngularVelocity(double new_yaw, double curr_yaw) {
 	  vel = yaw_vel2;
   }
 
-  return vel/2 * std::abs(vel/2);
+  return 0.3 * vel * std::abs(vel);
 
 }

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -131,3 +131,13 @@ void normalize(geometry_msgs::Point &p) {
     p.z = 0;
   }
 }
+
+double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed) {
+  max_vel+=0.01;
+  min_vel-=0.01;
+  v_old -= min_vel;
+  double t_old = - 1.0/slope *log((max_vel - min_vel)/v_old - 1.0);
+  double t_new = t_old + elapsed;
+  double speed = min_vel + (max_vel - min_vel)/(1.0 + exp(-slope * t_new ));
+  return speed;
+}

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -141,3 +141,36 @@ double velocitySigmoid(double max_vel, double min_vel, double slope, double v_ol
   double speed = min_vel + (max_vel - min_vel)/(1.0 + exp(-slope * t_new ));
   return speed;
 }
+
+double getAngularVelocity(double new_yaw, double curr_yaw) {
+  while (new_yaw > M_PI){
+	  new_yaw -= M_PI;
+  }
+  while (new_yaw < -M_PI){
+  	  new_yaw += M_PI;
+  }
+  while (curr_yaw > M_PI){
+	  curr_yaw -= M_PI;
+  }
+  while (curr_yaw < -M_PI){
+	  curr_yaw += M_PI;
+  }
+
+  double yaw_vel1 = new_yaw - curr_yaw;
+  double yaw_vel2;
+  if (yaw_vel1 > 0){
+	  yaw_vel2 = -(2*M_PI - yaw_vel1);
+  }else{
+	  yaw_vel2 = 2*M_PI + yaw_vel1;
+  }
+
+  double vel;
+  if (std::abs(yaw_vel1)<std::abs(yaw_vel2)){
+	  vel = yaw_vel1;
+  }else{
+	  vel = yaw_vel2;
+  }
+
+  return vel/2 * std::abs(vel/2);
+
+}

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -99,22 +99,22 @@ int azimuthAngletoIndex(int z, int res) {  //[-180,180]
 }
 
 // calculate the yaw for the next waypoint
-double nextYaw(geometry_msgs::PoseStamped u, geometry_msgs::Vector3Stamped v,
+double nextYaw(geometry_msgs::PoseStamped u, geometry_msgs::Point v,
                double last_yaw_) {
-  double dx = v.vector.x - u.pose.position.x;
-  double dy = v.vector.y - u.pose.position.y;
+  double dx = v.x - u.pose.position.x;
+  double dy = v.y - u.pose.position.y;
 
   return atan2(dy, dx);
 }
 
-geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
+geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Point waypt,
                                          double yaw) {
   geometry_msgs::PoseStamped pose_msg;
   pose_msg.header.stamp = ros::Time::now();
   pose_msg.header.frame_id = "/world";
-  pose_msg.pose.position.x = waypt.vector.x;
-  pose_msg.pose.position.y = waypt.vector.y;
-  pose_msg.pose.position.z = waypt.vector.z;
+  pose_msg.pose.position.x = waypt.x;
+  pose_msg.pose.position.y = waypt.y;
+  pose_msg.pose.position.z = waypt.z;
   pose_msg.pose.orientation = tf::createQuaternionMsgFromYaw(yaw);
   return pose_msg;
 }

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -43,8 +43,10 @@ geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
                                          double yaw);
 void normalize(geometry_msgs::Point &p);
 
-double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed);
-double velocityLinear(double max_vel, double min_vel, double slope, double v_old, double elapsed);
+double velocitySigmoid(double max_vel, double min_vel, double slope,
+                       double v_old, double elapsed);
+double velocityLinear(double max_vel, double min_vel, double slope,
+                      double v_old, double elapsed);
 double getAngularVelocity(double new_yaw, double curr_yaw);
 
 #endif  // COMMON_H

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -43,4 +43,6 @@ geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
                                          double yaw);
 void normalize(geometry_msgs::Point &p);
 
+double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed);
+
 #endif  // COMMON_H

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -44,6 +44,7 @@ geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
 void normalize(geometry_msgs::Point &p);
 
 double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed);
+double velocityLinear(double max_vel, double min_vel, double slope, double v_old, double elapsed);
 double getAngularVelocity(double new_yaw, double curr_yaw);
 
 #endif  // COMMON_H

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -37,9 +37,9 @@ int elevationAnglefromCartesian(double x, double y, double z,
                                 geometry_msgs::Point pos);
 int elevationAngletoIndex(int e, int res);
 int azimuthAngletoIndex(int z, int res);
-double nextYaw(geometry_msgs::PoseStamped u, geometry_msgs::Vector3Stamped v,
+double nextYaw(geometry_msgs::PoseStamped u, geometry_msgs::Point v,
                double last_yaw);
-geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
+geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Point waypt,
                                          double yaw);
 void normalize(geometry_msgs::Point &p);
 

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -44,5 +44,6 @@ geometry_msgs::PoseStamped createPoseMsg(geometry_msgs::Vector3Stamped waypt,
 void normalize(geometry_msgs::Point &p);
 
 double velocitySigmoid(double max_vel, double min_vel, double slope, double v_old, double elapsed);
+double getAngularVelocity(double new_yaw, double curr_yaw);
 
 #endif  // COMMON_H

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -73,6 +73,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
     setGoal();
   }
 
+  use_vel_setpoints_ = config.use_vel_setpoints_;
   stop_in_front_ = config.stop_in_front_;
   use_avoid_sphere_ = config.use_avoid_sphere_;
   use_ground_detection_ = config.use_ground_detection_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -59,6 +59,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
 
   no_progress_slope_ = config.no_progress_slope_;
   min_cloud_size_ = config.min_cloud_size_;
+  min_realsense_dist_ = config.min_realsense_dist_;
   avoid_radius_ = config.avoid_radius_;
   min_dist_backoff_ = config.min_dist_backoff_;
   pointcloud_timeout_hover_ = config.pointcloud_timeout_hover_;
@@ -154,7 +155,7 @@ void LocalPlanner::runPlanner() {
                    distance_to_closest_point_, counter_close_points_backoff_,
                    sphere_points_counter, complete_cloud_, min_cloud_size_,
                    min_dist_backoff_, avoid_radius_, histogram_box_,
-                   pose_.pose.position);
+                   pose_.pose.position, min_realsense_dist_);
 
   safety_radius_ = adaptSafetyMarginHistogram(
       distance_to_closest_point_, final_cloud_.points.size(), min_cloud_size_);
@@ -323,7 +324,7 @@ void LocalPlanner::determineStrategy() {
           star_planner_.ground_detector_ = GroundDetector(ground_detector_);
           star_planner_.setParams(min_cloud_size_, min_dist_backoff_,
                                   path_waypoints_, curr_yaw_,
-                                  use_ground_detection_);
+                                  use_ground_detection_, min_realsense_dist_);
           star_planner_.setReprojectedPoints(reprojected_points_,
                                              reprojected_points_age_,
                                              reprojected_points_dist_);

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -27,7 +27,7 @@ void LocalPlanner::setPose(const geometry_msgs::PoseStamped msg) {
     reach_altitude_ = false;
   }
 
-  if (!offboard_) {
+  if (!offboard_ && !mission_) {
     offboard_pose_.header = msg.header;
     offboard_pose_.pose.position = msg.pose.position;
     offboard_pose_.pose.orientation = msg.pose.orientation;
@@ -81,9 +81,10 @@ void LocalPlanner::dynamicReconfigureSetParams(
   adapt_cost_params_ = config.adapt_cost_params_;
   send_obstacles_fcu_ = config.send_obstacles_fcu_;
 
-  ROS_DEBUG("Dynamic reconfigure call");
   star_planner_.dynamicReconfigureSetStarParams(config, level);
   ground_detector_.dynamicReconfigureSetGroundParams(config, level);
+
+  ROS_DEBUG("\033[0;35m[OA] Dynamic reconfigure call \033[0m");
 }
 
 // log Data
@@ -94,13 +95,11 @@ void LocalPlanner::logData() {
                           std::ofstream::app);
     myfile1 << pose_.header.stamp.sec << "\t" << pose_.header.stamp.nsec << "\t"
             << pose_.pose.position.x << "\t" << pose_.pose.position.y << "\t"
-            << pose_.pose.position.z << "\t" << waypt_p_.pose.position.x << "\t"
-            << waypt_p_.pose.position.y << "\t" << waypt_p_.pose.position.z
-            << "\t" << local_planner_mode_ << "\t" << reached_goal_ << "\t"
-            << reach_altitude_ << "\t" << use_ground_detection_ << "\t"
-            << obstacle_ << "\t" << height_change_cost_param_adapted_ << "\t"
-            << over_obstacle_ << "\t" << too_low_ << "\t" << is_near_min_height_
-            << "\t" << goal_.x << "\t" << goal_.y << "\t" << goal_.z << "\t"
+            << pose_.pose.position.z << "\t" << reach_altitude_ << "\t"
+            << use_ground_detection_ << "\t" << obstacle_ << "\t"
+            << height_change_cost_param_adapted_ << "\t" << over_obstacle_
+            << "\t" << too_low_ << "\t" << is_near_min_height_ << "\t"
+            << goal_.x << "\t" << goal_.y << "\t" << goal_.z << "\t"
             << algorithm_total_time_[algorithm_total_time_.size() - 1] << "\t"
             << tree_time_[tree_time_.size() - 1] << "\n";
     myfile1.close();
@@ -121,7 +120,6 @@ void LocalPlanner::setGoal() {
   goal_.x = goal_x_param_;
   goal_.y = goal_y_param_;
   goal_.z = goal_z_param_;
-  reached_goal_ = false;
   ROS_INFO("===== Set Goal ======: [%f, %f, %f].", goal_.x, goal_.y, goal_.z);
   initGridCells(&path_waypoints_);
   path_waypoints_.cells.push_back(pose_.pose.position);
@@ -129,11 +127,18 @@ void LocalPlanner::setGoal() {
 }
 
 void LocalPlanner::runPlanner() {
+  // reset candidates for visualization
+  initGridCells(&path_candidates_);
+  initGridCells(&path_rejected_);
+  initGridCells(&path_blocked_);
+  initGridCells(&path_selected_);
+  initGridCells(&path_ground_);
+
   histogram_box_.setLimitsHistogramBox(pose_.pose.position,
                                        histogram_box_size_);
 
   if (use_ground_detection_ && currently_armed_) {
-    if (offboard_) {
+    if (offboard_ || mission_) {
       std::clock_t t1 = std::clock();
       ground_detector_.initializeGroundBox(min_dist_to_ground_);
       ground_detector_.ground_box_.setLimitsGroundBox(
@@ -141,6 +146,13 @@ void LocalPlanner::runPlanner() {
           min_dist_to_ground_);
       ground_detector_.setParams(min_dist_to_ground_, min_cloud_size_);
       ground_detector_.detectGround(complete_cloud_);
+
+      min_flight_height_ = ground_detector_.getMinFlightHeight(
+          pose_, curr_vel_, over_obstacle_, min_flight_height_, ground_margin_);
+      ground_detector_.getHeightInformation(over_obstacle_, too_low_,
+                                            is_near_min_height_);
+      ground_margin_ = ground_detector_.getMargin();
+
       ground_time_.push_back((std::clock() - t1) /
                              (double)(CLOCKS_PER_SEC / 1000));
     } else {
@@ -170,7 +182,7 @@ void LocalPlanner::runPlanner() {
 }
 
 void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
-  // construct histogram if it is needed for the current local_planner_mode_
+  // construct histogram if it is needed
   // or if it is required by the FCU
   reprojectPoints(polar_histogram_);
   Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
@@ -194,10 +206,15 @@ void LocalPlanner::determineStrategy() {
   tree_time_.push_back(0);
 
   if (!reach_altitude_) {
-    ROS_INFO("\033[1;32m Reach height (%f) first: Go fast\n \033[0m",
+    starting_height_ =
+        std::max(goal_.z - 0.5, take_off_pose_.pose.position.z + 1.0);
+    ROS_INFO("\033[1;35m[OA] Reach height (%f) first: Go fast\n \033[0m",
              starting_height_);
-    local_planner_mode_ = 0;
-    goFast();
+    waypoint_type_ = reachHeight;
+
+    if (pose_.pose.position.z > starting_height_) {
+      reach_altitude_ = true;
+    }
 
     if (send_obstacles_fcu_) {
       create2DObstacleRepresentation(true);
@@ -205,9 +222,10 @@ void LocalPlanner::determineStrategy() {
   } else if (final_cloud_.points.size() > min_cloud_size_ && stop_in_front_ &&
              reach_altitude_) {
     obstacle_ = true;
-    ROS_INFO("\033[1;32m There is an Obstacle Ahead stop in front\n \033[0m");
-    local_planner_mode_ = 3;
+    ROS_INFO(
+        "\033[1;35m[OA] There is an Obstacle Ahead stop in front\n \033[0m");
     stopInFrontObstacles();
+    waypoint_type_ = direct;
 
     if (send_obstacles_fcu_) {
       create2DObstacleRepresentation(true);
@@ -217,14 +235,17 @@ void LocalPlanner::determineStrategy() {
           final_cloud_.points.size() > min_cloud_size_) ||
          back_off_) &&
         reach_altitude_ && use_back_off_) {
-      local_planner_mode_ = 4;
-      ROS_INFO("\033[1;32m There is an Obstacle too close! Back off\n \033[0m");
       if (!back_off_) {
         back_off_point_ = closest_point_;
         back_off_start_point_ = pose_.pose.position;
         back_off_ = true;
+      } else {
+        double dist = distance3DCartesian(pose_.pose.position, back_off_point_);
+        if (dist > min_dist_backoff_ + 1.0) {
+          back_off_ = false;
+        }
       }
-      backOff();
+      waypoint_type_ = goBack;
       if (send_obstacles_fcu_) {
         create2DObstacleRepresentation(true);
       }
@@ -289,28 +310,11 @@ void LocalPlanner::determineStrategy() {
       // decide how to proceed
       if (hist_is_empty_ || !hist_relevant) {
         obstacle_ = false;
-        local_planner_mode_ = 1;
-        geometry_msgs::Point p;
-        tree_available_ = getDirectionFromTree(
-            p, tree_available_, star_planner_.path_node_positions_,
-            pose_.pose.position, goal_, false);
-        double dist_goal = distance3DCartesian(goal_, pose_.pose.position);
-        if (tree_available_ && dist_goal > 4.0) {
-          path_waypoints_.cells.push_back(p);
-          ROS_INFO(
-              "\033[1;32m There is NO Obstacle Ahead reuse old Tree\n \033[0m");
-          getNextWaypoint();
-        } else {
-          goFast();
-          ROS_INFO("\033[1;32m There is NO Obstacle Ahead go Fast\n \033[0m");
-        }
+        waypoint_type_ = tryPath;
       }
 
       if (!hist_is_empty_ && hist_relevant && reach_altitude_) {
         obstacle_ = true;
-        ROS_INFO(
-            "\033[1;32m There is an Obstacle Ahead use Histogram\n \033[0m");
-        local_planner_mode_ = 2;
 
         findFreeDirections(
             polar_histogram_, safety_radius_, path_candidates_, path_selected_,
@@ -318,7 +322,7 @@ void LocalPlanner::determineStrategy() {
             cost_path_candidates_, goal_, pose_, position_old_,
             goal_cost_param_, smooth_cost_param_,
             height_change_cost_param_adapted_, height_change_cost_param_, -1,
-            false, only_yawed_, ALPHA_RES);
+            false, velocity_mod_ < 0.1, ALPHA_RES);
 
         if (use_VFH_star_) {
           star_planner_.ground_detector_ = GroundDetector(ground_detector_);
@@ -336,28 +340,17 @@ void LocalPlanner::determineStrategy() {
 
           std::clock_t start_time = std::clock();
           star_planner_.buildLookAheadTree();
-          tree_available_ = true;
           tree_time_[tree_time_.size() - 1] =
               ((std::clock() - start_time) / (double)(CLOCKS_PER_SEC / 1000));
 
-          geometry_msgs::Point p;
-          tree_available_ = getDirectionFromTree(
-              p, tree_available_, star_planner_.path_node_positions_,
-              pose_.pose.position, goal_, true);
-          path_waypoints_.cells.push_back(p);
+          waypoint_type_ = tryPath;
         } else {
           int e_min_idx = -1;
           if (use_ground_detection_) {
-            min_flight_height_ = ground_detector_.getMinFlightHeight(
-                pose_, curr_vel_, over_obstacle_, min_flight_height_,
-                ground_margin_);
             e_min_idx = ground_detector_.getMinFlightElevationIndex(
                 pose_, min_flight_height_, ALPHA_RES);
-            ground_detector_.getHeightInformation(over_obstacle_, too_low_,
-                                                  is_near_min_height_);
-            ground_margin_ = ground_detector_.getMargin();
             if (over_obstacle_) {
-              ROS_DEBUG("\033[1;36m Minimal flight height: %f) \n \033[0m",
+              ROS_DEBUG("\033[1;36m[OA] Minimal flight height: %f) \n \033[0m",
                         min_flight_height_);
             }
           }
@@ -368,26 +361,25 @@ void LocalPlanner::determineStrategy() {
               path_waypoints_, cost_path_candidates_, goal_, pose_,
               position_old_, goal_cost_param_, smooth_cost_param_,
               height_change_cost_param_adapted_, height_change_cost_param_,
-              e_min_idx, over_obstacle_, only_yawed_, ALPHA_RES);
+              e_min_idx, over_obstacle_, velocity_mod_ < 0.1, ALPHA_RES);
           if (calculateCostMap(cost_path_candidates_, cost_idx_sorted_)) {
-            local_planner_mode_ = 3;
             stopInFrontObstacles();
+            waypoint_type_ = direct;
             stop_in_front_ = true;
             ROS_INFO(
-                "\033[1;31m All directions blocked: Stopping in front "
+                "\033[1;35m[OA] All directions blocked: Stopping in front "
                 "obstacle. \n \033[0m");
           } else {
             getDirectionFromCostMap();
+            waypoint_type_ = costmap;
           }
-        }
-        if (!stop_in_front_) {
-          getNextWaypoint();
         }
       }
 
       first_brake_ = true;
     }
   }
+  position_old_ = pose_.pose.position;
 }
 
 void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
@@ -498,7 +490,7 @@ void LocalPlanner::reprojectPoints(Histogram histogram) {
 
 // calculate the correct weight between fly over and fly around
 void LocalPlanner::evaluateProgressRate() {
-  if (reach_altitude_ && adapt_cost_params_ && !reached_goal_) {
+  if (reach_altitude_ && adapt_cost_params_) {
     double goal_dist = distance3DCartesian(pose_.pose.position, goal_);
     double goal_dist_old = distance3DCartesian(position_old_, goal_);
     double time = std::clock() / (double)(CLOCKS_PER_SEC / 1000);
@@ -530,8 +522,10 @@ void LocalPlanner::evaluateProgressRate() {
         height_change_cost_param_adapted_ += 0.03;
       }
     }
-    ROS_DEBUG("Progress rate to goal: %f, adapted height change cost: %f .",
-              avg_incline, height_change_cost_param_adapted_);
+    ROS_DEBUG(
+        "\033[0;35m[OA] Progress rate to goal: %f, adapted height change cost: "
+        "%f .\033[0m",
+        avg_incline, height_change_cost_param_adapted_);
   } else {
     height_change_cost_param_adapted_ = height_change_cost_param_;
   }
@@ -539,423 +533,8 @@ void LocalPlanner::evaluateProgressRate() {
 
 // get waypoint from sorted cost list
 void LocalPlanner::getDirectionFromCostMap() {
-  geometry_msgs::Point p;
-  p.x = path_candidates_.cells[cost_idx_sorted_[0]].x;
-  p.y = path_candidates_.cells[cost_idx_sorted_[0]].y;
-  p.z = path_candidates_.cells[cost_idx_sorted_[0]].z;
-  path_selected_.cells.push_back(p);
-  path_waypoints_.cells.push_back(p);
-}
-
-// check that the selected direction is really free and transform it into a
-// waypoint.
-void LocalPlanner::getNextWaypoint() {
-  int waypoint_index = path_waypoints_.cells.size();
-  int e_angle = path_waypoints_.cells[waypoint_index - 1].x;
-  int z_angle = path_waypoints_.cells[waypoint_index - 1].y;
-
-  int e_index = elevationAngletoIndex(e_angle, ALPHA_RES);
-  int z_index = azimuthAngletoIndex(z_angle, ALPHA_RES);
-
-  geometry_msgs::Vector3Stamped setpoint =
-      getWaypointFromAngle(e_angle, z_angle, pose_.pose.position);
-
-  waypt_ = setpoint;
-
-  ROS_DEBUG("Selected waypoint: [%f, %f, %f].", waypt_.vector.x,
-            waypt_.vector.y, waypt_.vector.z);
-
-  getPathMsg();
-}
-
-// if there isn't any obstacle in front of the UAV, increase cruising speed
-void LocalPlanner::goFast() {
-  tf::Vector3 vec;
-  vec.setX(goal_.x - pose_.pose.position.x);
-  vec.setY(goal_.y - pose_.pose.position.y);
-  vec.setZ(goal_.z - pose_.pose.position.z);
-
-  vec.normalize();
-
-  waypt_.vector.x = pose_.pose.position.x + vec.getX();
-  waypt_.vector.y = pose_.pose.position.y + vec.getY();
-  waypt_.vector.z = pose_.pose.position.z + vec.getZ();
-
-  // Prevent downward motion or move up if too close to ground
-  if (use_ground_detection_) {
-    vec.normalize();
-    min_flight_height_ = ground_detector_.getMinFlightHeight(
-        pose_, curr_vel_, over_obstacle_, min_flight_height_, ground_margin_);
-    ground_detector_.getHeightInformation(over_obstacle_, too_low_,
-                                          is_near_min_height_);
-    ground_margin_ = ground_detector_.getMargin();
-
-    if (over_obstacle_ && pose_.pose.position.z <= min_flight_height_ &&
-        waypt_.vector.z <= min_flight_height_) {
-      if ((min_flight_height_ - pose_.pose.position.z) > 0.5) {
-        waypt_.vector.z = pose_.pose.position.z + 0.5;
-      } else {
-        waypt_.vector.z = min_flight_height_;
-      }
-      too_low_ = true;
-      ROS_INFO(
-          "\033[1;36m Go Fast: Flight altitude too low (Minimal flight height: "
-          "%f ) rising.\n \033[0m",
-          min_flight_height_);
-    }
-    if (over_obstacle_ && pose_.pose.position.z > min_flight_height_ &&
-        pose_.pose.position.z < min_flight_height_ + 0.5 && vec.getZ() < 0) {
-      waypt_.vector.z = pose_.pose.position.z;
-      is_near_min_height_ = true;
-      ROS_INFO(
-          "\033[1;36m Go Fast: Preventing downward motion (Minimal flight "
-          "height: %f ) \n \033[0m",
-          min_flight_height_);
-    }
-  }
-
-  // fill direction as straight ahead
-  geometry_msgs::Point p;
-  p.x = 0;
-  p.y = 90;
-  p.z = 0;
-  path_waypoints_.cells.push_back(p);
-
-  // reset candidates for visualization
-  initGridCells(&path_candidates_);
-  initGridCells(&path_rejected_);
-  initGridCells(&path_blocked_);
-  initGridCells(&path_selected_);
-  initGridCells(&path_ground_);
-
-  ROS_DEBUG("Go fast selected direction: [%f, %f, %f].", vec.getX(), vec.getY(),
-            vec.getZ());
-  ROS_DEBUG("Go fast selected waypoint: [%f, %f, %f].", waypt_.vector.x,
-            waypt_.vector.y, waypt_.vector.z);
-
-  getPathMsg();
-}
-
-void LocalPlanner::backOff() {
-  tf::Vector3 vec;
-  vec.setX(pose_.pose.position.x - back_off_point_.x);
-  vec.setY(pose_.pose.position.y - back_off_point_.y);
-  vec.setZ(0);
-  vec.normalize();
-  double new_len = 0.5;
-  vec *= new_len;
-
-  waypt_.vector.x = pose_.pose.position.x + vec.getX();
-  waypt_.vector.y = pose_.pose.position.y + vec.getY();
-  waypt_.vector.z = back_off_start_point_.z;
-
-  // fill direction as straight ahead
-  geometry_msgs::Point p;
-  p.x = 0;
-  p.y = 90;
-  p.z = 0;
-  path_waypoints_.cells.push_back(p);
-
-  double dist = distance3DCartesian(pose_.pose.position, back_off_point_);
-  if (dist > min_dist_backoff_ + 1.0) {
-    back_off_ = false;
-  }
-
-  waypt_p_ = createPoseMsg(waypt_, last_yaw_);
-  path_msg_.poses.push_back(waypt_p_);
-  curr_yaw_ = last_yaw_;
-  position_old_ = pose_.pose.position;
-
-  // velocity wp
-  waypt_vel_.linear.x = waypt_p_.pose.position.x - pose_.pose.position.x;
-  waypt_vel_.linear.y = waypt_p_.pose.position.y - pose_.pose.position.y;
-  waypt_vel_.linear.z = waypt_p_.pose.position.z - pose_.pose.position.z;
-  waypt_vel_.angular.x = 0.0;
-  waypt_vel_.angular.y = 0.0;
-  waypt_vel_.angular.z = 0.0;
-
-  ROS_DEBUG("Backoff Point: [%f, %f, %f].", back_off_point_.x,
-            back_off_point_.y, back_off_point_.z);
-  ROS_DEBUG("Distance to Back off Point: %f", dist);
-  ROS_DEBUG("Back off selected direction: [%f, %f, %f].", vec.getX(),
-            vec.getY(), vec.getZ());
-  ROS_DEBUG("Back off selected waypoint: [%f, %f, %f].", waypt_.vector.x,
-            waypt_.vector.y, waypt_.vector.z);
-}
-
-// check if the UAV has reached the goal set for the mission
-bool LocalPlanner::withinGoalRadius() {
-  geometry_msgs::Point a;
-  a.x = std::abs(goal_.x - pose_.pose.position.x);
-  a.y = std::abs(goal_.y - pose_.pose.position.y);
-  a.z = std::abs(goal_.z - pose_.pose.position.z);
-  float goal_acceptance_radius = 0.5f;
-
-  if (a.x < goal_acceptance_radius && a.y < goal_acceptance_radius &&
-      a.z < goal_acceptance_radius) {
-    if (!reached_goal_) {
-      yaw_reached_goal_ = tf::getYaw(pose_.pose.orientation);
-    }
-    reached_goal_ = true;
-    return true;
-  } else if (over_obstacle_ && a.x < goal_acceptance_radius &&
-             a.y < goal_acceptance_radius) {
-    if (!reached_goal_) {
-      yaw_reached_goal_ = tf::getYaw(pose_.pose.orientation);
-    }
-    reached_goal_ = true;
-    return true;
-  } else
-    reached_goal_ = false;
-  return false;
-}
-
-// when taking off, first publish waypoints to reach the goal altitude
-void LocalPlanner::reachGoalAltitudeFirst() {
-  starting_height_ =
-      std::max(goal_.z - 0.5, take_off_pose_.pose.position.z + 1.0);
-  if (pose_.pose.position.z < starting_height_) {
-    waypt_.vector.x = offboard_pose_.pose.position.x;
-    waypt_.vector.y = offboard_pose_.pose.position.y;
-    waypt_.vector.z = pose_.pose.position.z + 0.5;
-  } else {
-    reach_altitude_ = true;
-    getPathMsg();
-  }
-}
-
-// smooth trajectory by liming the maximim accelleration possible
-geometry_msgs::Vector3Stamped LocalPlanner::smoothWaypoint(
-    geometry_msgs::Vector3Stamped wp) {
-  geometry_msgs::Vector3Stamped smooth_waypt;
-  std::clock_t t = std::clock();
-  float dt = (t - t_prev_) / (float)(CLOCKS_PER_SEC);
-  dt = dt > 0.0f ? dt : 0.004f;
-  t_prev_ = t;
-
-  Eigen::Vector2f vel_xy(curr_vel_.twist.linear.x, curr_vel_.twist.linear.y);
-  Eigen::Vector2f vel_waypt_xy(
-      (wp.vector.x - last_waypt_p_.pose.position.x) / dt,
-      (wp.vector.y - last_waypt_p_.pose.position.y) / dt);
-  Eigen::Vector2f vel_waypt_xy_prev(
-      (last_waypt_p_.pose.position.x - last_last_waypt_p_.pose.position.x) / dt,
-      (last_waypt_p_.pose.position.y - last_last_waypt_p_.pose.position.y) /
-          dt);
-  Eigen::Vector2f acc_waypt_xy((vel_waypt_xy - vel_waypt_xy_prev) / dt);
-
-  if (acc_waypt_xy.norm() > (acc_waypt_xy.norm() / 2.0f)) {
-    vel_xy = (acc_waypt_xy.norm() / 2.0f) * acc_waypt_xy.normalized() * dt +
-             vel_waypt_xy_prev;
-  }
-
-  smooth_waypt.vector.x = last_waypt_p_.pose.position.x + vel_xy(0) * dt;
-  smooth_waypt.vector.y = last_waypt_p_.pose.position.y + vel_xy(1) * dt;
-  smooth_waypt.vector.z = wp.vector.z;
-
-  ROS_DEBUG("Smoothed waypoint: [%f %f %f].", smooth_waypt.vector.x,
-            smooth_waypt.vector.y, smooth_waypt.vector.z);
-  return smooth_waypt;
-}
-
-void LocalPlanner::adaptSpeed(geometry_msgs::Vector3Stamped &wp,
-                              geometry_msgs::PoseStamped position,
-                              double time_since_pos_update,
-                              std::vector<int> h_FOV) {
-  ros::Duration since_last_velocity = ros::Time::now() - velocity_time_;
-  double since_last_velocity_sec = since_last_velocity.toSec();
-
-  if (!obstacle_) {
-    speed_ = std::min(speed_, max_speed_);
-    speed_ = velocityLinear(max_speed_, 0.0, velocity_sigmoid_slope_, speed_,
-                            since_last_velocity_sec);
-  } else {
-    speed_ = std::min(speed_, min_speed_);
-    speed_ = velocityLinear(min_speed_, 0.0, velocity_sigmoid_slope_, speed_,
-                            since_last_velocity_sec);
-  }
-
-  // check if new point lies in FOV
-  int e_angle = elevationAnglefromCartesian(
-      wp.vector.x, wp.vector.y, wp.vector.z, position.pose.position);
-  int z_angle = azimuthAnglefromCartesian(wp.vector.x, wp.vector.y, wp.vector.z,
-                                          position.pose.position);
-
-  int e_index = elevationAngletoIndex(e_angle, ALPHA_RES);
-  int z_index = azimuthAngletoIndex(z_angle, ALPHA_RES);
-
-  if (std::find(h_FOV.begin(), h_FOV.end(), z_index) != h_FOV.end()) {
-    waypoint_outside_FOV_ = false;
-  } else {
-    waypoint_outside_FOV_ = true;
-    if (reach_altitude_ && !reached_goal_ && !back_off_) {
-      int ind_dist = 100;
-      int i = 0;
-      for (std::vector<int>::iterator it = h_FOV.begin(); it != h_FOV.end();
-           ++it) {
-        if (std::abs(h_FOV[i] - z_index) < ind_dist) {
-          ind_dist = std::abs(h_FOV[i] - z_index);
-        }
-        i++;
-      }
-      double angle_diff = std::abs(ALPHA_RES * ind_dist);
-      double hover_angle = 30;
-      angle_diff = std::min(angle_diff, hover_angle);
-      speed_ = speed_ * (1.0 - angle_diff / hover_angle);
-      only_yawed_ = false;
-      if (speed_ < 0.01) {
-        only_yawed_ = true;
-      }
-    }
-  }
-  velocity_time_ = ros::Time::now();
-
-  // calculate correction for computation delay
-  ros::Duration since_update = ros::Time::now() - update_time_;
-  double since_update_sec = since_update.toSec();
-  double delta_dist = since_update_sec * velocity_mod_;
-  speed_ += delta_dist;
-
-  // set waypoint to correct speed
-  geometry_msgs::Point pose_to_wp;
-  pose_to_wp.x = wp.vector.x - position.pose.position.x;
-  pose_to_wp.y = wp.vector.y - position.pose.position.y;
-  pose_to_wp.z = wp.vector.z - position.pose.position.z;
-  normalize(pose_to_wp);
-  pose_to_wp.x *= speed_;
-  pose_to_wp.y *= speed_;
-  pose_to_wp.z *= speed_;
-
-  wp.vector.x = position.pose.position.x + pose_to_wp.x;
-  wp.vector.y = position.pose.position.y + pose_to_wp.y;
-  wp.vector.z = position.pose.position.z + pose_to_wp.z;
-  ROS_DEBUG("Speed adapted WP: [%f %f %f].", wp.vector.x, wp.vector.y,
-            wp.vector.z);
-}
-
-// create the message that is sent to the UAV
-void LocalPlanner::getPathMsg() {
-  path_msg_.header.frame_id = "/world";
-  last_last_waypt_p_ = last_waypt_p_;
-  last_waypt_p_ = waypt_p_;
-  last_yaw_ = curr_yaw_;
-  waypt_adapted_ = waypt_;
-
-  // If avoid sphere is used, project waypoint on sphere
-  if (use_avoid_sphere_ && avoid_sphere_age_ < 100 && reach_altitude_ &&
-      !reached_goal_ && !back_off_) {
-    waypt_adapted_ = getSphereAdaptedWaypoint(
-        pose_.pose.position, waypt_, avoid_centerpoint_, avoid_radius_);
-    ROS_DEBUG("Sphere adapted WP: [%f %f %f].", waypt_adapted_.vector.x,
-              waypt_adapted_.vector.y, waypt_adapted_.vector.z);
-  }
-
-  // adapt waypoint to suitable speed (slow down if waypoint is out of FOV)
-  new_yaw_ = nextYaw(pose_, waypt_adapted_, last_yaw_);
-  ros::Duration since_update = ros::Time::now() - update_time_;
-  double since_update_sec = since_update.toSec();
-  std::unique_lock<std::timed_mutex> velocity_lock(velocity_mutex_,
-                                                   std::defer_lock);
-  velocity_lock.lock();
-  adaptSpeed(waypt_adapted_, pose_, since_update_sec, z_FOV_idx_);
-  velocity_lock.unlock();
-  waypt_smoothed_ = waypt_adapted_;
-
-  // go to flight height first or smooth wp
-  if (!reach_altitude_) {
-    reachGoalAltitudeFirst();
-    waypt_adapted_ = waypt_;
-    waypt_smoothed_ = waypt_;
-    new_yaw_ = curr_yaw_;
-  } else {
-    if (!only_yawed_) {
-      if (!reached_goal_ && !stop_in_front_ && smooth_waypoints_) {
-        waypt_smoothed_ = smoothWaypoint(waypt_adapted_);
-        new_yaw_ = nextYaw(pose_, waypt_smoothed_, last_yaw_);
-      }
-    }
-  }
-
-  if (back_off_ && use_back_off_) {
-    new_yaw_ = last_yaw_;
-    double dist = distance3DCartesian(pose_.pose.position, back_off_point_);
-    if (dist > min_dist_backoff_ + 1.0) {
-      back_off_ = false;
-    }
-    waypt_adapted_ = waypt_;
-    waypt_smoothed_ = waypt_;
-  }
-
-  // change waypoint if drone is at goal or above
-  if (withinGoalRadius()) {
-    bool over_goal = false;
-    if (use_ground_detection_) {
-      if (over_obstacle_ && (is_near_min_height_ || too_low_)) {
-        over_goal = true;
-        waypt_smoothed_.vector.x = goal_.x;
-        waypt_smoothed_.vector.y = goal_.y;
-        if (pose_.pose.position.z < goal_.z) {
-          waypt_smoothed_.vector.z = goal_.z;
-          ROS_DEBUG("Rising to goal");
-        } else {
-          waypt_smoothed_.vector.z = min_flight_height_;
-          ROS_INFO("Above Goal cannot go lower: Hovering");
-        }
-      }
-    }
-    if (!over_goal) {
-      waypt_smoothed_.vector.x = goal_.x;
-      waypt_smoothed_.vector.y = goal_.y;
-      waypt_smoothed_.vector.z = goal_.z;
-    }
-  }
-
-  if (reached_goal_) {
-    new_yaw_ = yaw_reached_goal_;
-  }
-
-  ROS_DEBUG("Final waypoint: [%f %f %f].", waypt_smoothed_.vector.x,
-            waypt_smoothed_.vector.y, waypt_smoothed_.vector.z);
-  waypt_p_ = createPoseMsg(waypt_smoothed_, new_yaw_);
-
-  // velocity wp
-  waypt_vel_.linear.x = waypt_p_.pose.position.x - pose_.pose.position.x;
-  waypt_vel_.linear.y = waypt_p_.pose.position.y - pose_.pose.position.y;
-  waypt_vel_.linear.z = waypt_p_.pose.position.z - pose_.pose.position.z;
-  waypt_vel_.angular.x = 0.0;
-  waypt_vel_.angular.y = 0.0;
-  waypt_vel_.angular.z = getAngularVelocity(new_yaw_, curr_yaw_);
-
-  path_msg_.poses.push_back(waypt_p_);
-  curr_yaw_ = new_yaw_;
-  last_last_waypt_p_ = last_waypt_p_;
-  last_waypt_p_ = waypt_p_;
-  last_yaw_ = curr_yaw_;
-  position_old_ = pose_.pose.position;
-  smooth_waypoints_ = true;
-}
-
-void LocalPlanner::printAlgorithmStatistics() {
-  ROS_DEBUG("Current pose: [%f, %f, %f].", pose_.pose.position.x,
-            pose_.pose.position.y, pose_.pose.position.z);
-  ROS_DEBUG("Velocity: [%f, %f, %f], module: %f.", velocity_x_, velocity_y_,
-            velocity_z_, velocity_mod_);
-
-  logData();
-
-  if (withinGoalRadius()) {
-    ROS_INFO("Goal Reached: Hovering");
-    cv::Scalar mean, std;
-    ROS_DEBUG("------------ TIMING ----------- \n");
-    cv::meanStdDev(algorithm_total_time_, mean, std);
-    ROS_DEBUG("total mean %f std %f \n", mean[0], std[0]);
-    cv::meanStdDev(cloud_time_, mean, std);
-    ROS_DEBUG("cloud mean %f std %f \n", mean[0], std[0]);
-    cv::meanStdDev(ground_time_, mean, std);
-    ROS_DEBUG("ground detection mean %f std %f \n", mean[0], std[0]);
-    cv::meanStdDev(tree_time_, mean, std);
-    ROS_DEBUG("tree build mean %f std %f \n", mean[0], std[0]);
-    ROS_DEBUG("------------------------------- \n");
-  }
+  costmap_direction_e_ = path_candidates_.cells[cost_idx_sorted_[0]].x;
+  costmap_direction_z_ = path_candidates_.cells[cost_idx_sorted_[0]].y;
 }
 
 // stop in front of an obstacle at a distance defined by the variable
@@ -972,9 +551,10 @@ void LocalPlanner::stopInFrontObstacles() {
               (braking_distance * pose_to_goal(1) / pose_to_goal.norm());
     first_brake_ = false;
   }
-  ROS_INFO("New Stop Goal: [%.2f %.2f %.2f], obstacle distance %.2f. ", goal_.x,
-           goal_.y, goal_.z, distance_to_closest_point_);
-  goFast();
+  ROS_INFO(
+      "\033[0;35m [OA] New Stop Goal: [%.2f %.2f %.2f], obstacle distance "
+      "%.2f. \033[0m",
+      goal_.x, goal_.y, goal_.z, distance_to_closest_point_);
 }
 
 void LocalPlanner::getPosition(geometry_msgs::PoseStamped &pos) { pos = pose_; }
@@ -1013,37 +593,51 @@ void LocalPlanner::getCandidateDataForVisualization(
   FOV_cells = FOV_cells_;
 }
 
-void LocalPlanner::getPathData(nav_msgs::Path &path_msg,
-                               geometry_msgs::PoseStamped &waypt_p,
-                               geometry_msgs::Twist &waypt_vel) {
-  path_msg = path_msg_;
-  waypt_p = waypt_p_;
-  waypt_vel = waypt_vel_;
-}
-
 void LocalPlanner::setCurrentVelocity(geometry_msgs::TwistStamped vel) {
   curr_vel_ = vel;
 }
 
 void LocalPlanner::getTree(
     std::vector<TreeNode> &tree, std::vector<int> &closed_set,
-    std::vector<geometry_msgs::Point> &path_node_positions,
-    bool &tree_available) {
+    std::vector<geometry_msgs::Point> &path_node_positions) {
   tree = star_planner_.tree_;
   closed_set = star_planner_.closed_set_;
   path_node_positions = star_planner_.path_node_positions_;
-  tree_available = tree_available_;
-}
-
-void LocalPlanner::getWaypoints(geometry_msgs::Vector3Stamped &waypt,
-                                geometry_msgs::Vector3Stamped &waypt_adapted,
-                                geometry_msgs::Vector3Stamped &waypt_smoothed) {
-  waypt = waypt_;
-  waypt_adapted = waypt_adapted_;
-  waypt_smoothed = waypt_smoothed_;
 }
 
 void LocalPlanner::sendObstacleDistanceDataToFcu(
     sensor_msgs::LaserScan &obstacle_distance) {
   obstacle_distance = distance_data_;
+}
+
+void LocalPlanner::getAvoidanceOutput(avoidanceOutput &out) {
+  out.waypoint_type = waypoint_type_;
+
+  out.pose = pose_;
+  out.obstacle_ahead = obstacle_;
+  out.min_speed = min_speed_;
+  out.max_speed = max_speed_;
+  out.velocity_sigmoid_slope = velocity_sigmoid_slope_;
+
+  out.use_avoid_sphere = use_avoid_sphere_;
+  out.avoid_sphere_age = avoid_sphere_age_;
+  out.avoid_centerpoint = avoid_centerpoint_;
+  out.avoid_radius = avoid_radius_;
+
+  out.use_ground_detection = use_ground_detection_;
+  out.over_obstacle = over_obstacle_;
+  out.is_near_min_height = is_near_min_height_;
+  out.too_low = too_low_;
+  out.min_flight_height = min_flight_height_;
+
+  out.back_off_point = back_off_point_;
+  out.back_off_start_point = back_off_start_point_;
+  out.min_dist_backoff = min_dist_backoff_;
+
+  out.take_off_pose = take_off_pose_;
+  out.offboard_pose = offboard_pose_;
+
+  out.costmap_direction_e = costmap_direction_e_;
+  out.costmap_direction_z = costmap_direction_z_;
+  out.path_node_positions = star_planner_.path_node_positions_;
 }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -764,10 +764,10 @@ void LocalPlanner::adaptSpeed(geometry_msgs::Vector3Stamped &wp, geometry_msgs::
 
   if (!obstacle_) {
 	speed_ = std::min(speed_, max_speed_);
-    speed_ = velocitySigmoid(max_speed_, 0.0, velocity_sigmoid_slope_, speed_, since_last_velocity_sec);
+    speed_ = velocityLinear(max_speed_, 0.0, velocity_sigmoid_slope_, speed_, since_last_velocity_sec);
   } else {
 	speed_ = std::min(speed_, min_speed_);
-	speed_ = velocitySigmoid(min_speed_, 0.0, velocity_sigmoid_slope_, speed_, since_last_velocity_sec);
+	speed_ = velocityLinear(min_speed_, 0.0, velocity_sigmoid_slope_, speed_, since_last_velocity_sec);
   }
 
   // check if new point lies in FOV

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -665,6 +665,14 @@ void LocalPlanner::backOff() {
   curr_yaw_ = last_yaw_;
   position_old_ = pose_.pose.position;
 
+  //velocity wp
+  waypt_vel_.linear.x = waypt_p_.pose.position.x - pose_.pose.position.x;
+  waypt_vel_.linear.y = waypt_p_.pose.position.y - pose_.pose.position.y;
+  waypt_vel_.linear.z = waypt_p_.pose.position.z - pose_.pose.position.z;
+  waypt_vel_.angular.x = 0.0;
+  waypt_vel_.angular.y = 0.0;
+  waypt_vel_.angular.z = 0.0;
+
   ROS_DEBUG("Backoff Point: [%f, %f, %f].", back_off_point_.x,
             back_off_point_.y, back_off_point_.z);
   ROS_DEBUG("Distance to Back off Point: %f", dist);
@@ -908,6 +916,14 @@ void LocalPlanner::getPathMsg() {
             waypt_smoothed_.vector.y, waypt_smoothed_.vector.z);
   waypt_p_ = createPoseMsg(waypt_smoothed_, new_yaw_);
 
+  //velocity wp
+  waypt_vel_.linear.x = waypt_p_.pose.position.x - pose_.pose.position.x;
+  waypt_vel_.linear.y = waypt_p_.pose.position.y - pose_.pose.position.y;
+  waypt_vel_.linear.z = waypt_p_.pose.position.z - pose_.pose.position.z;
+  waypt_vel_.angular.x = 0.0;
+  waypt_vel_.angular.y = 0.0;
+  waypt_vel_.angular.z = getAngularVelocity(new_yaw_, curr_yaw_);
+
   path_msg_.poses.push_back(waypt_p_);
   curr_yaw_ = new_yaw_;
   last_last_waypt_p_ = last_waypt_p_;
@@ -997,9 +1013,11 @@ void LocalPlanner::getCandidateDataForVisualization(
 }
 
 void LocalPlanner::getPathData(nav_msgs::Path &path_msg,
-                               geometry_msgs::PoseStamped &waypt_p) {
+                               geometry_msgs::PoseStamped &waypt_p,
+							   geometry_msgs::Twist &waypt_vel) {
   path_msg = path_msg_;
   waypt_p = waypt_p_;
+  waypt_vel = waypt_vel_;
 }
 
 void LocalPlanner::setCurrentVelocity(geometry_msgs::TwistStamped vel) {

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -211,6 +211,7 @@ class LocalPlanner {
   GroundDetector ground_detector_;
   Box histogram_box_size_;
 
+  bool use_vel_setpoints_;
   bool currently_armed_ = false;
   bool offboard_ = false;
   bool mission_ = false;

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -118,6 +118,7 @@ class LocalPlanner {
   double relevance_margin_z_degree_ = 40;
   double relevance_margin_e_degree_ = 25;
   double velocity_sigmoid_slope_ = 1;
+  double min_realsense_dist_ = 0.2;
 
   std::vector<int> e_FOV_idx_;
   std::vector<int> z_FOV_idx_;

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -114,6 +114,7 @@ class LocalPlanner {
   double avoid_radius_;
   double relevance_margin_z_degree_ = 40;
   double relevance_margin_e_degree_ = 25;
+  double velocity_sigmoid_slope_ = 1;
 
   std::vector<int> e_FOV_idx_;
   std::vector<int> z_FOV_idx_;
@@ -131,6 +132,7 @@ class LocalPlanner {
   StarPlanner star_planner_;
 
   std::clock_t t_prev_ = 0.0f;
+  ros::Time velocity_time_;
 
   pcl::PointCloud<pcl::PointXYZ> reprojected_points_, final_cloud_;
 

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -158,6 +158,7 @@ class LocalPlanner {
   geometry_msgs::Vector3Stamped hover_point_;
   geometry_msgs::Vector3Stamped last_hist_waypt_;
   geometry_msgs::PoseStamped waypt_p_;
+  geometry_msgs::Twist waypt_vel_;
   geometry_msgs::TwistStamped curr_vel_;
 
   nav_msgs::Path path_msg_;
@@ -247,7 +248,8 @@ class LocalPlanner {
                                         nav_msgs::GridCells &FOV_cells,
                                         nav_msgs::GridCells &path_ground);
   void getPathData(nav_msgs::Path &path_msg,
-                   geometry_msgs::PoseStamped &waypt_p);
+                   geometry_msgs::PoseStamped &waypt_p,
+				   geometry_msgs::Twist &waypt_vel);
   void setCurrentVelocity(geometry_msgs::TwistStamped vel);
   void getTree(std::vector<TreeNode> &tree, std::vector<int> &closed_set,
                std::vector<geometry_msgs::Point> &path_node_positions,

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -10,6 +10,9 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <chrono>
+#include <thread>
+#include <mutex>
 
 #include <ros/ros.h>
 
@@ -181,7 +184,6 @@ class LocalPlanner {
   void getPathMsg();
   bool withinGoalRadius();
   void getDirectionFromCostMap();
-  void adaptSpeed();
   void stopInFrontObstacles();
   void updateObstacleDistanceMsg(Histogram hist);
   void updateObstacleDistanceMsg();
@@ -191,6 +193,8 @@ class LocalPlanner {
 
  public:
   GroundDetector ground_detector_;
+
+  std::timed_mutex velocity_mutex_;
 
   bool currently_armed_ = false;
   bool offboard_ = false;
@@ -252,6 +256,10 @@ class LocalPlanner {
                     geometry_msgs::Vector3Stamped &waypt_adapted,
                     geometry_msgs::Vector3Stamped &waypt_smoothed);
   void sendObstacleDistanceDataToFcu(sensor_msgs::LaserScan &obstacle_distance);
+  void adaptSpeed(geometry_msgs::Vector3Stamped &wp,
+		          geometry_msgs::PoseStamped position,
+				  double time_since_position_update,
+				  std::vector<int> h_FOV);
   void runPlanner();
 };
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -912,8 +912,8 @@ void LocalPlannerNode::getInterimWaypoint(geometry_msgs::PoseStamped &wp,
 
   //velocity wp
   wp_vel.linear.x = wp.pose.position.x - newest_pose_.pose.position.x;
-  wp_vel.linear.y = wp.pose.position.y - newest_pose_.pose.position.x;
-  wp_vel.linear.z = wp.pose.position.z - newest_pose_.pose.position.x;
+  wp_vel.linear.y = wp.pose.position.y - newest_pose_.pose.position.y;
+  wp_vel.linear.z = wp.pose.position.z - newest_pose_.pose.position.z;
   wp_vel.angular.x = 0;
   wp_vel.angular.y = 0;
   wp_vel.angular.z = getAngularVelocity(new_yaw, yaw);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -677,8 +677,13 @@ void LocalPlannerNode::publishSetpoint(const geometry_msgs::Twist wp,
   double length =
       std::sqrt(wp.linear.x * wp.linear.x + wp.linear.y * wp.linear.y +
                 wp.linear.z * wp.linear.z);
-  setpoint.pose = newest_pose_.pose;
-  setpoint.scale.x = length;
+  geometry_msgs::Point tip;
+  tip.x = newest_pose_.pose.position.x + wp.linear.x;
+  tip.y = newest_pose_.pose.position.y + wp.linear.y;
+  tip.z = newest_pose_.pose.position.z + wp.linear.z;
+  setpoint.points.push_back(newest_pose_.pose.position);
+  setpoint.points.push_back(tip);
+  setpoint.scale.x = 0.1;
   setpoint.scale.y = 0.1;
   setpoint.scale.z = 0.1;
   setpoint.color.a = 1.0;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -68,8 +68,10 @@ LocalPlannerNode::LocalPlannerNode() {
   path_pub_ = nh_.advertise<nav_msgs::Path>("/path_actual", 1);
   bounding_box_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/bounding_box", 1);
-  mavros_waypoint_pub_ = nh_.advertise<geometry_msgs::Twist>(
+  mavros_vel_setpoint_pub_ = nh_.advertise<geometry_msgs::Twist>(
       "/mavros/setpoint_velocity/cmd_vel_unstamped", 10);
+  mavros_pos_setpoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
+  "/mavros/setpoint_position/local", 10);
   mavros_obstacle_free_path_pub_ = nh_.advertise<mavros_msgs::Trajectory>(
       "/mavros/trajectory/generated", 10);
   mavros_obstacle_distance_pub_ =
@@ -544,9 +546,14 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
   publishSetpoint(result.velocity_waypoint, result.waypoint_type);
 
   // to mavros
-  mavros_waypoint_pub_.publish(result.velocity_waypoint);
   mavros_msgs::Trajectory obst_free_path = {};
-  transformVelocityToTrajectory(obst_free_path, result.velocity_waypoint);
+  if(local_planner_.use_vel_setpoints_){
+      mavros_vel_setpoint_pub_.publish(result.velocity_waypoint);
+      transformVelocityToTrajectory(obst_free_path, result.velocity_waypoint);
+  }else{
+	  mavros_pos_setpoint_pub_.publish(result.position_waypoint);
+	  transformPoseToTrajectory(obst_free_path, result.position_waypoint);
+  }
   mavros_obstacle_free_path_pub_.publish(obst_free_path);
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -767,7 +767,7 @@ void LocalPlannerNode::transformVelocityToTrajectory(
   obst_avoid.point_1.acceleration_or_force.y = NAN;
   obst_avoid.point_1.acceleration_or_force.z = NAN;
   obst_avoid.point_1.yaw = NAN;
-  obst_avoid.point_1.yaw_rate = vel.angular.z;
+  obst_avoid.point_1.yaw_rate = -vel.angular.z;
 
   fillUnusedTrajectoryPoint(obst_avoid.point_2);
   fillUnusedTrajectoryPoint(obst_avoid.point_3);
@@ -894,9 +894,9 @@ void LocalPlannerNode::getInterimWaypoint(geometry_msgs::PoseStamped &wp,
       std::abs(goal_msg_.pose.position.x - newest_pose_.pose.position.x) +
       std::abs(goal_msg_.pose.position.y - newest_pose_.pose.position.y);
   geometry_msgs::Point p;
-  tree_available_ =
-      getDirectionFromTree(p, tree_available_, path_node_positions_,
-                           newest_pose_.pose.position, false);
+  tree_available_ = getDirectionFromTree(
+      p, tree_available_, path_node_positions_, newest_pose_.pose.position,
+      goal_msg_.pose.position, false);
 
   tf::Quaternion q(
       newest_pose_.pose.orientation.x, newest_pose_.pose.orientation.y,

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -72,9 +72,9 @@ class LocalPlannerNode {
   std::timed_mutex variable_mutex_;
   std::timed_mutex publisher_mutex_;
 
-  void publishSetpoint(const geometry_msgs::PoseStamped wp, double mode);
+  void publishSetpoint(const geometry_msgs::Twist wp, double mode);
   void threadFunction();
-  void getInterimWaypoint(geometry_msgs::PoseStamped &wp);
+  void getInterimWaypoint(geometry_msgs::PoseStamped &wp, geometry_msgs::Twist &wp_vel);
   void updatePlannerInfo();
   void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid,
                                  geometry_msgs::PoseStamped pose);

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -63,7 +63,8 @@ class LocalPlannerNode {
 
   ros::Publisher log_name_pub_;
   ros::Publisher current_waypoint_pub_;
-  ros::Publisher mavros_waypoint_pub_;
+  ros::Publisher mavros_pos_setpoint_pub_;
+  ros::Publisher mavros_vel_setpoint_pub_;
   ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher mavros_obstacle_distance_pub_;
   ros::Publisher waypoint_pub_;

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -74,10 +74,13 @@ class LocalPlannerNode {
 
   void publishSetpoint(const geometry_msgs::Twist wp, double mode);
   void threadFunction();
-  void getInterimWaypoint(geometry_msgs::PoseStamped &wp, geometry_msgs::Twist &wp_vel);
+  void getInterimWaypoint(geometry_msgs::PoseStamped &wp,
+                          geometry_msgs::Twist &wp_vel);
   void updatePlannerInfo();
   void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid,
                                  geometry_msgs::PoseStamped pose);
+  void transformVelocityToTrajectory(mavros_msgs::Trajectory &obst_avoid,
+                                     geometry_msgs::Twist vel);
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point);
 
  private:

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -32,6 +32,7 @@
 #include "avoidance/common_ros.h"
 #include "local_planner.h"
 #include "planner_functions.h"
+#include "waypoint_generator.h"
 
 class LocalPlannerNode {
  public:
@@ -40,7 +41,6 @@ class LocalPlannerNode {
 
   bool point_cloud_updated_;
   bool never_run_;
-  bool tree_available_ = false;
   bool write_cloud_ = false;
   bool position_received_ = false;
 
@@ -59,6 +59,7 @@ class LocalPlannerNode {
   ros::Time last_wp_time_;
 
   LocalPlanner local_planner_;
+  WaypointGenerator wp_generator_;
 
   ros::Publisher log_name_pub_;
   ros::Publisher current_waypoint_pub_;
@@ -72,7 +73,8 @@ class LocalPlannerNode {
   std::timed_mutex variable_mutex_;
   std::timed_mutex publisher_mutex_;
 
-  void publishSetpoint(const geometry_msgs::Twist wp, double mode);
+  void publishSetpoint(const geometry_msgs::Twist wp,
+                       waypoint_choice waypoint_type);
   void threadFunction();
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp,
                           geometry_msgs::Twist &wp_vel);
@@ -82,6 +84,7 @@ class LocalPlannerNode {
   void transformVelocityToTrajectory(mavros_msgs::Trajectory &obst_avoid,
                                      geometry_msgs::Twist vel);
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point);
+  void publishWaypoints(bool hover);
 
  private:
   ros::NodeHandle nh_;
@@ -146,7 +149,7 @@ class LocalPlannerNode {
   void velocityCallback(const geometry_msgs::TwistStamped msg);
   void stateCallback(const mavros_msgs::State msg);
   void readParams();
-  void publishAll();
+  void publishPlannerData();
   void publishPath(const geometry_msgs::PoseStamped msg);
   void initMarker(visualization_msgs::MarkerArray *marker,
                   nav_msgs::GridCells path, float red, float green, float blue);
@@ -159,7 +162,7 @@ class LocalPlannerNode {
   void clickedPointCallback(const geometry_msgs::PointStamped &msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped &msg);
   void fcuInputGoalCallback(const mavros_msgs::Trajectory &msg);
-  ;
+
   void printPointInfo(double x, double y, double z);
   void publishGoal();
   void publishBox();
@@ -167,7 +170,6 @@ class LocalPlannerNode {
   void publishGround();
   void publishReachHeight();
   void publishTree();
-  void publishWaypoints();
 };
 
 #endif  // LOCAL_PLANNER_LOCAL_PLANNER_NODE_H

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -618,7 +618,15 @@ geometry_msgs::Vector3Stamped getSphereAdaptedWaypoint(
                        center_to_wp_2D[1] * pose_to_center_2D[1];
     Eigen::Vector2f n(center_to_wp_2D[0] - cos_theta * pose_to_center_2D[0],
                       center_to_wp_2D[1] - cos_theta * pose_to_center_2D[1]);
-    n = n.normalized();
+
+    double mag_n = sqrt(n[0] * n[0] + n[1] * n[1]);
+    if(mag_n > 0){
+    	n[0] = n[0]/mag_n;
+    	n[1] = n[1]/mag_n;
+    }else{
+    	n[0] = 0;
+    	n[1] = 0;
+    }
     double cos_new_theta = 0.9 * cos_theta;
     double sin_new_theta = sin(acos(cos_new_theta));
     Eigen::Vector2f center_to_wp_2D_new(

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -59,8 +59,8 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
                       pcl::PointCloud<pcl::PointXYZ> complete_cloud,
                       double min_cloud_size, double min_dist_backoff,
                       double sphere_radius, Box histogram_box,
-                      geometry_msgs::Point position) {
-  double min_realsense_dist = 0.2;
+                      geometry_msgs::Point position, double min_realsense_dist) {
+
   std::clock_t start_time = std::clock();
   pcl::PointCloud<pcl::PointXYZ>::iterator pcl_it;
   cropped_cloud.points.clear();

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -566,14 +566,17 @@ bool getDirectionFromTree(geometry_msgs::Point &p, bool tree_available,
           elevationAnglefromCartesian(goal.x, goal.y, goal.z, position);
       int goal_z = azimuthAnglefromCartesian(goal.x, goal.y, goal.z, position);
 
-      double tree_progression = 1.0 - double(wp_idx) / double(size);
-      double angle_difference =
-          std::abs(indexAngleDifference(wp_z, goal_z)) / 180.0;
-      double goal_weight = tree_progression * angle_difference;
+//      double tree_progression = 1.0 - double(wp_idx) / double(size);
+//      double angle_difference =
+//          std::abs(indexAngleDifference(wp_z, goal_z)) / 180.0;
+//      double goal_weight = tree_progression * angle_difference;
+//
+//      p.x = wp_e * (1.0 - goal_weight) + goal_e * goal_weight;
+//      p.y = wp_z * (1.0 - goal_weight) + goal_z * goal_weight;
 
-      p.x = wp_e * (1.0 - goal_weight) + goal_e * goal_weight;
-      p.y = wp_z * (1.0 - goal_weight) + goal_z * goal_weight;
-      ;
+      p.x = wp_e;
+      p.y = wp_z;
+
       p.z = 0.0;
     }
   }

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -566,17 +566,13 @@ bool getDirectionFromTree(geometry_msgs::Point &p, bool tree_available,
           elevationAnglefromCartesian(goal.x, goal.y, goal.z, position);
       int goal_z = azimuthAnglefromCartesian(goal.x, goal.y, goal.z, position);
 
-//      double tree_progression = 1.0 - double(wp_idx) / double(size);
-//      double angle_difference =
-//          std::abs(indexAngleDifference(wp_z, goal_z)) / 180.0;
-//      double goal_weight = tree_progression * angle_difference;
-//
-//      p.x = wp_e * (1.0 - goal_weight) + goal_e * goal_weight;
-//      p.y = wp_z * (1.0 - goal_weight) + goal_z * goal_weight;
+      double tree_progression = 1.0 - double(wp_idx) / double(size);
+      double angle_difference =
+          std::abs(indexAngleDifference(wp_z, goal_z)) / 180.0;
+      double goal_weight = tree_progression * angle_difference;
 
-      p.x = wp_e;
-      p.y = wp_z;
-
+      p.x = wp_e * (1.0 - goal_weight) + goal_e * goal_weight;
+      p.y = wp_z * (1.0 - goal_weight) + goal_z * goal_weight;
       p.z = 0.0;
     }
   }

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -56,7 +56,7 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
                       pcl::PointCloud<pcl::PointXYZ> complete_cloud,
                       double min_cloud_size, double min_dist_backoff,
                       double sphere_radius, Box histogram_box,
-                      geometry_msgs::Point position);
+                      geometry_msgs::Point position, double min_realsense_dist);
 void calculateFOV(std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
                   double yaw, double pitch);
 void propagateHistogram(Histogram &polar_histogram_est,

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -96,7 +96,8 @@ bool calculateCostMap(std::vector<float> cost_path_candidates,
                       std::vector<int> &cost_idx_sorted);
 bool getDirectionFromTree(geometry_msgs::Point &p, bool tree_available,
                           std::vector<geometry_msgs::Point> path_node_positions,
-                          geometry_msgs::Point position, bool new_tree);
+                          geometry_msgs::Point position,
+                          geometry_msgs::Point goal, bool new_tree);
 geometry_msgs::Vector3Stamped getSphereAdaptedWaypoint(
     geometry_msgs::Point position, geometry_msgs::Vector3Stamped wp,
     geometry_msgs::Point avoid_centerpoint, double avoid_radius);

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -94,12 +94,12 @@ void printHistogram(Histogram hist, std::vector<int> z_FOV_idx, int e_FOV_min,
                     double resolution);
 bool calculateCostMap(std::vector<float> cost_path_candidates,
                       std::vector<int> &cost_idx_sorted);
-bool getDirectionFromTree(geometry_msgs::Point &p, bool tree_available,
+bool getDirectionFromTree(geometry_msgs::Point &p,
                           std::vector<geometry_msgs::Point> path_node_positions,
                           geometry_msgs::Point position,
-                          geometry_msgs::Point goal, bool new_tree);
-geometry_msgs::Vector3Stamped getSphereAdaptedWaypoint(
-    geometry_msgs::Point position, geometry_msgs::Vector3Stamped wp,
+                          geometry_msgs::Point goal);
+geometry_msgs::Point getSphereAdaptedWaypoint(
+    geometry_msgs::Point position, geometry_msgs::Point wp,
     geometry_msgs::Point avoid_centerpoint, double avoid_radius);
 
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -15,12 +15,14 @@ void StarPlanner::dynamicReconfigureSetStarParams(
 
 void StarPlanner::setParams(const double& min_cloud_size, const double& min_dist_backoff,
                             const nav_msgs::GridCells& path_waypoints, const double& curr_yaw,
-                            bool use_ground_detection) {
+                            bool use_ground_detection, const double& min_realsense_dist) {
+
   path_waypoints_ = path_waypoints;
   curr_yaw_ = curr_yaw;
   use_ground_detection_ = use_ground_detection;
   min_cloud_size_ = min_cloud_size;
   min_dist_backoff_ = min_dist_backoff;
+  min_realsense_dist_ = min_realsense_dist;
 }
 
 void StarPlanner::setPose(const geometry_msgs::PoseStamped& pose) { pose_ = pose; }
@@ -163,7 +165,7 @@ void StarPlanner::buildLookAheadTree() {
                      distance_to_closest_point, backoff_points_counter,
                      sphere_points_counter, complete_cloud_, min_cloud_size_,
                      min_dist_backoff_, avoid_radius, histogram_box_,
-                     origin_position);
+                     origin_position, min_realsense_dist_);
     double safety_radius = adaptSafetyMarginHistogram(
         distance_to_closest_point, cropped_cloud.points.size(),
         min_cloud_size_);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -303,6 +303,6 @@ void StarPlanner::buildLookAheadTree() {
   path_node_origins_.push_back(0);
   tree_age_ = 0;
 
-  ROS_INFO("Tree calculated in %2.2fms.",
+  ROS_INFO("\033[0;35m[SP]Tree calculated in %2.2fms.\033[0m",
            (std::clock() - start_time) / (double)(CLOCKS_PER_SEC / 1000));
 }

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -73,6 +73,7 @@ class StarPlanner {
   double ground_margin_;
   double min_cloud_size_;
   double min_dist_backoff_;
+  double min_realsense_dist_;
 
   std::vector<double> reprojected_points_age_;
   std::vector<double> reprojected_points_dist_;
@@ -102,7 +103,7 @@ class StarPlanner {
 
   void setParams(const double& min_cloud_size, const double& min_dist_backoff,
                  const nav_msgs::GridCells& path_waypoints, const double& curr_yaw,
-                 bool use_ground_detection);
+                 bool use_ground_detection, const double& min_realsense_dist);
 
   void setReprojectedPoints(const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
                             const std::vector<double>& reprojected_points_age,

--- a/local_planner/src/nodes/waypoint_generator.h
+++ b/local_planner/src/nodes/waypoint_generator.h
@@ -1,0 +1,126 @@
+#ifndef WAYPOINT_GENERATOR_H
+#define WAYPOINT_GENERATOR_H
+
+#include <math.h>
+#include <Eigen/Dense>
+#include <chrono>
+#include <deque>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ros/ros.h>
+
+#include "box.h"
+#include "common.h"
+#include "ground_detector.h"
+#include "histogram.h"
+#include "local_planner.h"
+#include "planner_functions.h"
+#include "star_planner.h"
+#include "tree_node.h"
+
+#include <pcl/ModelCoefficients.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl/filters/extract_indices.h>
+#include <pcl/filters/statistical_outlier_removal.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/point_types.h>
+#include <pcl/sample_consensus/method_types.h>
+#include <pcl/sample_consensus/model_types.h>
+#include <pcl/sample_consensus/sac_model_perpendicular_plane.h>
+#include <pcl/segmentation/sac_segmentation.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl_ros/transforms.h>
+
+#include <tf/transform_listener.h>
+
+#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Vector3Stamped.h>
+
+#include <nav_msgs/GridCells.h>
+#include <nav_msgs/Path.h>
+
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <dynamic_reconfigure/server.h>
+#include <local_planner/LocalPlannerNodeConfig.h>
+
+struct waypointResult {
+  waypoint_choice waypoint_type;
+  nav_msgs::Path path;
+  geometry_msgs::PoseStamped position_waypoint;
+  geometry_msgs::Twist velocity_waypoint;
+  geometry_msgs::Point goto_position;
+  geometry_msgs::Point adapted_goto_position;
+  geometry_msgs::Point smoothed_goto_position;
+};
+
+class WaypointGenerator {
+ private:
+  avoidanceOutput planner_info_;
+  waypointResult output_;
+  waypoint_choice last_wp_type_;
+
+  geometry_msgs::PoseStamped pose_;
+  geometry_msgs::Point goal_;
+  double curr_yaw_;
+  double curr_vel_magnitude_;
+  ros::Time update_time_;
+  geometry_msgs::TwistStamped curr_vel_;
+
+  bool reached_goal_;
+  bool reach_altitude_ = false;
+  bool waypoint_outside_FOV_;
+  bool only_yawed_;
+  double last_yaw_;
+  double yaw_reached_goal_;
+  double new_yaw_;
+  double speed_ = 1.0;
+  int e_FOV_max_, e_FOV_min_;
+
+  geometry_msgs::Point hover_position_;
+  geometry_msgs::PoseStamped last_position_waypoint_;
+  geometry_msgs::PoseStamped last_last_position_waypoint_;
+
+  ros::Time velocity_time_;
+  std::vector<int> z_FOV_idx_;
+  std::clock_t last_t_smooth_ = 0.0f;
+
+  void calculateWaypoint();
+  void updateState();
+  void goFast();
+  void backOff();
+  void transformPositionToVelocityWaypoint();
+  bool withinGoalRadius();
+  void reachGoalAltitudeFirst();
+  geometry_msgs::Point smoothWaypoint(geometry_msgs::Point wp);
+  void adaptSpeed(geometry_msgs::Point &wp, geometry_msgs::PoseStamped position,
+                  double time_since_pos_update, std::vector<int> h_FOV);
+  void getPathMsg();
+
+ public:
+  void getWaypoints(waypointResult &output);
+  void setPlannerInfo(avoidanceOutput input);
+  void updateState(geometry_msgs::PoseStamped act_pose,
+                   geometry_msgs::PoseStamped goal,
+                   geometry_msgs::TwistStamped vel, bool stay, ros::Time t);
+
+  WaypointGenerator();
+  ~WaypointGenerator();
+};
+
+#endif  // WAYPOINT_GENERATOR_H


### PR DESCRIPTION
Change in avoidance architecture. The planner is now completely decoupled from the waypoint generation. Therefore the waypoints can be published at a constant rate. Also both position and velocity setpoints are supported and it can be chosen which to use from rqt reconfigure

Tested in SITL and on one flight with Intel Aero