### PR TITLE
Add mavros_extras as dependency for local_planner

### DIFF
--- a/local_planner/package.xml
+++ b/local_planner/package.xml
@@ -52,6 +52,7 @@
   <build_depend>tf</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>mavros</build_depend>
+  <build_depend>mavros_extras</build_depend>
   <build_depend>mavros_msgs</build_depend>
 
   <run_depend>dynamic_reconfigure</run_depend>
@@ -66,6 +67,7 @@
   <run_depend>tf</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>mavros</run_depend>
+  <run_depend>mavros_extras</run_depend>
   <run_depend>mavros_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This PR adds a `mavros_extras` as a dependency to the local planner.

This is needed when building `mavros` and `mavros_extras` are being initially built together from source in the catkin workspace.

@baumanta 