### PR TITLE
Add example & simple tests

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -203,7 +203,9 @@ target_link_libraries(path_handler_node
 catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
                                       test/test_example.cpp)
 if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
+                                             ${catkin_LIBRARIES}
+                                             ${YAML_CPP_LIBRARIES})
 endif()
 
 ## Add folders to be run by python nosetests

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -199,11 +199,12 @@ target_link_libraries(path_handler_node
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_avoidance.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
+# Add gtest based cpp test target and link libraries
+catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
+                                      test/test_example.cpp)
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+endif()
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/global_planner/test/main.cpp
+++ b/global_planner/test/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/global_planner/test/test_example.cpp
+++ b/global_planner/test/test_example.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <string>
+using std::string;
+
+class StringTest : public ::testing::Test {
+ public:
+  string actualString;
+  string wrongString;
+  string expectString;
+
+  char *actualValTrue;
+  char *actualValFalse;
+  char *expectVal;
+
+  // Use this method to set up any state that you need for all of your tests
+  void SetUp() override {
+    actualString = "hello gtest";
+    wrongString = "hello world";
+    expectString = "hello gtest";
+
+    actualValTrue = new char[actualString.size() + 1];
+    strncpy(actualValTrue, actualString.c_str(), actualString.size() + 1);
+
+    actualValFalse = new char[wrongString.size() + 1];
+    strncpy(actualValFalse, wrongString.c_str(), wrongString.size() + 1);
+
+    expectVal = new char[expectString.size() + 1];
+    strncpy(expectVal, expectString.c_str(), expectString.size() + 1);
+  }
+
+  // Use this method to clean up any memory, network etc. after each test
+  void TearDown() override {
+    delete[] actualValTrue;
+    delete[] actualValFalse;
+    delete[] expectVal;
+  }
+};
+
+// Example code we are testing:
+namespace myNormalCode {
+
+void reverseInPlace(string &toReverse) {
+  // NB! this only works for ASCII
+  for (int i = 0, j = toReverse.size() - 1; i < j; i++, j--) {
+    char tmp = toReverse[i];
+    toReverse[i] = toReverse[j];
+    toReverse[j] = tmp;
+  }
+}
+}
+
+TEST_F(StringTest, StrEqual) {
+  // GIVEN: two strings that are the same
+
+  // THEN: we expect them to be equal
+  EXPECT_STREQ(actualString.c_str(), expectString.c_str());
+}
+
+TEST_F(StringTest, CStrNotEqual) {
+  // GIVEN: two char* that are NOT the same
+
+  // THEN: we expect them to be not equal
+  EXPECT_STRNE(expectVal, actualValFalse);
+}
+
+TEST_F(StringTest, testReverse) {
+  // GIVEN: a string, and a manually reversed string as well
+  string toReverse = actualString;
+  const string expectedReversed = "tsetg olleh";
+
+  // WHEN: we reverse the string
+  myNormalCode::reverseInPlace(toReverse);
+
+  // THEN: they should be the same
+  EXPECT_STREQ(expectedReversed.c_str(), toReverse.c_str());
+}

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -195,9 +195,12 @@ target_link_libraries(local_planner_node
 
 # Add gtest based cpp test target and link libraries
 catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
-                                      test/test_example.cpp)
+                                      test/test_example.cpp
+                                      test/test_common.cpp)
 if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
+                                             ${catkin_LIBRARIES}
+                                             ${YAML_CPP_LIBRARIES})
 endif()
 
 ## Add folders to be run by python nosetests

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -193,11 +193,12 @@ target_link_libraries(local_planner_node
 ## Testing ##
 #############
 
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_avoidance.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
+# Add gtest based cpp test target and link libraries
+catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
+                                      test/test_example.cpp)
+if(TARGET ${PROJECT_NAME}-test)
+  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+endif()
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -1,5 +1,13 @@
 #include "common.h"
 
+#include <math.h>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+#include <tf/transform_listener.h>
+
 float distance2DPolar(int e1, int z1, int e2, int z2) {
   return sqrt(pow((e1 - e2), 2) + pow((z1 - z2), 2));
 }

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -1,18 +1,9 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <math.h>
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <vector>
-
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Twist.h>
 #include <geometry_msgs/Vector3Stamped.h>
