### PR TITLE
Bug fix and some improvements

### DIFF
--- a/local_planner/resource/local_planner.rviz
+++ b/local_planner/resource/local_planner.rviz
@@ -29,7 +29,7 @@ Visualization Manager:
   Displays:
     - Class: rviz/MarkerArray
       Enabled: true
-      Marker Topic: /rviz_world_loader/marker
+      Marker Topic: /world
       Name: World
       Namespaces:
         {}
@@ -215,7 +215,7 @@ Visualization Manager:
       Use rainbow: true
       Value: true
     - Class: rviz/Image
-      Enabled: false
+      Enabled: true
       Image Topic: /camera/rgb/image_raw
       Max Value: 1
       Median window: 5
@@ -225,7 +225,7 @@ Visualization Manager:
       Queue Size: 2
       Transport Hint: raw
       Unreliable: false
-      Value: false
+      Value: true
     - Class: rviz/Marker
       Enabled: true
       Marker Topic: /complete_tree
@@ -305,7 +305,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/ThirdPersonFollower
-      Distance: 16.3333511
+      Distance: 28.7849445
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.0599999987
         Stereo Focal Distance: 1
@@ -320,10 +320,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 0.199798495
+      Pitch: 0.69479847
       Target Frame: camera_link
       Value: ThirdPersonFollower (rviz)
-      Yaw: 5.92043209
+      Yaw: 4.88542843
     Saved:
       - Class: rviz/ThirdPersonFollower
         Distance: 10

--- a/local_planner/resource/local_planner.rviz
+++ b/local_planner/resource/local_planner.rviz
@@ -53,6 +53,22 @@ Visualization Manager:
       Plane Cell Count: 36
       Reference Frame: <Fixed Frame>
       Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /path_actual
+      Name: path_actual
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Marker
+      Enabled: true
+      Marker Topic: /path_waypoint
+      Name: path_waypoint
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
     - Alpha: 1
       Axes Length: 1
       Axes Radius: 0.100000001
@@ -119,56 +135,10 @@ Visualization Manager:
     - Class: rviz/MarkerArray
       Enabled: true
       Marker Topic: /goal_position
-      Name: MarkerArray
+      Name: Goal
       Namespaces:
         "": true
       Queue Size: 100
-      Value: true
-    - Alpha: 1
-      Buffer Length: 1
-      Class: rviz/Path
-      Color: 255; 0; 0
-      Enabled: true
-      Head Diameter: 0.300000012
-      Head Length: 0.200000003
-      Length: 0.300000012
-      Line Style: Lines
-      Line Width: 0.0299999993
-      Name: Old trajectory
-      Offset:
-        X: 0
-        Y: 0
-        Z: 0
-      Pose Color: 255; 85; 255
-      Pose Style: None
-      Radius: 0.0299999993
-      Shaft Diameter: 0.100000001
-      Shaft Length: 0.100000001
-      Topic: /path_actual
-      Unreliable: false
-      Value: true
-    - Alpha: 1
-      Buffer Length: 1
-      Class: rviz/Path
-      Color: 25; 255; 0
-      Enabled: true
-      Head Diameter: 0.300000012
-      Head Length: 0.200000003
-      Length: 0.300000012
-      Line Style: Billboards
-      Line Width: 0.0299999993
-      Name: Path
-      Offset:
-        X: 0
-        Y: 0
-        Z: 0
-      Pose Color: 255; 85; 255
-      Pose Style: None
-      Radius: 0.0299999993
-      Shaft Diameter: 0.100000001
-      Shaft Length: 0.100000001
-      Topic: /waypoint
-      Unreliable: false
       Value: true
     - Class: rviz/Axes
       Enabled: true
