### PR TITLE
readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD
 apt-get update
 ```
 
-2. Install gazebo with ROS (many dependencies including gazebo7 will come with those two packages).
+2. Install gazebo with ROS.
 
 ```bash
-apt install ros-kinetic-gazebo-ros-control ros-kinetic-gazebo-ros-pkgs
+apt install ros-kinetic-desktop-full
 
 # Source ROS
 source /opt/ros/kinetic/setup.bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The active developers of the avoidance repo are syncing up on a bi-weekly basis 
     - [Global Planner](#global-planner)
 - [Troubleshooting](#troubleshooting)
 - [Advanced](#advanced)
-  - [Interaction with PX4 Autopilot](#interaction-with-px4-autopilot)
+  - [Message Flows](#message-flow)
+    - [PX4 and local planner](#px4-and-local-planner)
+    - [PX4 and global planner](#px4-and-gloabl-planner)
 - [Contributing](#contributing)
 
 # Getting Started
@@ -340,10 +342,11 @@ roslaunch global_planner global_planner_offboard.launch point_cloud_topic:=<poin
 
 Read the [Running on Odroid](https://github.com/PX4/avoidance/tree/master/global_planner/resource/odroid) instructions.
 
+# Advanced
 
-# Message Flows
+## Message Flows
 
-## PX4 and local planner
+### PX4 and local planner
 
 This is the complete message flow *from* PX4 Firmware to the local planner.
 
@@ -367,7 +370,7 @@ ROS topic | ROS Msgs. | MAVROS Plugin | MAVLink | PX4 Topic
 /mavros/obstacle/send | sensor_msgs::LaserScan | obstacle_distance | OBSTACLE_DISTANCE | obstacle_distance
 /mavros/set_mode | mavros_msgs::SetMode | sys_status | SET_MODE | vehicle_command
 
-## PX4 and global planner
+### PX4 and global planner
 
 This is the complete message flow *from* PX4 Firmware *to* the global planner.
 
@@ -381,3 +384,5 @@ This is the complete message flow *to* PX4 Firmware *from* the global planner.
 ROS topic | ROS Msgs. | MAVROS Plugin | MAVLink | PX4 Topic 
 --- | --- | --- | --- | ---
 /mavros/setpoint_position/local (offboard) | geometry_msgs::PoseStamped | setpoint_position | SET_POSITION_LOCAL_POSITION_NED | position_setpoint_triplet
+
+# Contributing

--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ roslaunch local_planner local_planner_stereo.launch
 * simulate a forward looking kinect depth sensor:
 
 ```bash
-roslaunch local_planner local_planner_depth-camera.lauch
+roslaunch local_planner local_planner_depth-camera.launch
 ```
 
 * simulate a three kinect depth sensors:
 
 ```bash
-roslaunch local_planner local_planner_sitl_3cam.lauch
+roslaunch local_planner local_planner_sitl_3cam.launch
 ```
 
 You will see the Iris drone unarmed in the Gazebo world. To start flying, there are two options: OFFBOARD or MISSION mode. For OFFBOAD, run:

--- a/README.md
+++ b/README.md
@@ -10,13 +10,34 @@ PX4 computer vision algorithms packaged as ROS nodes for depth sensor fusion and
 The active developers of the avoidance repo are syncing up on a bi-weekly basis on the WG dev call.
 
 * Join the call: https://zoom.us/j/506512712
-* Time: Monday, 9PM CET
+* Time: Monday, 5PM CET
 * Meeting ID: 506512712
 * Dronecode calendar: https://www.dronecode.org/calendar/
 
 [![PX4 Avoidance video](http://img.youtube.com/vi/VqZkAWSl_U0/0.jpg)](https://www.youtube.com/watch?v=VqZkAWSl_U0)
 
-# Quick Start with Docker
+# Table of Contents
+- [Getting Started](#getting-started)
+  - [Installation](#installation)
+    - [Quick Start with Docker](#quick-start-with-docker)
+    - [Installation for Ubuntu 16.04 and ROS Kinetic](#installation-for-ubuntu-16.04-and-ros-kinetic)
+  - [Run the Simulation](#run-the-simulation)
+    - [Local Planner](#local-planner)
+    - [Global Planner](#global-planner)
+  - [Run on Hardware](#run-on-hardware)
+    - [Prerequisite](#prerequisite)
+    - [Local Planner](#local-planner)
+    - [Global Planner](#global-planner)
+- [Troubleshooting](#troubleshooting)
+- [Advanced](#advanced)
+  - [Interaction with PX4 Autopilot](#interaction-with-px4-autopilot)
+- [Contributing](#contributing)
+
+# Getting Started
+
+## Installation
+
+### Quick Start with Docker
 
 A ROS container based on Ubuntu 16.04 has been created and can be used to quickly try the simulation, as a demo. Running it is as simple as installing docker and docker-compose, and running `$ docker-compose up` from the right folder. Find the corresponding instructions [here](docker/demo).
 
@@ -24,9 +45,7 @@ For __deployment__ instructions, check "[Deploying with Docker](docker#deploying
 
 If you want to leverage docker in your __development__ environment, check the "[Developing with Docker](docker#developing-with-docker)" section.
 
-# Prerequisites
-
-## Installation for Ubuntu 16.04 and ROS Kinetic
+### Installation for Ubuntu 16.04 and ROS Kinetic
 
 This is a step-by-step guide to install and build all the prerequisites for running this module on Ubuntu 16.04. You might want to skip some of them if your system is already partially installed. A corresponding docker container is defined [here](docker/ubuntu/Dockerfile) as reference.
 
@@ -96,6 +115,8 @@ Note that you can build the node in release mode this way:
 catkin build -w ~/catkin_ws --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
+## Run the Simulation
+
 9. Clone the PX4 Firmware and all its submodules (it may take some time).
 
 ```bash
@@ -135,31 +156,7 @@ export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:~/Firmware
 
 You should now be ready to run the simulation.
 
-## Installation for Ubuntu 14.04 and ROS Indigo
-
-A full step-by-step guide is not available for this configuration. You might find the [instructions for Ubuntu 16.04 and ROS Kinetic](#installation-for-ubuntu-1604-and-ros-kinetic) useful, though. Another source of information is also the [PX4 dev guide](http://dev.px4.io).
-
-Notable differences with ROS Kinetic are:
-
-* Installing the pointcloud library requires another package from another repository:
-
-```bash
-# Install PCL
-sudo add-apt-repository ppa:v-launchpad-jochen-sprickerhof-de/pcl
-sudo apt-get update
-sudo apt-get install libpcl-all
-```
-
-* Octomap has different packages for Indigo:
-
-```bash
-# Install the Octomap Library
-sudo apt-get install ros-indigo-octomap ros-indigo-octomap-mapping
-```
-
-# Running the Planner in Simulation
-
-## Simulating a depth camera
+### Global Planner
 
 1. Make sure that you have sources the catkin setup.bash from your catkin workspace.
 
@@ -226,7 +223,7 @@ rosrun topic_tools transform /stereo/disparity /stereo/disparity_image sensor_ms
 
 Now the disparity map can be visualized by rviz or rqt under the topic */stereo/disparity_image*.
 
-## Running the Local Planner
+### Local Planner
 
 The local planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm simulating stereo vision
 
@@ -242,7 +239,7 @@ Another option is to simulate a kinect depth sensor:
 roslaunch local_planner local_planner_depth-camera.lauch
 ```
 
-You will see the Iris drone unarmed in the Gazebo world. To start flying, put the drone in OFFBOARD mode and arm it. The avoidance node will then take control of it.
+You will see the Iris drone unarmed in the Gazebo world. To start flying, there are two options: OFFBOARD or MISSION mode. For OFFBOAD, run:
 
 ```bash
 # In another terminal
@@ -255,18 +252,10 @@ The drone will first change its altitude to reach the goal height. It is possibl
 Then the drone will start moving towards the goal. The default x, y goal position can be changed in Rviz by clicking on the 2D Nav Goal button and then chosing the new goal x and y position by clicking on the visualized gray space. If the goal has been set correctly, a yellow sphere will appear where you have clicked in the grey world.
 ![Screenshot rviz goal selection](docs/lp_goal_rviz.png)
 
-### How to recover the logs
+For MISSIONS, open [QGroundControl]() and plan a mission as described [here](). Set the parameter `MPC_OBS_AVOID` true. Start the mission and the vehicle will fly the mission waypoints dynamically recomputing the path such that it is collision free.
 
-It is possible to log the point cloud, the polar histogram, the waypoints and the drone position when simulating the local planner. In order to (dis)enable logging, you need to set the following arguments to `false`/`true` in the `local_planner_depth-camera.launch` launch file:
-```bash
-<arg name="record_point_cloud" default="true" />
-<arg name="record_histogram"   default="true" />
-<arg name="record_waypoints"   default="true" />
-<arg name="record_position"    default="true" />
-```
-You can retrieve the logs in the `~/.ros/` folder of you computer.
 
-## Troubleshooting
+# Troubleshooting
 
 ### I see the drone position in rviz (shown as a red arrow), but the world around is empty
 Check that some camera topics (including */camera/depth/points*) are published with the following command:

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ PX4 computer vision algorithms packaged as ROS nodes for depth sensor fusion and
 
 The two algorithms are standalone and they are not meant to be used together.
 
-The *local_planner* requires less computational power but it doesn't compute optimal paths towards the goal since it doesn't store information about the expolred environment. On the other hand, the *global_planner* buils a map of the envirnment leading to optima
+The *local_planner* requires less computational power but it doesn't compute optimal paths towards the goal since it doesn't store information about the already explored environment. On the other hand, the *global_planner* is computatonally more expensive since it builds a map of the environment. For the map to be good enough for navigation, accurate global position and heading are required. 
+
+> **Note** The development team is right now focused on the *local_planner*.
   
 The documentation contains information about how to setup and run the two planner systems on the Gazebo simulator and on a companion computer running Ubuntu 16.04, for both avoidance and collision prevention use cases.
 
 > **Note** PX4-side setup is covered in the PX4 User Guide:
-  - [Ostacle Avoidance](https://docs.px4.io/en/computer_vision/obstacle_avoidance.html)
+  - [Obstacle Avoidance](https://docs.px4.io/en/computer_vision/obstacle_avoidance.html)
   - [Collision Prevention](https://docs.px4.io/en/computer_vision/collision_prevention.html)
 
 ## Bi-weekly Dev Call
@@ -179,7 +181,7 @@ You should now be ready to run the simulation using local or global planner.
 
 ### Global Planner
 
-To run the simulation.
+This section shows how to start the *global_planner* and use it for avoidance in offboard mode.
 
 ```bash
 roslaunch global_planner global_planner_sitl_mavros.launch
@@ -216,7 +218,9 @@ One can plan a new path by setting a new goal with the *2D Nav Goal* button in r
 
 ### Local Planner
 
-The local planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
+This section shows how to start the *local_planner* and use it for avoidance in mission or offboard mode.
+
+The planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
 
 * simulate a forward looking stereo camera running OpenCV's block matching algorithm
 
@@ -263,7 +267,7 @@ rosrun mavros mavsafety arm
 
 The drone will first change its altitude to reach the goal height. It is possible to modify the goal altitude with `rqt_reconfigure` GUI.
 ![Screenshot rqt_reconfigure goal height](docs/lp_goal_height.png)
-Then the drone will start moving towards the goal. The default x, y goal position can be changed in Rviz by clicking on the 2D Nav Goal button and then chosing the new goal x and y position by clicking on the visualized gray space. If the goal has been set correctly, a yellow sphere will appear where you have clicked in the grey world.
+Then the drone will start moving towards the goal. The default x, y goal position can be changed in Rviz by clicking on the 2D Nav Goal button and then choosing the new goal x and y position by clicking on the visualized gray space. If the goal has been set correctly, a yellow sphere will appear where you have clicked in the grey world.
 ![Screenshot rviz goal selection](docs/lp_goal_rviz.png)
 
 For MISSIONS, open [QGroundControl](http://qgroundcontrol.com/) and plan a mission as described [here](https://docs.px4.io/en/flight_modes/mission.html). Set the parameter `MPC_OBS_AVOID` true. Start the mission and the vehicle will fly the mission waypoints dynamically recomputing the path such that it is collision free.
@@ -309,7 +313,7 @@ Parameters to set through QGC:
 * ROS Kinetic: see [Installation](#installaton)
 * Other Required Components for Intel Realsense:
   - Librealsense (Realsense SDK). The installation instructions can be found [here](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md)
-  - [Librealsense ROS wrappers)](https://github.com/intel-ros/realsense.git)
+  - [Librealsense ROS wrappers](https://github.com/intel-ros/realsense.git)
 
 Tested models:
 - local planner: Intel NUC, Jetson TX2, Intel Atom x7-Z8750 (built-in on Intel Aero RTF drone)
@@ -317,7 +321,7 @@ Tested models:
 
 ## Global Planner
 
-The global planner has been so far tested on a Odroid by the development team. 
+The global planner has been so far tested on a Odroid companion computer by the development team. 
 
 For more information, read the [Running on Odroid](https://github.com/PX4/avoidance/tree/master/global_planner/resource/odroid) instructions.
 
@@ -325,7 +329,7 @@ For more information, read the [Running on Odroid](https://github.com/PX4/avoida
 
 Once the catkin workspace has been built, to run the planner with a Realsense D435 camera launch *local_planner_example.launch* editing the arguments:
 
-1. `tf_*` representing the dispacement between the camera and the flight controller
+1. `tf_*` representing the displacement between the camera and the flight controller
 2. `fcu_url` representing the port connecting the companion computer to the flight controller
 3. `serial_no_camera_front` representing the Realsense serial number
 

--- a/README.md
+++ b/README.md
@@ -59,80 +59,78 @@ Note that in the following instructions, we assume your catkin workspace (in whi
 
 1. Add ROS to sources.list.
 
-```bash
-echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
-apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
-apt-get update
-```
+   ```bash
+   echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
+   apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+   apt-get update
+   ```
 
-2. Install gazebo with ROS.
+1. Install gazebo with ROS.
 
-```bash
-apt install ros-kinetic-desktop-full
+   ```bash
+   apt install ros-kinetic-desktop-full
+   
+   # Source ROS
+   source /opt/ros/kinetic/setup.bash
+   ```
 
-# Source ROS
-source /opt/ros/kinetic/setup.bash
-```
+1. Initialize rosdep.
 
-3. Initialize rosdep.
+   ```bash
+   rosdep init
+   rosdep update
+   ```
 
-```bash
-rosdep init
-rosdep update
-```
+1. Install catkin and create your catkin workspace directory.
 
-4. Install catkin and create your catkin workspace directory.
+   ```bash
+   apt install python-catkin-tools
+   mkdir -p ~/catkin_ws/src
+   ```
 
-```bash
-apt install python-catkin-tools
-mkdir -p ~/catkin_ws/src
-```
+1. Install mavros. The package coming from the ROS repository should be fine. Just in case, instructions to install it from sources can be found here: https://dev.px4.io/en/ros/mavros_installation.html.
 
-5. Install mavros. The package coming from the ROS repository should be fine. Just in case, instructions to install it from sources can be found here: https://dev.px4.io/en/ros/mavros_installation.html.
+   ```bash
+   apt install ros-kinetic-mavros ros-kinetic-mavros-extras
+   ```
 
-```bash
-apt install ros-kinetic-mavros ros-kinetic-mavros-extras
-```
+1. Install the geographiclib dataset
 
-6. Install the geographiclib dataset
+   ```bash
+   wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh
+   sudo ./install_geographiclib_datasets.sh
+   ```
 
-```bash
-wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh
-sudo ./install_geographiclib_datasets.sh
-```
+1. Install avoidance module dependencies (pointcloud library and octomap).
 
-7. Install avoidance module dependencies (pointcloud library and octomap).
+   ```bash
+   apt install libpcl1 ros-kinetic-octomap-* ros-kinetic-yaml-*
+   ```
 
-```bash
-apt install libpcl1 ros-kinetic-octomap-* ros-kinetic-yaml-*
-```
+1. Clone this repository in your catkin workspace in order to build the avoidance node.
 
-8. Clone this repository in your catkin workspace in order to build the avoidance node.
+   ```bash
+   cd ~/catkin_ws/src
+   git clone https://github.com/PX4/avoidance.git
+   ```
 
-```bash
-cd ~/catkin_ws/src
-git clone https://github.com/PX4/avoidance.git
-```
+1. Actually build the avoidance node.
 
-9. Actually build the avoidance node.
+   ```bash
+   catkin build -w ~/catkin_ws
+   ```
+   
+   Note that you can build the node in release mode this way:
+   
+   ```bash
+   catkin build -w ~/catkin_ws --cmake-args -DCMAKE_BUILD_TYPE=Release
+   ```
 
-```bash
-catkin build -w ~/catkin_ws
-```
+1. Source the catkin setup.bash from your catkin workspace.
 
-If it fails, try to build again. It seems like it sometimes fails in an undeterministic way.
-
-Note that you can build the node in release mode this way:
-
-```bash
-catkin build -w ~/catkin_ws --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
-
-10. Source the catkin setup.bash from your catkin workspace.
-
-```bash
-source ~/catkin_ws/devel/setup.bash
-```
+   ```bash
+   source ~/catkin_ws/devel/setup.bash
+   ```
 
 ## Run the Avoidance Gazebo Simulation
 
@@ -142,36 +140,36 @@ In the following section we guide you trough installing and running a Gazebo sim
 
 1. Clone the PX4 Firmware and all its submodules (it may take some time).
 
-```bash
-cd ~
-git clone https://github.com/PX4/Firmware.git
-cd ~/Firmware
-git submodule update --init --recursive
-```
+   ```bash
+   cd ~
+   git clone https://github.com/PX4/Firmware.git
+   cd ~/Firmware
+   git submodule update --init --recursive
+   ```
 
-2. Install PX4 dependencies. A complete list is available on the [PX4 Dev Guide](http://dev.px4.io/en/setup/dev_env_linux_ubuntu.html#common-dependencies).
+1. Install PX4 dependencies. A complete list is available on the [PX4 Dev Guide](http://dev.px4.io/en/setup/dev_env_linux_ubuntu.html#common-dependencies).
 
-3. We will now build the Firmware once in order to generate SDF model files for Gazebo. This step will actually run a simulation that you can directly quit.
+1. We will now build the Firmware once in order to generate SDF model files for Gazebo. This step will actually run a simulation that you can directly quit.
 
-```bash
-# Add the models from the avoidance module to GAZEBO_MODEL_PATH
-export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/sim/models
+   ```bash
+   # Add the models from the avoidance module to GAZEBO_MODEL_PATH
+   export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/sim/models
+   
+   # This is necessary to prevent some Qt-related errors (feel free to try to omit it)
+   export QT_X11_NO_MITSHM=1
+   
+   # Setup some more Gazebo-related environment variables
+   . ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/px4_sitl_default
+   
+   # Build and run simulation
+   make px4_sitl_default gazebo
+   ```
 
-# This is necessary to prevent some Qt-related errors (feel free to try to omit it)
-export QT_X11_NO_MITSHM=1
+1. Add the Firmware directory to ROS_PACKAGE_PATH so that ROS can start PX4.
 
-# Setup some more Gazebo-related environment variables
-. ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/px4_sitl_default
-
-# Build and run simulation
-make px4_sitl_default gazebo
-```
-
-4. Add the Firmware directory to ROS_PACKAGE_PATH so that ROS can start PX4.
-
-```bash
-export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:~/Firmware
-```
+   ```bash
+   export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:~/Firmware
+   ```
 
 You should now be ready to run the simulation using local or global planner.
 
@@ -216,40 +214,40 @@ One can plan a new path by setting a new goal with the *2D Nav Goal* button in r
 
 The local planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
 
-*   simulate a forward looking stereo camera running OpenCV's block matching algorithm
+* simulate a forward looking stereo camera running OpenCV's block matching algorithm
 
-```bash
-# if stereo-image-proc not yet installed
-sudo apt-get install ros-kinetic-stereo-image-proc
+   ```bash
+   # if stereo-image-proc not yet installed
+   sudo apt-get install ros-kinetic-stereo-image-proc
+   
+   roslaunch local_planner local_planner_stereo.launch
+   ```
 
-roslaunch local_planner local_planner_stereo.launch
-```
+   The disparity map from `stereo-image-proc` is published as a [stereo_msgs/DisparityImage](http://docs.ros.org/api/stereo_msgs/html/msg/DisparityImage.html) message, which is not supported by rviz or rqt. To visualize the    message, either run:
 
-The disparity map from `stereo-image-proc` is published as a [stereo_msgs/DisparityImage](http://docs.ros.org/api/stereo_msgs/html/msg/DisparityImage.html) message, which is not supported by rviz or rqt. To visualize the message, either run:
+   ```bash
+   rosrun image_view stereo_view stereo:=/stereo image:=image_rect_color
+   ```
 
-```bash
-rosrun image_view stereo_view stereo:=/stereo image:=image_rect_color
-```
+   or publish the DisparityImage as a simple sensor_msgs/Image
 
-or publish the DisparityImage as a simple sensor_msgs/Image
+   ```bash
+   rosrun topic_tools transform /stereo/disparity /stereo/disparity_image sensor_msgs/Image 'm.image'
+   ```
 
-```bash
-rosrun topic_tools transform /stereo/disparity /stereo/disparity_image sensor_msgs/Image 'm.image'
-```
-
-Now the disparity map can be visualized by rviz or rqt under the topic */stereo/disparity_image*.
+   Now the disparity map can be visualized by rviz or rqt under the topic */stereo/disparity_image*.
 
 * simulate a forward looking kinect depth sensor:
 
-```bash
-roslaunch local_planner local_planner_depth-camera.launch
-```
+   ```bash
+   roslaunch local_planner local_planner_depth-camera.launch
+   ```
 
 * simulate a three kinect depth sensors:
 
-```bash
-roslaunch local_planner local_planner_sitl_3cam.launch
-```
+   ```bash
+   roslaunch local_planner local_planner_sitl_3cam.launch
+   ```
 
 You will see the Iris drone unarmed in the Gazebo world. To start flying, there are two options: OFFBOARD or MISSION mode. For OFFBOAD, run:
 

--- a/README.md
+++ b/README.md
@@ -212,15 +212,18 @@ The graph of the ROS nodes is shown below:
 One can plan a new path by setting a new goal with the *2D Nav Goal* button in rviz. The planned path should show up in rviz and the drone should follow the path, updating it when obstacles are detected. It is also possible to set a goal without using the obstacle avoidance (i.e. the drone will go straight to this goal and potentially collide with obstacles). To do so, set the position with the *2D Pose Estimate* button in rviz.
 
 
-#### Simulating stereo-vision
-To simulate obstacle avoidance with stereo-cameras, the package `stereo-image-proc` must be installed.
+### Local Planner
+
+The local planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
+
+*   simulate a forward looking stereo camera running OpenCV's block matching algorithm
 
 ```bash
-# Launch simulation
-roslaunch global_planner global_planner_stereo.launch
-```
+# if stereo-image-proc not yet installed
+sudo apt-get install ros-kinetic-stereo-image-proc
 
-Simulated stereo-vision is prone to errors due to artificial texture, which may make obstacles appear extremely close to the camera. For better results, choose a more natural [world](https://github.com/PX4/avoidance/blob/master/sim/worlds/simple_obstacle.world).
+roslaunch local_planner local_planner_stereo.launch
+```
 
 The disparity map from `stereo-image-proc` is published as a [stereo_msgs/DisparityImage](http://docs.ros.org/api/stereo_msgs/html/msg/DisparityImage.html) message, which is not supported by rviz or rqt. To visualize the message, either run:
 
@@ -236,18 +239,6 @@ rosrun topic_tools transform /stereo/disparity /stereo/disparity_image sensor_ms
 
 Now the disparity map can be visualized by rviz or rqt under the topic */stereo/disparity_image*.
 
-### Local Planner
-
-The local planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
-
-* simulate a forward looking stereo camera running OpenCV's block matching algorithm
-
-```bash
-# if stereo-image-proc not yet installed
-sudo apt-get install ros-kinetic-stereo-image-proc
-
-roslaunch local_planner local_planner_stereo.launch
-```
 * simulate a forward looking kinect depth sensor:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Obstacle Detection and Avoidance
-PX4 computer vision algorithms packaged as ROS nodes for depth sensor fusion and obstacle avoidance. This repository contains two different implementations, targeting different use cases:
+PX4 computer vision algorithms packaged as ROS nodes for depth sensor fusion and obstacle avoidance. This repository contains two different implementations:
 
-  * A local, VFH+ based planner that plans (including some history) in a vector field histogram
-  * A global, graph based planner that plans in a traditional occupancy grid
+  * *local_planner* is a local VFH+* based planner that plans (including some history) in a vector field histogram
+  * *global_planner* is a global, graph based planner that plans in a traditional octomap occupancy grid
+
+The two algorithms are standalone and they are not meant to be used together.
+
+The *local_planner* requires less computational power but it doesn't compute optimal paths towards the goal since it doesn't store information about the expolred environment. On the other hand, the *global_planner* buils a map of the envirnment leading to optima
   
 The documentation contains information about how to setup and run the two planner systems on the Gazebo simulator and on a companion computer running Ubuntu 16.04, for both avoidance and collision prevention use cases.
 
@@ -341,7 +345,7 @@ is displayed on the console.
 The local planner supports also multi camera setups. `local_planner_example.launch` needs to be modified by:
 
 1. launching one RealSense nodlet (`rs_depthcloud.launch`) for each camera making sure that each of them has a unique `namespace`
-2. launch one `static_transform_publsher` node for each camera
+2. launch one `static_transform_publisher` node for each camera
 
 An example of a three camera launch file is [local_planner_A700_3cam.launch](https://github.com/PX4/avoidance/blob/master/local_planner/launch/local_planner_A700_3cam.launch).
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ A stream of point-clouds should now be published to */point_cloud*.
 
 ### PX4 Autopilot
 
-Parameters to set trough QGC:
+Parameters to set through QGC:
 * MPC_OBS_AVOID to 1
 * SYS_COMPANION to 57600 or
 
@@ -324,7 +324,7 @@ For more information, read the [Running on Odroid](https://github.com/PX4/avoida
 
 ## Local Planner
 
-Once the catkin workspace has been buit, to run the planner with a Realsense D435 camera launch local_planner_example.launch editing the arguments:
+Once the catkin workspace has been built, to run the planner with a Realsense D435 camera launch local_planner_example.launch editing the arguments:
 
 1. `tf_*` representing the dispacement between the camera and the flight controller
 2. `fcu_url` representing the port connecting the companion computer to the flight controller

--- a/README.md
+++ b/README.md
@@ -285,28 +285,7 @@ Pro Tip: Be careful when attaching the camera with a USB3 cable. USB3 might migh
 
 Orther tested camera models are: Intel Realsense D415 and R200.
 
-### PX4 Autopilot
-
-Parameters to set trough QGC:
-* MPC_OBS_AVOID to 1
-* SYS_COMPANION to 57600 or
-
-### Companion Computer
-
-* OS: Ubuntu 16.04 OS or a docker container running Ubuntu 16.04 must be setup (e.g. if using on a Yocto based system). 
-* ROS Kinetic: see [Installation](installaton)
-* Other Required Components for Intel Realsense:
-  - Librealsense (Realsense SDK). The installation instructions can be found [here](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md)
-  - [Librealsense ROS wrappers)](https://github.com/intel-ros/realsense.git)
-
-Tested models for the local planner Intel NUC, Jetson TX2, Intel Atom x7-Z8750 (built-in on Intel Aero RTF drone), for the global planner Odroid.
-
-## Global Planner
-
-The global planner uses the octomap_servers to get probabilistic information about the evironment.
-The octomap_server needs a stream of point-clouds to generate the accumulated data.
-
-### Generating Point-clouds from Depth-maps
+#### Generating Point-clouds from Depth-maps
 
 In case the point-cloud stream already exists, this step can be skipped.
 
@@ -321,33 +300,31 @@ rosrun disparity_to_point_cloud disparity_to_point_cloud_node \
 
 A stream of point-clouds should now be published to */point_cloud*.
 
-### Running the planner
+### PX4 Autopilot
 
-The planner can be built with:
+Parameters to set trough QGC:
+* MPC_OBS_AVOID to 1
+* SYS_COMPANION to 57600 or
 
-```bash
-catkin build
-```
+### Companion Computer
 
-Note that you can build it in release mode by adding `--cmake-args -DCMAKE_BUILD_TYPE=Release` as an argument to catkin:
+* OS: Ubuntu 16.04 OS or a docker container running Ubuntu 16.04 must be setup (e.g. if using on a Yocto based system). 
+* ROS Kinetic: see [Installation](#installaton)
+* Other Required Components for Intel Realsense:
+  - Librealsense (Realsense SDK). The installation instructions can be found [here](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md)
+  - [Librealsense ROS wrappers)](https://github.com/intel-ros/realsense.git)
 
-```bash
-catkin build --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
+Tested models for the local planner Intel NUC, Jetson TX2, Intel Atom x7-Z8750 (built-in on Intel Aero RTF drone), for the global planner Odroid.
 
-And then just run with the corresponding launch file:
+## Global Planner
 
-```bash
-roslaunch global_planner global_planner_offboard.launch point_cloud_topic:=<point_cloud_topic>
-```
+The global planner has been so far tested on a Odroid by the development team. 
 
-### Running on Odroid
-
-Read the [Running on Odroid](https://github.com/PX4/avoidance/tree/master/global_planner/resource/odroid) instructions.
+For more information, read the [Running on Odroid](https://github.com/PX4/avoidance/tree/master/global_planner/resource/odroid) instructions.
 
 ## Local Planner
 
-To run the planner with a Realsense D435 camera launch local_planner_example.launch editing the arguments:
+Once the catkin workspace has been buit, to run the planner with a Realsense D435 camera launch local_planner_example.launch editing the arguments:
 
 1. `tf_*` representing the dispacement between the camera and the flight controller
 2. `fcu_url` representing the port connecting the companion computer to the flight controller
@@ -456,3 +433,4 @@ ROS topic | ROS Msgs. | MAVROS Plugin | MAVLink | PX4 Topic
 /mavros/setpoint_position/local (offboard) | geometry_msgs::PoseStamped | setpoint_position | SET_POSITION_LOCAL_POSITION_NED | position_setpoint_triplet
 
 # Contributing
+

--- a/README.md
+++ b/README.md
@@ -90,20 +90,27 @@ mkdir -p ~/catkin_ws/src
 apt install ros-kinetic-mavros ros-kinetic-mavros-extras
 ```
 
-6. Install avoidance module dependencies (pointcloud library and octomap).
+6. Install the geographiclib dataset
 
 ```bash
-apt install libpcl1 ros-kinetic-octomap-*
+wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh
+sudo ./install_geographiclib_datasets.sh
 ```
 
-7. Clone this repository in your catkin workspace in order to build the avoidance node.
+7. Install avoidance module dependencies (pointcloud library and octomap).
+
+```bash
+apt install libpcl1 ros-kinetic-octomap-* ros-kinetic-yaml-*
+```
+
+8. Clone this repository in your catkin workspace in order to build the avoidance node.
 
 ```bash
 cd ~/catkin_ws/src
 git clone https://github.com/PX4/avoidance.git
 ```
 
-8. Actually build the avoidance node.
+9. Actually build the avoidance node.
 
 ```bash
 catkin build -w ~/catkin_ws
@@ -117,7 +124,7 @@ Note that you can build the node in release mode this way:
 catkin build -w ~/catkin_ws --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
-9. Source the catkin setup.bash from your catkin workspace.
+10. Source the catkin setup.bash from your catkin workspace.
 
 ```bash
 source ~/catkin_ws/devel/setup.bash
@@ -262,7 +269,7 @@ The drone will first change its altitude to reach the goal height. It is possibl
 Then the drone will start moving towards the goal. The default x, y goal position can be changed in Rviz by clicking on the 2D Nav Goal button and then chosing the new goal x and y position by clicking on the visualized gray space. If the goal has been set correctly, a yellow sphere will appear where you have clicked in the grey world.
 ![Screenshot rviz goal selection](docs/lp_goal_rviz.png)
 
-For MISSIONS, open [QGroundControl]() and plan a mission as described [here](). Set the parameter `MPC_OBS_AVOID` true. Start the mission and the vehicle will fly the mission waypoints dynamically recomputing the path such that it is collision free.
+For MISSIONS, open [QGroundControl](http://qgroundcontrol.com/) and plan a mission as described [here](https://docs.px4.io/en/flight_modes/mission.html). Set the parameter `MPC_OBS_AVOID` true. Start the mission and the vehicle will fly the mission waypoints dynamically recomputing the path such that it is collision free.
 
 # Run on Hardware
 
@@ -381,6 +388,8 @@ Some parameters that can be tuned in *rqt reconfigure*.
 # Advanced
 
 ## Message Flows
+
+More information about the communication between avoidance system and the Autopilot can be found in the [PX4 User Guide](https://docs.px4.io/en/computer_vision/obstacle_avoidance.html)
 
 ### PX4 and local planner
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The graph of the ROS nodes is shown below:
 One can plan a new path by setting a new goal with the *2D Nav Goal* button in rviz. The planned path should show up in rviz and the drone should follow the path, updating it when obstacles are detected. It is also possible to set a goal without using the obstacle avoidance (i.e. the drone will go straight to this goal and potentially collide with obstacles). To do so, set the position with the *2D Pose Estimate* button in rviz.
 
 
-## Simulating stereo-vision
+#### Simulating stereo-vision
 To simulate obstacle avoidance with stereo-cameras, the package `stereo-image-proc` must be installed.
 
 ```bash
@@ -287,6 +287,10 @@ Orther tested camera models are: Intel Realsense D415 and R200.
 
 ### PX4 Autopilot
 
+Parameters to set trough QGC:
+* MPC_OBS_AVOID to 1
+* SYS_COMPANION to 57600 or
+
 ### Companion Computer
 
 * OS: Ubuntu 16.04 OS or a docker container running Ubuntu 16.04 must be setup (e.g. if using on a Yocto based system). 
@@ -302,7 +306,7 @@ Tested models for the local planner Intel NUC, Jetson TX2, Intel Atom x7-Z8750 (
 The global planner uses the octomap_servers to get probabilistic information about the evironment.
 The octomap_server needs a stream of point-clouds to generate the accumulated data.
 
-## Generating Point-clouds from Depth-maps
+### Generating Point-clouds from Depth-maps
 
 In case the point-cloud stream already exists, this step can be skipped.
 
@@ -342,6 +346,27 @@ roslaunch global_planner global_planner_offboard.launch point_cloud_topic:=<poin
 Read the [Running on Odroid](https://github.com/PX4/avoidance/tree/master/global_planner/resource/odroid) instructions.
 
 ## Local Planner
+
+To run the planner with a Realsense D435 camera launch local_planner_example.launch editing the arguments:
+
+1. `tf_*` representing the dispacement between the camera and the flight controller
+2. `fcu_url` representing the port connecting the companion computer to the flight controller
+3. `serial_no_camera_front` representing the Realsense serial number
+
+The planner is running correctly when
+
+```bash
+[OA] Planning started, using 1 cameras
+```
+
+is displayed on the console.
+
+The local planner supports also multi camera setups. `local_planner_example.launch` needs to be modified by:
+
+1. launching one RealSense nodlet (`rs_depthcloud.launch`) for each camera making sure that each of them has a unique `namespace`
+2. launch one static_transform_publsher node for each camera
+
+An example of a three camera launch file is [local_planner_A700_3cam.launch](https://github.com/PX4/avoidance/blob/master/local_planner/launch/local_planner_A700_3cam.launch).
 
 
 # Troubleshooting

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/sim/mode
 export QT_X11_NO_MITSHM=1
 
 # Setup some more Gazebo-related environment variables
-. ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/posix_sitl_default
+. ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/px4_sitl_default
 
 # Build and run simulation
-make posix_sitl_default gazebo
+make px4_sitl_default gazebo
 ```
 
 4. Add the Firmware directory to ROS_PACKAGE_PATH so that ROS can start the PX4.
@@ -369,7 +369,7 @@ Check that the clock is being published by Gazebo:
 rostopic echo /clock
 ```
 
-If it is not, you have a problem with Gazebo (Did it finish loading the world? Do you see the buildings and the drone in the Gazebo UI?). However, if it is publishing the clock, then it might be a problem with the depth camera plugin. Make sure the package `ros-kinetic-gazebo-ros-pkgs` is installed. If not, install it and rebuild the Firmware (with `$ make posix_sitl_default gazebo` as explained above).
+If it is not, you have a problem with Gazebo (Did it finish loading the world? Do you see the buildings and the drone in the Gazebo UI?). However, if it is publishing the clock, then it might be a problem with the depth camera plugin. Make sure the package `ros-kinetic-gazebo-ros-pkgs` is installed. If not, install it and rebuild the Firmware (with `$ make px4_sitl_default gazebo` as explained above).
 
 ### I see the drone and world in rviz, but the drone does not move when I set a new "2D Nav Goal"
 Is the drone in OFFBOARD mode? Is it armed and flying?

--- a/README.md
+++ b/README.md
@@ -434,3 +434,8 @@ ROS topic | ROS Msgs. | MAVROS Plugin | MAVLink | PX4 Topic
 
 # Contributing
 
+Fork the project and then close you repository. Create a new branch off of master for your new feature or bug fix.
+
+Please, take into consideration our [coding style](https://github.com/PX4/avoidance/blob/master/tools/fix_style.sh).
+
+Commit your changes with informative commit messages, push your branch and open a new pull request. Please provide ROS bags and the Autopilot flight logs relevant to the changes you have made.

--- a/README.md
+++ b/README.md
@@ -270,9 +270,25 @@ For MISSIONS, open [QGroundControl]() and plan a mission as described [here](). 
 
 ### Camera
 
+Both planners require a 3D point cloud of type `sensor_msgs::PointCloud2`. Any camera that can provide such data is compatible.
+
+The officially supported camera is Intel Realsense D435. We recommend using Firmware version 5.9.13.0. The instructions on how to update the Firmware of the camera can be found [here](https://www.intel.com/content/www/us/en/support/articles/000028171/emerging-technologies/intel-realsense-technology.html)
+
+Pro Tip: Be careful when attaching the camera with a USB3 cable. USB3 might might interfere with GPS and other signals. If possible, always use USB2 cables.
+
+Orther tested camera models are: Intel Realsense D415 and R200.
+
 ### PX4 Autopilot
 
 ### Companion Computer
+
+* OS: Ubuntu 16.04 OS or a docker container running Ubuntu 16.04 must be setup (e.g. if using on a Yocto based system). 
+* ROS Kinetic: see [Installation](installaton)
+* Other Required Components for Intel Realsense:
+  - Librealsense (Realsense SDK). The installation instructions can be found [here](https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md)
+  - [Librealsense ROS wrappers)](https://github.com/intel-ros/realsense.git)
+
+Tested models for the local planner Intel NUC, Jetson TX2, Intel Atom x7-Z8750 (built-in on Intel Aero RTF drone), for the global planner Odroid.
 
 ## Global Planner
 


### PR DESCRIPTION
I have started rearranging the instructions such that there is:
- instructions on how to set up ROS
- general instruction on the simulation common to both planner plus a section dedicated to each planner describing the launch files and what to expect from the simulation
- general HW prerequisite with then a section for each planner
- troubleshooting section
- interaction with PX4
- guidelines for contribution

There are still missing sections and repetitions. 

FYI - @hamishwillee 
Some parts are copied from https://docs.google.com/document/d/1acs0C3bKPRqyiakP9Z43FAFn-wUydcqy9-PZ8D3FwBE/edit