### PR TITLE
Add mutex before calling dynamic reconfigure

### DIFF
--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -160,7 +160,8 @@ class LocalPlannerNode {
   geometry_msgs::TwistStamped vel_msg_;
   bool armed_, offboard_, mission_, new_goal_;
 
-  dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig> server_;
+  dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;
+  boost::recursive_mutex config_mutex_;
 
   void dynamicReconfigureCallback(avoidance::LocalPlannerNodeConfig &config,
                                   uint32_t level);


### PR DESCRIPTION
Fix for this warning
```[ WARN] [1539698071.890387845]: updateConfig() called on a dynamic_reconfigure::Server that provides its own mutex. This can lead to deadlocks if updateConfig() is called during an update. Providing a mutex to the constructor is highly recommended in this case. Please forward this message to the node author. ```