### PR TITLE
Modify FOV via a parameter.

### DIFF
--- a/local_planner/launch/local_planner_A700_1cam.launch
+++ b/local_planner/launch/local_planner_A700_1cam.launch
@@ -63,6 +63,8 @@
       <param name="goal_x_param" value="15" />
       <param name="goal_y_param" value="15"/>
       <param name="goal_z_param" value="4" />
+      <param name="horizontal_FOV" value="90" />
+      <param name="vertical_FOV" value="59" />
       <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>
   

--- a/local_planner/launch/local_planner_A700_3cam.launch
+++ b/local_planner/launch/local_planner_A700_3cam.launch
@@ -97,6 +97,8 @@
       <param name="goal_x_param" value="15" />
       <param name="goal_y_param" value="15"/>
       <param name="goal_z_param" value="4" />
+      <param name="horizontal_FOV" value="270" />
+      <param name="vertical_FOV" value="59" />
       <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>
     

--- a/local_planner/launch/local_planner_depth-camera.launch
+++ b/local_planner/launch/local_planner_depth-camera.launch
@@ -24,6 +24,8 @@
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
+        <param name="horizontal_FOV" value="60" />
+        <param name="vertical_FOV" value="45" />
         <param name="world_name" value="$(find local_planner)/../sim/worlds/$(arg world_file_name).yaml" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>

