### PR TITLE
Add log replay functionality

### DIFF
--- a/local_planner/launch/log_replay.launch
+++ b/local_planner/launch/log_replay.launch
@@ -60,5 +60,10 @@
       <param name="accept_goal_input_topic" value="true" />
       <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>
+    
+    <node name="rviz" pkg="rviz" type="rviz" output="screen" args="-d $(find local_planner)/resource/local_planner.rviz" />
+    
+    <!-- Launch rqt_reconfigure -->
+    <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />
 
 </launch>

--- a/local_planner/launch/log_replay.launch
+++ b/local_planner/launch/log_replay.launch
@@ -1,0 +1,64 @@
+<launch>
+
+    <param name="use_sim_time" value="true" />
+    <arg name="bag_name" default="/not_specified_bag_name" />
+
+    <node pkg="rosbag" type="play" name="player" required="true" output="screen" args="--clock $(arg bag_name)">
+       <remap from="/adapted_waypoint" to="/rosbag/adapted_waypoint"/>
+       <remap from="/avoid_sphere" to="/rosbag/avoid_sphere"/>
+       <remap from="/blocked_marker" to="/rosbag/blocked_marker"/>
+       <remap from="/bounding_box" to="/rosbag/bounding_box"/>
+       <remap from="/camera_front/color/camera_info" to="/rosbag/camera_front/color/camera_info"/>
+       <remap from="/camera_front/color/image_raw" to="/rosbag/camera_front/color/image_raw"/>
+       <remap from="/camera_front/realsense2_camera_manager/parameter_descriptions" to="/rosbag/camera_front/realsense2_camera_manager/parameter_descriptions"/>
+       <remap from="/camera_front/realsense2_camera_manager/parameter_updates" to="/rosbag/camera_front/realsense2_camera_manager/parameter_updates"/>
+       <remap from="/camera_left/color/camera_info" to="/rosbag/camera_left/color/camera_info"/>
+       <remap from="/camera_left/color/image_raw" to="/rosbag/camera_left/color/image_raw"/>
+       <remap from="/camera_right/color/camera_info" to="/rosbag/camera_right/color/camera_info"/>
+       <remap from="/camera_right/color/image_raw" to="/rosbag/camera_right/color/image_raw"/>
+       <remap from="/camera_right/realsense2_camera_manager/parameter_descriptions" to="/rosbag/camera_right/realsense2_camera_manager/parameter_descriptions"/>
+       <remap from="/camera_right/realsense2_camera_manager/parameter_updates" to="/rosbag/camera_right/realsense2_camera_manager/parameter_updates"/>
+       <remap from="/complete_tree" to="/rosbag/complete_tree"/>
+       <remap from="/cpu_usage" to="/rosbag/cpu_usage"/>
+       <remap from="/current_setpoint" to="/rosbag/current_setpoint"/>
+       <remap from="/ground_measurement" to="/rosbag/ground_measurement"/>
+       <remap from="/histogram_image" to="/rosbag/histogram_image"/>
+       <remap from="/initial_height" to="/rosbag/initial_height"/>
+       <remap from="/local_planner_node/parameter_descriptions" to="/rosbag/local_planner_node/parameter_descriptions"/>
+       <remap from="/local_planner_node/parameter_updates" to="/rosbag/local_planner_node/parameter_updates"/>
+       <remap from="/local_pointcloud" to="/rosbag/local_pointcloud"/>
+       <remap from="/mavros/companion_process/status" to="/rosbag/mavros/companion_process/status"/>
+       <remap from="/mavros/obstacle/send" to="/rosbag/mavros/obstacle/send"/>
+       <remap from="/mavros/setpoint_position/local" to="/rosbag/mavros/setpoint_position/local"/>
+       <remap from="/mavros/trajectory/desired" to="/rosbag/mavros/trajectory/desired"/>
+       <remap from="/mavros/trajectory/generated" to="/rosbag/mavros/trajectory/generated"/>
+       <remap from="/memory_usage" to="/rosbag/memory_usage"/>
+       <remap from="/offboard_pose" to="/rosbag/offboard_pose"/>
+       <remap from="/original_waypoint" to="/rosbag/original_waypoint"/>
+       <remap from="/path_actual" to="/rosbag/path_actual"/>
+       <remap from="/path_waypoint" to="/rosbag/path_waypoint"/>
+       <remap from="/processes" to="/rosbag/processes"/>
+       <remap from="/rejected_marker" to="/rosbag/rejected_marker"/>
+       <remap from="/reprojected_points" to="/rosbag/reprojected_points"/>
+       <remap from="/selected_marker" to="/rosbag/selected_marker"/>
+       <remap from="/smoothed_waypoint" to="/rosbag/smoothed_waypoint"/>
+       <remap from="/take_off_pose" to="/rosbag/take_off_pose"/>
+       <remap from="/tree_path" to="/rosbag/tree_path"/>  
+       <remap from="/goal_position" to="/input/goal_position"/>   
+    </node>
+
+    <!-- Launch avoidance -->
+    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find local_planner)/resource/custom_rosconsole.conf"/>
+    <rosparam command="load" file="$(find local_planner)/cfg/params.yaml"/>
+    <arg name="pointcloud_topics" default="[/rosbag/local_pointcloud]"/>
+
+    <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
+      <param name="goal_x_param" value="15" />
+      <param name="goal_y_param" value="15"/>
+      <param name="goal_z_param" value="4" />
+      <param name="disable_rise_to_goal_altitude" value="true" />
+      <param name="accept_goal_input_topic" value="true" />
+      <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
+    </node>
+
+</launch>

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -14,7 +14,7 @@ void LocalPlanner::setPose(const geometry_msgs::PoseStamped msg) {
   curr_yaw_ = tf::getYaw(msg.pose.orientation);
   star_planner_.setPose(pose_);
 
-  if (!currently_armed_) {
+  if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
     take_off_pose_.header = msg.header;
     take_off_pose_.pose.position = msg.pose.position;
     take_off_pose_.pose.orientation = msg.pose.orientation;
@@ -198,6 +198,10 @@ sensor_msgs::Image LocalPlanner::generateHistogramImage(Histogram& histogram) {
 
 void LocalPlanner::determineStrategy() {
   star_planner_.tree_age_++;
+
+  if(disable_rise_to_goal_altitude_){
+	  reach_altitude_ = true;
+  }
 
   if (!reach_altitude_) {
     starting_height_ =

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -198,6 +198,7 @@ class LocalPlanner {
   bool smooth_waypoints_ = true;
   bool send_obstacles_fcu_ = false;
   bool stop_in_front_active_ = false;
+  bool disable_rise_to_goal_altitude_;
 
   double pointcloud_timeout_hover_;
   double pointcloud_timeout_land_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -683,7 +683,6 @@ void LocalPlannerNode::clickedGoalCallback(
 
 void LocalPlannerNode::updateGoalCallback(const visualization_msgs::MarkerArray& msg){
 	if(accept_goal_input_topic_ && msg.markers.size()>0){
-		std::cout<<"Getting a goal input\n";
 		goal_msg_.pose = msg.markers[0].pose;
 		new_goal_ = true;
 	}

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -71,6 +71,8 @@ class LocalPlannerNode {
   std::string world_path_;
   bool never_run_ = true;
   bool position_received_ = false;
+  bool disable_rise_to_goal_altitude_;
+  bool accept_goal_input_topic_;
 
   std::atomic<bool> should_exit_{false};
 
@@ -150,6 +152,7 @@ class LocalPlannerNode {
   ros::Subscriber clicked_point_sub_;
   ros::Subscriber clicked_goal_sub_;
   ros::Subscriber fcu_input_sub_;
+  ros::Subscriber goal_topic_sub_;
 
   // Publishers
   ros::Publisher local_pointcloud_pub_;
@@ -209,6 +212,7 @@ class LocalPlannerNode {
   void publishMarkerFOV(nav_msgs::GridCells& FOV_cells);
   void clickedPointCallback(const geometry_msgs::PointStamped& msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped& msg);
+  void updateGoalCallback(const visualization_msgs::MarkerArray& msg);
   void fcuInputGoalCallback(const mavros_msgs::Trajectory& msg);
 
   void printPointInfo(double x, double y, double z);

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
   bool hover = false;
   bool landing = false;
   avoidanceOutput planner_output;
+  Node.local_planner_.disable_rise_to_goal_altitude_ = Node.disable_rise_to_goal_altitude_;
   bool startup = true;
   Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_BOOT;
 


### PR DESCRIPTION
This PR add a new launch file (sorry for even more launch files...) which enables you to play back a previously recorded rosbag and run the planner on the same pointcloud, position and goal data. This way you can compare your current version of the planner and its actions to the one recorded in the log.

This required two small changes to the planner:
- disable raise to goal altitude: I add a parameter which allow to disable the rising to goal altitude before starting with the planning. This is necessary because the log might not contain the arming position therefore the planner would never generate setpoint. This is also generally very useful to have for bench tests.
- listen to goal topic: I added a parameter which allows to listen to a topic which contain the goal location. This is necessary to grab the goal position from the bag file. 