### PR TITLE
Pass down model argument in global_planner launch

### DIFF
--- a/global_planner/launch/global_planner_sitl_mavros.launch
+++ b/global_planner/launch/global_planner_sitl_mavros.launch
@@ -7,6 +7,7 @@
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
+    <arg name="model" default="iris_depth_camera" />
 
     <param name="use_sim_time" value="true" />
 
@@ -22,6 +23,7 @@
     <!-- Mavros and Sitl -->
     <include file="$(find global_planner)/launch/mavros_sitl.launch" >
         <arg name="world_path" value="$(arg world_path)" />
+        <arg name="model" value="$(arg model)" />
     </include>
 
     <!-- Global planner -->

--- a/global_planner/launch/global_planner_stereo.launch
+++ b/global_planner/launch/global_planner_stereo.launch
@@ -1,10 +1,12 @@
 <launch>
     <arg name="use_three_point_msg" default="false" />
+    <arg name="model" default="iris_depth_camera" />
 
     <include file="$(find global_planner)/launch/global_planner_sitl_mavros.launch" >
         <arg name="use_three_point_msg" value="$(arg use_three_point_msg)" />
         <arg name="use_stereo_simulation" value="true" />
         <arg name="point_cloud_topic" value="/stereo/points2" />
+        <arg name="model" value="$(arg model)" />
         <!-- <arg name="world" value="outdoor_village" /> -->
     </include>
 

--- a/global_planner/launch/mavros_sitl.launch
+++ b/global_planner/launch/mavros_sitl.launch
@@ -10,6 +10,7 @@
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="mavros_transformation" default="-1.57" />
+    <arg name="model" default="iris_depth_camera"/>
 
     <param name="use_sim_time" value="true" />
 
@@ -39,6 +40,6 @@
 
     <!-- Spawn iris with depth camera -->
     <node name="spawn_model" pkg="gazebo_ros" type="spawn_model" output="screen"
-          args="-sdf -database iris_depth_camera -model iris">
+          args="-sdf -database $(arg model) -model iris">
     </node>
 </launch>


### PR DESCRIPTION
This adds a model argument in the global planner launch files, passing
it down from global_planner_stereo.launch to global_planner_sitl_mavros.launch
and eventually to mavros_sitl.launch. Before this, it was hardcoded to
iris_depth_camera inside of mavros_sitl.launch.