### PR TITLE
Local Planner: Remove OpenCV dependency

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   tf
   pcl_ros
+  octomap_msgs
 )
 find_package(PCL 1.7 REQUIRED)
 find_package(octomap REQUIRED)

--- a/global_planner/package.xml
+++ b/global_planner/package.xml
@@ -50,6 +50,7 @@
   <build_depend>mav_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>octomap</build_depend>
+  <build_depend>octomap_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>mavros</build_depend>
@@ -63,6 +64,7 @@
   <run_depend>mav_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>octomap</run_depend>
+  <run_depend>octomap_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>mavros</run_depend>

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -18,7 +18,6 @@ find_package(catkin REQUIRED COMPONENTS
   mavlink
 )
 find_package(PCL 1.7 REQUIRED)
-find_package(OpenCV REQUIRED)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -151,7 +150,7 @@ add_executable(local_planner_node src/nodes/local_planner_node.cpp)
 # )
 target_link_libraries(local_planner_node
   local_planner
-  ${catkin_LIBRARIES} ${OpenCV_LIBS})
+  ${catkin_LIBRARIES})
 
 #############
 ## Install ##

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -1,5 +1,7 @@
 #include "planner_functions.h"
 
+#include <numeric>
+
 // initialize GridCell message
 void initGridCells(nav_msgs::GridCells *cell) {
   cell->cells.clear();
@@ -485,8 +487,12 @@ bool calculateCostMap(std::vector<float> cost_path_candidates,
     ROS_WARN("\033[1;31mbold Empty candidates vector!\033[0m\n");
     return 1;
   } else {
-    cv::sortIdx(cost_path_candidates, cost_idx_sorted,
-                CV_SORT_EVERY_ROW + CV_SORT_ASCENDING);
+    cost_idx_sorted.resize(cost_path_candidates.size());
+    std::iota(cost_idx_sorted.begin(), cost_idx_sorted.end(), 0);
+
+    std::sort(cost_idx_sorted.begin(), cost_idx_sorted.end(),
+      [&cost_path_candidates](size_t i1, size_t i2)
+      { return cost_path_candidates[i1] < cost_path_candidates[i2]; });
     return 0;
   }
 }


### PR DESCRIPTION
It's only used for cv::sortIdx and it pulled Qt dependencies which caused problems on my system (Fedora).

Also adds octomap_msgs dependency to the global planner, since it requires that.