@@ -244,72 +214,6 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 10
-        Min Value: -10
-        Value: true
-      Axis: Z
-      Channel Name: intensity
-      Class: rviz/PointCloud2
-      Color: 255; 255; 255
-      Color Transformer: ""
-      Decay Time: 0
-      Enabled: false
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 4096
-      Min Color: 0; 0; 0
-      Min Intensity: 0
-      Name: GroundCloud
-      Position Transformer: ""
-      Queue Size: 10
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.00999999978
-      Style: Flat Squares
-      Topic: /ground_pointcloud
-      Unreliable: false
-      Use Fixed Frame: true
-      Use rainbow: true
-      Value: false
-    - Class: rviz/Marker
-      Enabled: false
-      Marker Topic: /bounding_box
-      Name: Box
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: false
-    - Class: rviz/Marker
-      Enabled: false
-      Marker Topic: /ground_box
-      Name: GroundBox
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: false
-    - Class: rviz/MarkerArray
-      Enabled: false
-      Marker Topic: /height_map
-      Name: HeightMap
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: false
-    - Class: rviz/Image
-      Enabled: true
-      Image Topic: /camera/depth/image_raw
-      Max Value: 1
-      Median window: 5
-      Min Value: 0
-      Name: Image
-      Normalize Range: true
-      Queue Size: 2
-      Transport Hint: raw
-      Unreliable: false
-      Value: true
     - Class: rviz/Image
       Enabled: false
       Image Topic: /camera/rgb/image_raw
@@ -332,12 +236,20 @@ Visualization Manager:
       Value: true
     - Class: rviz/Marker
       Enabled: true
-      Marker Topic: /initial_height
-      Name: InitialHeight
+      Marker Topic: /tree_path
+      Name: TreePath
       Namespaces:
         "": true
       Queue Size: 100
       Value: true
+    - Class: rviz/Marker
+      Enabled: false
+      Marker Topic: /initial_height
+      Name: InitialHeight
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: false
     - Class: rviz/Marker
       Enabled: true
       Marker Topic: /take_off_pose
@@ -370,22 +282,6 @@ Visualization Manager:
         "": true
       Queue Size: 100
       Value: true
-    - Class: rviz/Marker
-      Enabled: true
-      Marker Topic: /tree_path
-      Name: TreePath
-      Namespaces:
-        "": true
-      Queue Size: 100
-      Value: true
-    - Class: rviz/MarkerArray
-      Enabled: true
-      Marker Topic: /world
-      Name: world
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -409,7 +305,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/ThirdPersonFollower
-      Distance: 20.4885559
+      Distance: 16.3333511
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.0599999987
         Stereo Focal Distance: 1
@@ -424,10 +320,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 0.499797255
+      Pitch: 0.199798495
       Target Frame: camera_link
       Value: ThirdPersonFollower (rviz)
-      Yaw: 5.25543547
+      Yaw: 5.92043209
     Saved:
       - Class: rviz/ThirdPersonFollower
         Distance: 10
@@ -477,7 +373,7 @@ Window Geometry:
   Hide Right Dock: true
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a0000037afc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730200000a00000004fd00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000001be000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000001ec000001b60000001600fffffffb0000000a0049006d00610067006500000002ce000000c00000001600ffffff00000001000001320000034ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000340000034f000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007600000004afc0100000002fb0000000800540069006d00650100000000000007600000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000005f00000037a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a0000037afc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730200000a00000004fd00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000001be000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000001ec000001b60000001600fffffffb0000000a0049006d00610067006500000002ce000000c0000000000000000000000001000001320000034ffc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000340000034f000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007600000004afc0100000002fb0000000800540069006d00650100000000000007600000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000005f00000037a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:

--- a/local_planner/resource/realsense_params.sh
+++ b/local_planner/resource/realsense_params.sh
@@ -2,9 +2,12 @@
 
 rosrun dynamic_reconfigure dynparam set /camera_front/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
 rosrun dynamic_reconfigure dynparam set /camera_front/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
+rosrun dynamic_reconfigure dynparam set /camera_front/realsense2_camera_manager rs435_depth_visual_preset 3
 
 rosrun dynamic_reconfigure dynparam set /camera_left/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
 rosrun dynamic_reconfigure dynparam set /camera_left/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
+rosrun dynamic_reconfigure dynparam set /camera_left/realsense2_camera_manager rs435_depth_visual_preset 3
 
 rosrun dynamic_reconfigure dynparam set /camera_right/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
 rosrun dynamic_reconfigure dynparam set /camera_right/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
