### PR TITLE
Remove hard-coding of default goal_msg

### DIFF
--- a/local_planner/launch/local_planner_A700_1cam.launch
+++ b/local_planner/launch/local_planner_A700_1cam.launch
@@ -60,8 +60,6 @@
     <arg name="pointcloud_topics" default="[/camera_front/depth/points]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
       <param name="goal_z_param" value="4" />
       <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>

--- a/local_planner/launch/local_planner_A700_3cam.launch
+++ b/local_planner/launch/local_planner_A700_3cam.launch
@@ -94,8 +94,6 @@
     <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
       <param name="goal_z_param" value="4" />
       <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
     </node>

--- a/local_planner/launch/local_planner_aero.launch
+++ b/local_planner/launch/local_planner_aero.launch
@@ -45,8 +45,6 @@
   <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
 
   <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-    <param name="goal_x_param" value="15" />
-    <param name="goal_y_param" value="15"/>
     <param name="goal_z_param" value="4" />
     <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
   </node>

--- a/local_planner/launch/local_planner_aeroD415.launch
+++ b/local_planner/launch/local_planner_aeroD415.launch
@@ -34,8 +34,6 @@
 
   <!-- Launch Local Planner -->
   <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-    <param name="goal_x_param" value="15" />
-    <param name="goal_y_param" value="15"/>
     <param name="goal_z_param" value="4" />
     <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
   </node>

--- a/local_planner/launch/local_planner_depth-camera.launch
+++ b/local_planner/launch/local_planner_depth-camera.launch
@@ -21,8 +21,6 @@
 
     <!-- Launch local planner -->
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-        <param name="goal_x_param" value="17" />
-        <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
         <param name="world_name" value="$(find local_planner)/../sim/worlds/$(arg world_file_name).yaml" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 

--- a/local_planner/launch/local_planner_sitl_3cam.launch
+++ b/local_planner/launch/local_planner_sitl_3cam.launch
@@ -25,8 +25,6 @@
     
     <!-- Launch local planner -->
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">
-        <param name="goal_x_param" value="17" />
-        <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
         <param name="world_name" value="$(find local_planner)/../sim/worlds/$(arg world_file_name).yaml" />

--- a/local_planner/launch/local_planner_stereo.launch
+++ b/local_planner/launch/local_planner_stereo.launch
@@ -31,8 +31,6 @@
 
   <!-- Launch local planner -->
   <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-    <param name="goal_x_param" value="15" />
-    <param name="goal_y_param" value="15"/>
     <param name="goal_z_param" value="4" />
     <param name="world_name" value="$(find local_planner)/../sim/worlds/$(arg world_file_name).yaml" />
     <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 

--- a/local_planner/launch/log_replay.launch
+++ b/local_planner/launch/log_replay.launch
@@ -53,8 +53,6 @@
     <arg name="pointcloud_topics" default="[/rosbag/local_pointcloud]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
       <param name="goal_z_param" value="4" />
       <param name="disable_rise_to_goal_altitude" value="true" />
       <param name="accept_goal_input_topic" value="true" />

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -110,7 +110,6 @@ LocalPlannerNode::~LocalPlannerNode() { delete server_; }
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file
-  auto goal = local_planner_.getGoal();
   nh_.param<bool>("disable_rise_to_goal_altitude", disable_rise_to_goal_altitude_, false);
   nh_.param<bool>("accept_goal_input_topic", accept_goal_input_topic_, false);
 
