### PR TITLE
Change 1Cam launch file SN

### DIFF
--- a/local_planner/launch/local_planner_A700_1cam.launch
+++ b/local_planner/launch/local_planner_A700_1cam.launch
@@ -18,10 +18,7 @@
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="est" default="ekf2"/>
-    <arg name="serial_no_camera_front"    default="819112072871"/>
-    <arg name="serial_no_camera_down"    default="817512071697"/>
-    <arg name="serial_no_camera_left"    default="817612071531"/>
-    <arg name="serial_no_camera_right"    default="817512070752"/>
+    <arg name="serial_no_camera_front"    default="819612070807"/>
     <arg name="depth_fps"            default="30"/>
     <arg name="infra1_fps"           default="30"/>
     <arg name="infra2_fps"           default="30"/>


### PR DESCRIPTION
Mostly for convenience with testing on the UP board, this commit changes the S/N of the RealSense I am using. Also it's confusing to have three S/N in the launch file for just 1 RealSense.