-
-#include <tf/transform_listener.h>
 
 #include <pcl/point_cloud.h>
 #include <pcl_conversions/pcl_conversions.h>

--- a/local_planner/test/main.cpp
+++ b/local_planner/test/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include "../src/nodes/common.h"
+
+TEST(Common, polar2DdistanceSameIsZero){
+    // GIVEN: two identical points
+    const int e = 5, z = 9;
+    
+    // WHEN: we get the distance between the same points
+    float dist = distance2DPolar(e, z, e, z);
+    
+    // THEN: the distance should be zero
+    EXPECT_FLOAT_EQ(0.f, dist);
+}
+
+
+TEST(Common, polar2DdistanceOnKnownPoints){
+    // GIVEN: two points
+    const int e1 = 5, z1 = 9;
+    const int e2 = 50, z2 = 39;
+    
+    // WHEN: we get the distance between the same points
+    float dist = distance2DPolar(e1, z1, e2, z2);
+    
+    // THEN: the distance should be...
+    EXPECT_FLOAT_EQ(54.083271f, dist);
+}

--- a/local_planner/test/test_example.cpp
+++ b/local_planner/test/test_example.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <string>
+using std::string;
+
+class StringTest : public ::testing::Test {
+ public:
+  string actualString;
+  string wrongString;
+  string expectString;
+
+  char *actualValTrue;
+  char *actualValFalse;
+  char *expectVal;
+
+  // Use this method to set up any state that you need for all of your tests
+  void SetUp() override {
+    actualString = "hello gtest";
+    wrongString = "hello world";
+    expectString = "hello gtest";
+
+    actualValTrue = new char[actualString.size() + 1];
+    strncpy(actualValTrue, actualString.c_str(), actualString.size() + 1);
+
+    actualValFalse = new char[wrongString.size() + 1];
+    strncpy(actualValFalse, wrongString.c_str(), wrongString.size() + 1);
+
+    expectVal = new char[expectString.size() + 1];
+    strncpy(expectVal, expectString.c_str(), expectString.size() + 1);
+  }
+
+  // Use this method to clean up any memory, network etc. after each test
+  void TearDown() override {
+    delete[] actualValTrue;
+    delete[] actualValFalse;
+    delete[] expectVal;
+  }
+};
+
+// Example code we are testing:
+namespace myNormalCode {
+
+void reverseInPlace(string &toReverse) {
+  // NB! this only works for ASCII
+  for (int i = 0, j = toReverse.size() - 1; i < j; i++, j--) {
+    char tmp = toReverse[i];
+    toReverse[i] = toReverse[j];
+    toReverse[j] = tmp;
+  }
+}
+}
+
+TEST_F(StringTest, StrEqual) {
+  // GIVEN: two strings that are the same
+
+  // THEN: we expect them to be equal
+  EXPECT_STREQ(actualString.c_str(), expectString.c_str());
+}
+
+TEST_F(StringTest, CStrNotEqual) {
+  // GIVEN: two char* that are NOT the same
+
+  // THEN: we expect them to be not equal
+  EXPECT_STRNE(expectVal, actualValFalse);
+}
+
+TEST_F(StringTest, testReverse) {
+  // GIVEN: a string, and a manually reversed string as well
+  string toReverse = actualString;
+  const string expectedReversed = "tsetg olleh";
+
+  // WHEN: we reverse the string
+  myNormalCode::reverseInPlace(toReverse);
+
+  // THEN: they should be the same
+  EXPECT_STREQ(expectedReversed.c_str(), toReverse.c_str());
+}


### PR DESCRIPTION
This uses the ROS builtin bindings to googletest to add some very basic tests. There are example tests (just doing string manipulation) in both the global_planner and local_planner, and a simple test of a function in the library in the local_planner.

Tests can be run with `catkin_make run_tests`, or by adding the `run_tests` Make target in your IDE. New test/*.cpp files should be added to the CMakeLists to make sure they are run.

In future these should be run before opening a PR and before merging. Also, any new features should have at least tests added from a high level, and bug fixes should demonstrate with a test to make sure they actually fix the issue.

More tests, and possibly even some CI infrastructure, to come in future PRs.