+rosrun dynamic_reconfigure dynparam set /camera_right/realsense2_camera_manager rs435_depth_visual_preset 3

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -186,3 +186,15 @@ double getAngularVelocity(double desired_yaw, double curr_yaw) {
 
   return 0.5 * vel;
 }
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) throw std::runtime_error("popen() failed!");
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != nullptr)
+            result += buffer.data();
+    }
+    return result;
+}

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -6,6 +6,11 @@
 #include <iostream>
 #include <limits>
 #include <vector>
+#include <cstdio>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <array>
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -48,5 +53,6 @@ double velocityLinear(double max_vel, double min_vel, double slope,
                       double v_old, double elapsed);
 void wrapAngleToPlusMinusPI(double &angle);
 double getAngularVelocity(double desired_yaw, double curr_yaw);
+std::string exec(const char* cmd);
 
 #endif  // COMMON_H

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -80,7 +80,8 @@ LocalPlannerNode::LocalPlannerNode() {
       nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
   current_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/current_setpoint", 1);
-  log_name_pub_ = nh_.advertise<std_msgs::String>("/log_name", 1);
+  cpu_pub_ = nh_.advertise<std_msgs::String>("/cpu_usage", 1);
+  memory_pub_ = nh_.advertise<std_msgs::String>("/memory_usage", 1);
   takeoff_pose_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/take_off_pose", 1);
   offboard_pose_pub_ =
@@ -908,10 +909,17 @@ void LocalPlannerNode::threadFunction() {
                 (std::clock() - start_time) / (double)(CLOCKS_PER_SEC / 1000));
     }
 