@@ -121,7 +120,7 @@ void LocalPlannerNode::readParams() {
   nh_.param<std::string>("world_name", world_path_, "");
   goal_msg_.pose.position.x = NAN;
   goal_msg_.pose.position.y = NAN;
-  goal_msg_.pose.position.z = NAN;
+  nh_.param<double>("goal_z_param", goal_msg_.pose.position.z, 3.5);
 
   // Read in parameter for waypoint generator
   waypointGenerator_params new_params;
@@ -676,8 +675,7 @@ void LocalPlannerNode::clickedGoalCallback(
     const geometry_msgs::PoseStamped& msg) {
   new_goal_ = true;
   goal_msg_ = msg;
-  /* Selecting the goal from Rviz sets x and y. Get the z coordinate set in
-   * the launch file */
+  /* Selecting the goal from Rviz sets x and y. Leave the z coordiante unchanged */
   goal_msg_.pose.position.z = local_planner_.getGoal().z;
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -232,7 +232,7 @@ void LocalPlannerNode::updatePlannerInfo() {
     local_planner_.setGoal(goal_msg_.pose.position);
     new_goal_ = false;
   }
-   last_pc_time_ = ros::Time::now();
+   last_pointcloud_time_ = ros::Time::now();
 
 }
 

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -94,7 +94,7 @@ class LocalPlannerNode {
   const ros::Duration pointcloud_timeout_hover_ = ros::Duration(0.4);
   const ros::Duration pointcloud_timeout_land_ = ros::Duration(10);
 
-  ros::Time last_wp_time_;
+  ros::Time last_pc_time_;
   ros::Time t_status_sent_;
 
   LocalPlanner local_planner_;
@@ -133,6 +133,7 @@ class LocalPlannerNode {
                                      geometry_msgs::Twist vel);
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
   void publishWaypoints(bool hover);
+  bool isGoalValid();
 
   const ros::NodeHandle& nodeHandle() const { return nh_; }
 

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -94,7 +94,7 @@ class LocalPlannerNode {
   const ros::Duration pointcloud_timeout_hover_ = ros::Duration(0.4);
   const ros::Duration pointcloud_timeout_land_ = ros::Duration(10);
 
-  ros::Time last_pc_time_;
+  ros::Time last_pointcloud_time_;
   ros::Time t_status_sent_;
 
   LocalPlanner local_planner_;

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -41,8 +41,9 @@ int main(int argc, char** argv) {
         ros::Duration(Node.local_planner_.pointcloud_timeout_land_);
     ros::Duration pointcloud_timeout_hover =
         ros::Duration(Node.local_planner_.pointcloud_timeout_hover_);
-    ros::Duration since_last_cloud = now - Node.last_wp_time_;
+    ros::Duration since_last_cloud = now - Node.last_pc_time_;
     ros::Duration since_start = now - start_time;
+
 
     if (since_last_cloud > pointcloud_timeout_land &&
         since_start > pointcloud_timeout_land) {
@@ -87,6 +88,9 @@ int main(int argc, char** argv) {
         }
       }
     }
+    if(!Node.isGoalValid()){
+        ROS_WARN("Waiting for valid goal");
+    }
 
     // If planner is not running, update planner info and get last results
     if (Node.cameras_.size() == Node.numReceivedClouds() &&
@@ -113,7 +117,7 @@ int main(int argc, char** argv) {
     }
 
     // send waypoint
-    if (!Node.never_run_ && !landing) {
+    if (!Node.never_run_ && !landing && Node.isGoalValid()) {
       Node.publishWaypoints(hover);
       if(!hover) Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
     } else {

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
         ros::Duration(Node.local_planner_.pointcloud_timeout_land_);
     ros::Duration pointcloud_timeout_hover =
         ros::Duration(Node.local_planner_.pointcloud_timeout_hover_);
-    ros::Duration since_last_cloud = now - Node.last_pc_time_;
+    ros::Duration since_last_cloud = now - Node.last_pointcloud_time_;
     ros::Duration since_start = now - start_time;
 
 

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -61,8 +61,8 @@ int main(int argc, char** argv) {
         }
       }
     } else {
-      if (Node.never_run_ || (since_last_cloud > pointcloud_timeout_hover &&
-                              since_start > pointcloud_timeout_hover)) {
+      if (since_last_cloud > pointcloud_timeout_hover &&
+                              since_start > pointcloud_timeout_hover) {
         if (Node.position_received_) {
           hover = true;
           Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_CRITICAL;


### PR DESCRIPTION
This replaces the hard-coded goal message and introduces some logic
to recognize if a proper goal has not been defined yet. (aka. it is NAN).

Drawback: we only check the pointcloud availability once the goal is set.