### PR TITLE
launch scripts: fixes to launch PX4

### DIFF
--- a/global_planner/launch/mavros_sitl.launch
+++ b/global_planner/launch/mavros_sitl.launch
@@ -10,16 +10,12 @@
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="mavros_transformation" default="-1.57" />
-    <arg name="est" default="ekf2"/>
-    <arg name="vehicle" default="iris"/>
-    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
 
     <param name="use_sim_time" value="true" />
 
-    <!-- Launch FCU -->
-    <node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4) $(arg rcS)">
-    </node>
+    <!-- Launch PX4 SITL -->
+    <include file="$(find px4)/launch/px4.launch">
+    </include>
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">

--- a/local_planner/launch/local_planner_aero.launch
+++ b/local_planner/launch/local_planner_aero.launch
@@ -23,15 +23,6 @@
     <!--<arg name="mavros_transformation" default="-1.57" /> -->
     <arg name="est" default="ekf2"/>
     
-    
-    <!--<arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/> -->
-
-
-    <!-- Launch FCU -->
-    <!--<node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4) $(arg rcS)">
-    </node> -->
-
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">
         <include file="$(find mavros)/launch/node.launch">

--- a/local_planner/launch/local_planner_aeroD415.launch
+++ b/local_planner/launch/local_planner_aeroD415.launch
@@ -23,14 +23,6 @@
     <!--<arg name="mavros_transformation" default="-1.57" /> -->
     <arg name="est" default="ekf2"/>
     
-    
-    <!--<arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/> -->
-
-
-    <!-- Launch FCU -->
-    <!--<node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4) $(arg rcS)">
-    </node> -->
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">

--- a/local_planner/launch/mavros_sitl.launch
+++ b/local_planner/launch/mavros_sitl.launch
@@ -11,16 +11,12 @@
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="mavros_transformation" default="-1.57" />
-    <arg name="est" default="ekf2"/>
-    <arg name="vehicle" default="iris"/>
-    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
 
     <param name="use_sim_time" value="true" />
 
-    <!-- Launch FCU -->
-    <node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4) $(arg rcS)">
-    </node>
+    <!-- Launch PX4 SITL -->
+    <include file="$(find px4)/launch/px4.launch">
+    </include>
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">


### PR DESCRIPTION
The upstream PX4 CLI interface got changed. This changes to use the newly
added px4.launch script, which makes the avoidance repo independent from
the CLI interface.

Requires https://github.com/PX4/Firmware/pull/10247