### PR TITLE
Make the global planner great again

### DIFF
--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -95,6 +95,7 @@ class GlobalPlanner {
   double max_overestimate_factor_ = 2.0;
   int max_iterations_ = 2000;
   bool goal_is_blocked_ = false;
+  bool current_cell_blocked_ = false;
   bool goal_must_be_free_ =
       true;  // If false, the planner may try to find a path close to the goal
   bool use_current_yaw_ =

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -513,13 +513,14 @@ bool GlobalPlanner::findPath(std::vector<Cell>& path) {
 bool GlobalPlanner::getGlobalPath() {
   Cell s = Cell(curr_pos_);
   Cell t = Cell(goal_pos_);
+  current_cell_blocked_ = isOccupied(s);
 
   if (goal_must_be_free_ && getRisk(t) > max_cell_risk_) {
     // If goal is occupied, no path is published
     ROS_INFO("Goal position is occupied");
     goal_is_blocked_ = true;
     return false;
-  } else if (isOccupied(s)) {
+  } else if (current_cell_blocked_) {
     // If current position is occupied the way back is published
     ROS_INFO("Current position is occupied, going back.");
     // goBack();

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -190,6 +190,11 @@ void GlobalPlannerNode::positionCallback(
     popNextGoal();
   }
 
+  // If the current cell is blocked, try finding a path again
+  if(global_planner_.current_cell_blocked_){
+	  planPath();
+  }
+
   // Print and publish info
   if (is_in_goal && !waypoints_.empty()) {
     ROS_INFO("Reached current goal %s, %d goals left\n\n",


### PR DESCRIPTION
This commit alleviates some problems the global planner has with
noise. If the current cell is detected as occupied, it cannot currently find
a path. This commit introduces a boolean flag that keeps the planner
re-trying until a path is found.

Fixes #33

To be honest, it doesn't quite make the global planner great again, but it makes it mediocre at least