### PR TITLE
README: add missing mavros-extras package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mkdir -p ~/catkin_ws/src
 5. Install mavros. The package coming from the ROS repository should be fine. Just in case, instructions to install it from sources can be found here: https://dev.px4.io/en/ros/mavros_installation.html.
 
 ```bash
-apt install ros-kinetic-mavros
+apt install ros-kinetic-mavros ros-kinetic-mavros-extras
 ```
 
 6. Install avoidance module dependencies (pointcloud library and octomap).


### PR DESCRIPTION
Mavros-extras seems to be a dependency as well
```
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
Could not find a package configuration file provided by "mavros_extras"
with any of the following names:

    mavros_extrasConfig.cmake
    mavros_extras-config.cmake
```