### PR TITLE
Local Planner: improve locking & data updating

### DIFF
--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -85,6 +85,7 @@ class LocalPlannerNode {
   void threadFunction();
   void getInterimWaypoint(geometry_msgs::PoseStamped &wp,
                           geometry_msgs::Twist &wp_vel);
+  bool canUpdatePlannerInfo();
   void updatePlannerInfo();
   void transformPoseToTrajectory(mavros_msgs::Trajectory &obst_avoid,
                                  geometry_msgs::PoseStamped pose);
@@ -92,6 +93,8 @@ class LocalPlannerNode {
                                      geometry_msgs::Twist vel);
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget &point);
   void publishWaypoints(bool hover);
+
+  const ros::NodeHandle &nodeHandle() const { return nh_; }
 
  private:
   ros::NodeHandle nh_;


### PR DESCRIPTION
- use a condition variable to run the planner
- never block the main thread to wait for the planner
- correctly wait for the planner thread to quit
- run the waypoint generator synchronous with a position update to ensure that we immediately publish a position setpoint when we got a new vehicle position