### PR TITLE
changes for building local planner with catkin build

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -183,11 +183,14 @@ target_link_libraries(local_planner_node
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
+install(DIRECTORY
+  launch
+  resource
+  cfg
 #   # myfile1
 #   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 #############
 ## Testing ##

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -47,4 +47,4 @@ gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in comple
 gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)
 gen.add("tree_discount_factor_",    double_t,    0, "Discount factor in tree cost function", 0.8,  0, 1)
 
-exit(gen.generate(PACKAGE, "avoidance", "LocalPlannerNode"))
+exit(gen.generate(PACKAGE, "avoidance", "local_planner_node"))


### PR DESCRIPTION
When building the local_planner with catkin build, the installation fails and throws out the following error: 

```
CMake Error at cmake_install.cmake:118 (file):
  file INSTALL cannot find
  "<>/catkin_ws/devel/.private/local_planner/include/local_planner/local_planner_nodeConfig.h".


make: *** [install] Error 1
```
Changes to the cfg file fixes that. 
After changing the cfg file, the launch files are not automatically installed, changes to the `CMakeLists.txt` file fixes that. 