-    // publish log name
-    std_msgs::String msg;
-    msg.data = local_planner_.log_name_;
-    log_name_pub_.publish(msg);
+    // publish performance data
+    std_msgs::String cpu_msg;
+    std_msgs::String mem_msg;
+    std::string cpu = exec(" top -bn 1 | awk '{print $9}' | tail -n +8 | awk '{s+=$1} END {print s/8}'");
+    std::string mem = exec(" top -b -n1 | grep Mem | head -1 | awk '{print $4, $5, $6, $7, $8, $9, $10, $11}'");
+
+    cpu_msg.data = cpu;
+    mem_msg.data = mem;
+
+    cpu_pub_.publish(cpu_msg);
+    memory_pub_.publish(mem_msg);
   }
 }
 

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -68,7 +68,8 @@ class LocalPlannerNode {
   WaypointGenerator wp_generator_;
 
   ros::Publisher world_pub_;
-  ros::Publisher log_name_pub_;
+  ros::Publisher cpu_pub_;
+  ros::Publisher memory_pub_;
   ros::Publisher current_waypoint_pub_;
   ros::Publisher mavros_pos_setpoint_pub_;
   ros::Publisher mavros_vel_setpoint_pub_;

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -56,6 +56,9 @@ class LocalPlannerNode {
   std::vector<geometry_msgs::Point> path_node_positions_;
   geometry_msgs::PoseStamped hover_point_;
   geometry_msgs::PoseStamped newest_pose_;
+  geometry_msgs::PoseStamped last_pose_;
+  geometry_msgs::Point newest_waypoint_position_;
+  geometry_msgs::Point last_waypoint_position_;
   sensor_msgs::PointCloud2 newest_point_cloud_;
   geometry_msgs::PoseStamped goal_msg_;
 
@@ -104,11 +107,10 @@ class LocalPlannerNode {
  private:
   ros::NodeHandle nh_;
 
-  nav_msgs::Path path_actual_;
-
   double avoid_radius_;
   geometry_msgs::Point avoid_centerpoint_;
   bool use_sphere_;
+  int path_length_ = 0;
 
   // Subscribers
   ros::Subscriber pointcloud_sub_;
@@ -129,7 +131,8 @@ class LocalPlannerNode {
   ros::Publisher height_map_pub_;
   ros::Publisher cached_pointcloud_pub_;
   ros::Publisher marker_pub_;
-  ros::Publisher path_pub_;
+  ros::Publisher path_actual_pub_;
+  ros::Publisher path_waypoint_pub_;
   ros::Publisher marker_rejected_pub_;
   ros::Publisher marker_blocked_pub_;
   ros::Publisher marker_candidates_pub_;
@@ -165,7 +168,7 @@ class LocalPlannerNode {
   void stateCallback(const mavros_msgs::State& msg);
   void readParams();
   void publishPlannerData();
-  void publishPath(const geometry_msgs::PoseStamped& msg);
+  void publishPaths();
   void initMarker(visualization_msgs::MarkerArray *marker,
                   nav_msgs::GridCells& path, const float red, const float green, const float blue);
   void publishMarkerBlocked(nav_msgs::GridCells& path_blocked);

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -69,6 +69,10 @@ void WaypointGenerator::calculateWaypoint() {
     }
   }
   last_wp_type_ = planner_info_.waypoint_type;
+  last_time_ = ros::Time::now();
+  last_position_waypoint_ = output_.position_waypoint;
+  last_yaw_ = curr_yaw_;
+  last_velocity_ = Eigen::Vector2f(curr_vel_.twist.linear.x, curr_vel_.twist.linear.y);
 }
 
 void WaypointGenerator::updateState(geometry_msgs::PoseStamped act_pose,
@@ -426,10 +430,6 @@ void WaypointGenerator::getPathMsg() {
   transformPositionToVelocityWaypoint();
 
   output_.path.poses.push_back(output_.position_waypoint);
-  last_position_waypoint_ = output_.position_waypoint;
-  last_yaw_ = curr_yaw_;
-  last_velocity_ = Eigen::Vector2f(curr_vel_.twist.linear.x, curr_vel_.twist.linear.y);
-  last_time_ = now;
 }
 
 void WaypointGenerator::getWaypoints(waypointResult &output) {

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -171,7 +171,6 @@ void WaypointGenerator::backOff() {
   output_.goto_position.z = planner_info_.back_off_start_point.z;
 
   output_.position_waypoint = createPoseMsg(output_.goto_position, last_yaw_);
-  output_.path.poses.push_back(output_.position_waypoint);
   transformPositionToVelocityWaypoint();
   last_yaw_ = curr_yaw_;
 
@@ -355,7 +354,6 @@ void WaypointGenerator::adaptSpeed() {
 
 // create the message that is sent to the UAV
 void WaypointGenerator::getPathMsg() {
-  output_.path.header.frame_id = "/world";
   output_.adapted_goto_position = output_.goto_position;
 
   const ros::Time now = ros::Time::now();
@@ -428,8 +426,6 @@ void WaypointGenerator::getPathMsg() {
   output_.position_waypoint =
       createPoseMsg(output_.smoothed_goto_position, new_yaw_);
   transformPositionToVelocityWaypoint();
-
-  output_.path.poses.push_back(output_.position_waypoint);
 }
 
 void WaypointGenerator::getWaypoints(waypointResult &output) {

--- a/local_planner/src/nodes/waypoint_generator.h
+++ b/local_planner/src/nodes/waypoint_generator.h
@@ -21,13 +21,9 @@
 #include <geometry_msgs/Twist.h>
 #include <geometry_msgs/Vector3Stamped.h>
 
-#include <nav_msgs/GridCells.h>
-#include <nav_msgs/Path.h>
-
 
 struct waypointResult {
   waypoint_choice waypoint_type;
-  nav_msgs::Path path;
   geometry_msgs::PoseStamped position_waypoint;
   geometry_msgs::Twist velocity_waypoint;
   geometry_msgs::Point goto_position;


### PR DESCRIPTION
- fix bug in smoothing, where the last time was not always saved which led to incorrect time differentials
- log cpu and memory usage in rostopics
- change markers for actual path and path directed by the waypoints. These markers before accumulated over time. This led to message bandwidths of 160MB/s after a few minutes for each path and overloaded the memory when logging.
- set Realsense visual preset to HIGH_ACCURACY mode by default as it proved to be better than the default mode


We got nice flights with these changes