### PR TITLE
do not try to visualize drone if running on hardware

### DIFF
--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -213,8 +213,10 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
 
   //visualize drone in RVIZ
   visualization_msgs::Marker marker;
-  if (!visualizeDrone(msg, marker)) {
-    drone_pub_.publish(marker);
+  if(!world_path_.empty()){
+    if (!visualizeDrone(msg, marker)) {
+      drone_pub_.publish(marker);
+    }
   }
 }
 


### PR DESCRIPTION
The master was broken on hardware, as the Rviz visualization for the drone tried to execute also when no world file was specified.