### PR TITLE
Update README.md: Explicitly Instruct to Install gazebo-ros packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ Note that in the following instructions, we assume your catkin workspace (in whi
    source /opt/ros/kinetic/setup.bash
    ```
 
+  Full installation of ROS Kinetic comes with Gazebo 7.
+  
+  If you are using different version of Gazebo, 
+  
+  please make sure install ros-gazebo related packages
+  
+  For Gazebo 8,
+  ```
+  apt install ros-kinetic-gazebo8-*
+  ```
+  For Gazebo 9,
+  ```
+  apt install ros-kinetic-gazebo9-*
+  ```
+  
 1. Initialize rosdep.
 
    ```bash
@@ -222,7 +237,7 @@ This section shows how to start the *local_planner* and use it for avoidance in 
 
 The planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_08.pdf) algorithm. To run the algorithm it is possible to
 
-* simulate a forward looking stereo camera running OpenCV's block matching algorithm
+* simulate a forward looking stereo camera running OpenCV's block matching algorithm (SGBM by default)
 
    ```bash
    # if stereo-image-proc not yet installed
@@ -234,6 +249,9 @@ The planner is based on the [3DVFH+](http://ceur-ws.org/Vol-1319/morse14_paper_0
    The disparity map from `stereo-image-proc` is published as a [stereo_msgs/DisparityImage](http://docs.ros.org/api/stereo_msgs/html/msg/DisparityImage.html) message, which is not supported by rviz or rqt. To visualize the    message, either run:
 
    ```bash
+   # if image_view is not yet installed
+   sudo apt-get install ros-kinetic-image-view
+   
    rosrun image_view stereo_view stereo:=/stereo image:=image_rect_color
    ```
 


### PR DESCRIPTION
I could not find regarding that explicitly telling ros-gazebo related packages are required in

px4-dev guides, sitl_gazebo, and here all the documents are meant for fresh installing.

If someone(like me) is already have installed ROS and Gazebo somehow, 

It could waste much time of users and developers both ( like my issue here #172, possibly #159  )

It could be very easily be missed due to much complexity of the relevant project regarding this repo.

PX4 Firmware, SITL_Gazebo, ROS, MAVLink, MAVROS, OpenCV(in ROS) and so on...

P.S. Addition for how to install possible missing package(ros-kinetic-image-view)