--- a/local_planner/launch/local_planner_sitl_3cam.launch
+++ b/local_planner/launch/local_planner_sitl_3cam.launch
@@ -26,6 +26,8 @@
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
+        <param name="horizontal_FOV" value="180" />
+        <param name="vertical_FOV" value="45" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
         <param name="world_name" value="$(find local_planner)/../sim/worlds/simple_obstacle.yaml" />
     </node>

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -111,7 +111,7 @@ void LocalPlanner::runPlanner() {
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   z_FOV_idx_.clear();
-  calculateFOV(z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
+  calculateFOV(H_FOV_, V_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
 
   // visualization of FOV in RViz
   initGridCells(&FOV_cells_);
@@ -272,6 +272,7 @@ void LocalPlanner::determineStrategy() {
         if (use_VFH_star_) {
           star_planner_.setParams(min_cloud_size_, min_dist_backoff_,
                                   path_waypoints_, curr_yaw_, min_realsense_dist_);
+          star_planner_.setFOV(H_FOV_, V_FOV_);
           star_planner_.setReprojectedPoints(reprojected_points_,
                                              reprojected_points_age_,
                                              reprojected_points_dist_);

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -111,7 +111,7 @@ void LocalPlanner::runPlanner() {
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   z_FOV_idx_.clear();
-  calculateFOV(H_FOV_, V_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
+  calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
 
   // visualization of FOV in RViz
   initGridCells(&FOV_cells_);
@@ -272,7 +272,7 @@ void LocalPlanner::determineStrategy() {
         if (use_VFH_star_) {
           star_planner_.setParams(min_cloud_size_, min_dist_backoff_,
                                   path_waypoints_, curr_yaw_, min_realsense_dist_);
-          star_planner_.setFOV(H_FOV_, V_FOV_);
+          star_planner_.setFOV(h_FOV_, v_FOV_);
           star_planner_.setReprojectedPoints(reprojected_points_,
                                              reprojected_points_age_,
                                              reprojected_points_dist_);

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -186,6 +186,8 @@ class LocalPlanner {
 
  public:
 
+  double H_FOV_ = 59.0;
+  double V_FOV_ = 46.0;
   Box histogram_box_;
   bool use_vel_setpoints_;
   bool currently_armed_ = false;

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -186,8 +186,8 @@ class LocalPlanner {
 
  public:
 
-  double H_FOV_ = 59.0;
-  double V_FOV_ = 46.0;
+  double h_FOV_ = 59.0;
+  double v_FOV_ = 46.0;
   Box histogram_box_;
   bool use_vel_setpoints_;
   bool currently_armed_ = false;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -124,6 +124,13 @@ void LocalPlannerNode::readParams() {
   nh_.param<double>("min_speed_close_to_goal", new_params.min_speed_close_to_goal, 0.5);
 
   wp_generator_.param_ = new_params;
+
+  //set field of view
+  nh_.param<double>("horizontal_FOV", local_planner_.H_FOV_, 59.0);
+  nh_.param<double>("vertical_FOV", local_planner_.V_FOV_, 46.0);
+  local_planner_.H_FOV_ = local_planner_.H_FOV_;
+  local_planner_.V_FOV_ = local_planner_.V_FOV_;
+  wp_generator_.setFOV(local_planner_.H_FOV_, local_planner_.V_FOV_);
 }
 
 void LocalPlannerNode::initializeCameraSubscribers(

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -126,11 +126,9 @@ void LocalPlannerNode::readParams() {
   wp_generator_.param_ = new_params;
 
   //set field of view
-  nh_.param<double>("horizontal_FOV", local_planner_.H_FOV_, 59.0);
-  nh_.param<double>("vertical_FOV", local_planner_.V_FOV_, 46.0);
-  local_planner_.H_FOV_ = local_planner_.H_FOV_;
-  local_planner_.V_FOV_ = local_planner_.V_FOV_;
-  wp_generator_.setFOV(local_planner_.H_FOV_, local_planner_.V_FOV_);
+  nh_.param<double>("horizontal_FOV", local_planner_.h_FOV_, 59.0);
+  nh_.param<double>("vertical_FOV", local_planner_.v_FOV_, 46.0);
+  wp_generator_.setFOV(local_planner_.h_FOV_, local_planner_.v_FOV_);
 }
 
 void LocalPlannerNode::initializeCameraSubscribers(

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -127,16 +127,16 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
 }
 
 // Calculate FOV. Azimuth angle is wrapped, elevation is not!
-void calculateFOV(double H_FOV, double V_FOV, std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
+void calculateFOV(double h_fov, double v_fov, std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
                   double yaw, double pitch) {
   double z_FOV_max =
-      std::round((-yaw * 180.0 / M_PI + H_FOV / 2.0 + 270.0) / ALPHA_RES) - 1;
+      std::round((-yaw * 180.0 / M_PI + h_fov / 2.0 + 270.0) / ALPHA_RES) - 1;
   double z_FOV_min =
-      std::round((-yaw * 180.0 / M_PI - H_FOV / 2.0 + 270.0) / ALPHA_RES) - 1;
+      std::round((-yaw * 180.0 / M_PI - h_fov / 2.0 + 270.0) / ALPHA_RES) - 1;
   e_FOV_max =
-      std::round((-pitch * 180.0 / M_PI + V_FOV / 2.0 + 90.0) / ALPHA_RES) - 1;
+      std::round((-pitch * 180.0 / M_PI + v_fov / 2.0 + 90.0) / ALPHA_RES) - 1;
   e_FOV_min =
-      std::round((-pitch * 180.0 / M_PI - V_FOV / 2.0 + 90.0) / ALPHA_RES) - 1;
+      std::round((-pitch * 180.0 / M_PI - v_fov / 2.0 + 90.0) / ALPHA_RES) - 1;
 
   if (z_FOV_max >= GRID_LENGTH_Z && z_FOV_min >= GRID_LENGTH_Z) {
     z_FOV_max -= GRID_LENGTH_Z;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -127,7 +127,7 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
 }
 
 // Calculate FOV. Azimuth angle is wrapped, elevation is not!
-void calculateFOV(std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
+void calculateFOV(double H_FOV, double V_FOV, std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
                   double yaw, double pitch) {
   double z_FOV_max =
       std::round((-yaw * 180.0 / M_PI + H_FOV / 2.0 + 270.0) / ALPHA_RES) - 1;

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -55,8 +55,8 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
                       double min_cloud_size, double min_dist_backoff,
                       double sphere_radius, Box histogram_box,
                       geometry_msgs::Point position, double min_realsense_dist);
-void calculateFOV(std::vector<int> &z_FOV_idx, int &e_FOV_min, int &e_FOV_max,
-                  double yaw, double pitch);
+void calculateFOV(double H_FOV, double V_FOV, std::vector<int> &z_FOV_idx, int &e_FOV_min,
+		          int &e_FOV_max, double yaw, double pitch);
 void propagateHistogram(Histogram &polar_histogram_est,
                         pcl::PointCloud<pcl::PointXYZ> reprojected_points,
                         std::vector<double> reprojected_points_age,

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -55,7 +55,7 @@ void filterPointCloud(pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
                       double min_cloud_size, double min_dist_backoff,
                       double sphere_radius, Box histogram_box,
                       geometry_msgs::Point position, double min_realsense_dist);
-void calculateFOV(double H_FOV, double V_FOV, std::vector<int> &z_FOV_idx, int &e_FOV_min,
+void calculateFOV(double h_FOV, double v_FOV, std::vector<int> &z_FOV_idx, int &e_FOV_min,
 		          int &e_FOV_max, double yaw, double pitch);
 void propagateHistogram(Histogram &polar_histogram_est,
                         pcl::PointCloud<pcl::PointXYZ> reprojected_points,

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -24,9 +24,9 @@ void StarPlanner::setParams(const double& min_cloud_size, const double& min_dist
   min_realsense_dist_ = min_realsense_dist;
 }
 
-void StarPlanner::setFOV(double& H_FOV, double& V_FOV){
-	H_FOV_ = H_FOV;
-	V_FOV_ = V_FOV;
+void StarPlanner::setFOV(double& h_FOV, double& v_FOV){
+	h_FOV_ = h_FOV;
+	v_FOV_ = v_FOV;
 }
 
 void StarPlanner::setPose(const geometry_msgs::PoseStamped& pose) { pose_ = pose; }
@@ -185,7 +185,7 @@ void StarPlanner::buildLookAheadTree() {
       // build new histogram
       std::vector<int> z_FOV_idx;
       int e_FOV_min, e_FOV_max;
-      calculateFOV(H_FOV_, V_FOV_, z_FOV_idx, e_FOV_min, e_FOV_max, tree_[origin].yaw_,
+      calculateFOV(h_FOV_, v_FOV_, z_FOV_idx, e_FOV_min, e_FOV_max, tree_[origin].yaw_,
                    0.0);  // assume pitch is zero at every node
 
       Histogram propagated_histogram = Histogram(2 * ALPHA_RES);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -24,6 +24,11 @@ void StarPlanner::setParams(const double& min_cloud_size, const double& min_dist
   min_realsense_dist_ = min_realsense_dist;
 }
 
+void StarPlanner::setFOV(double& H_FOV, double& V_FOV){
+	H_FOV_ = H_FOV;
+	V_FOV_ = V_FOV;
+}
+
 void StarPlanner::setPose(const geometry_msgs::PoseStamped& pose) { pose_ = pose; }
 
 void StarPlanner::setCloud(const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud) {
@@ -180,7 +185,7 @@ void StarPlanner::buildLookAheadTree() {
       // build new histogram
       std::vector<int> z_FOV_idx;
       int e_FOV_min, e_FOV_max;
-      calculateFOV(z_FOV_idx, e_FOV_min, e_FOV_max, tree_[origin].yaw_,
+      calculateFOV(H_FOV_, V_FOV_, z_FOV_idx, e_FOV_min, e_FOV_max, tree_[origin].yaw_,
                    0.0);  // assume pitch is zero at every node
 
       Histogram propagated_histogram = Histogram(2 * ALPHA_RES);

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -52,8 +52,8 @@
 #include <local_planner/LocalPlannerNodeConfig.h>
 
 class StarPlanner {
-  double H_FOV_ = 59.0;
-  double V_FOV_ = 46.0;
+  double h_FOV_ = 59.0;
+  double v_FOV_ = 46.0;
   int childs_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   double tree_node_distance_ = 1.0;
@@ -95,7 +95,7 @@ class StarPlanner {
   void setParams(const double& min_cloud_size, const double& min_dist_backoff,
                  const nav_msgs::GridCells& path_waypoints, const double& curr_yaw,
                  const double& min_realsense_dist);
-  void setFOV(double& H_FOV, double& V_FOV);
+  void setFOV(double& h_FOV, double& v_FOV);
   void setReprojectedPoints(const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
                             const std::vector<double>& reprojected_points_age,
                             const std::vector<double>& reprojected_points_dist);

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -52,6 +52,8 @@
 #include <local_planner/LocalPlannerNodeConfig.h>
 
 class StarPlanner {
+  double H_FOV_ = 59.0;
+  double V_FOV_ = 46.0;
   int childs_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   double tree_node_distance_ = 1.0;
@@ -93,7 +95,7 @@ class StarPlanner {
   void setParams(const double& min_cloud_size, const double& min_dist_backoff,
                  const nav_msgs::GridCells& path_waypoints, const double& curr_yaw,
                  const double& min_realsense_dist);
-
+  void setFOV(double& H_FOV, double& V_FOV);
   void setReprojectedPoints(const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
                             const std::vector<double>& reprojected_points_age,
                             const std::vector<double>& reprojected_points_dist);

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -79,6 +79,11 @@ void WaypointGenerator::calculateWaypoint() {
   last_velocity_ = Eigen::Vector2f(curr_vel_.twist.linear.x, curr_vel_.twist.linear.y);
 }
 
+void WaypointGenerator::setFOV(double& H_FOV, double& V_FOV){
+	H_FOV_ = H_FOV;
+	V_FOV_ = V_FOV;
+}
+
 void WaypointGenerator::updateState(geometry_msgs::PoseStamped act_pose,
                                     geometry_msgs::PoseStamped goal,
                                     geometry_msgs::TwistStamped vel, bool stay,
@@ -102,7 +107,7 @@ void WaypointGenerator::updateState(geometry_msgs::PoseStamped act_pose,
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   z_FOV_idx_.clear();
-  calculateFOV(z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
+  calculateFOV(H_FOV_, V_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
 
   double velocity_x_ = curr_vel_.twist.linear.x;
   double velocity_y_ = curr_vel_.twist.linear.y;

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -79,9 +79,9 @@ void WaypointGenerator::calculateWaypoint() {
   last_velocity_ = Eigen::Vector2f(curr_vel_.twist.linear.x, curr_vel_.twist.linear.y);
 }
 
-void WaypointGenerator::setFOV(double& H_FOV, double& V_FOV){
-	H_FOV_ = H_FOV;
-	V_FOV_ = V_FOV;
+void WaypointGenerator::setFOV(double& h_FOV, double& v_FOV){
+	h_FOV_ = h_FOV;
+	v_FOV_ = v_FOV;
 }
 
 void WaypointGenerator::updateState(geometry_msgs::PoseStamped act_pose,
@@ -107,7 +107,7 @@ void WaypointGenerator::updateState(geometry_msgs::PoseStamped act_pose,
   double roll, pitch, yaw;
   m.getRPY(roll, pitch, yaw);
   z_FOV_idx_.clear();
-  calculateFOV(H_FOV_, V_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
+  calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
 
   double velocity_x_ = curr_vel_.twist.linear.x;
   double velocity_y_ = curr_vel_.twist.linear.y;

--- a/local_planner/src/nodes/waypoint_generator.h
+++ b/local_planner/src/nodes/waypoint_generator.h
@@ -67,6 +67,8 @@ class WaypointGenerator {
   double new_yaw_;
   double speed_ = 1.0;
   int e_FOV_max_, e_FOV_min_;
+  double H_FOV_ = 59.0;
+  double V_FOV_ = 46.0;
 
   geometry_msgs::Point hover_position_;
   geometry_msgs::PoseStamped last_position_waypoint_;
@@ -91,6 +93,7 @@ class WaypointGenerator {
   waypointGenerator_params param_;
   void getWaypoints(waypointResult &output);
   void setPlannerInfo(avoidanceOutput input);
+  void setFOV(double& H_FOV, double& V_FOV);
   void updateState(geometry_msgs::PoseStamped act_pose,
                    geometry_msgs::PoseStamped goal,
                    geometry_msgs::TwistStamped vel, bool stay, ros::Time t);

--- a/local_planner/src/nodes/waypoint_generator.h
+++ b/local_planner/src/nodes/waypoint_generator.h
@@ -67,8 +67,8 @@ class WaypointGenerator {
   double new_yaw_;
   double speed_ = 1.0;
   int e_FOV_max_, e_FOV_min_;
-  double H_FOV_ = 59.0;
-  double V_FOV_ = 46.0;
+  double h_FOV_ = 59.0;
+  double v_FOV_ = 46.0;
 
   geometry_msgs::Point hover_position_;
   geometry_msgs::PoseStamped last_position_waypoint_;
@@ -93,7 +93,7 @@ class WaypointGenerator {
   waypointGenerator_params param_;
   void getWaypoints(waypointResult &output);
   void setPlannerInfo(avoidanceOutput input);
-  void setFOV(double& H_FOV, double& V_FOV);
+  void setFOV(double& h_FOV, double& v_FOV);
   void updateState(geometry_msgs::PoseStamped act_pose,
                    geometry_msgs::PoseStamped goal,
                    geometry_msgs::TwistStamped vel, bool stay, ros::Time t);


### PR DESCRIPTION
As all hardware setups as well as SITL models have different fields of view, it is important to not have that hardcoded anymore. Especially, if the obstacle distance is sent to fcu, data is discarded if the FOV is set too small