### PR TITLE
Add unit tests for planner functions

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -136,7 +136,7 @@ add_library(local_planner
   src/nodes/common.cpp
   src/nodes/rviz_world_loader.cpp
 )
-	
+
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
@@ -214,7 +214,7 @@ if(CATKIN_ENABLE_TESTING)
 	                                             ${catkin_LIBRARIES}
 	                                             ${YAML_CPP_LIBRARIES})
 	endif()
-	
+
 	## Add folders to be run by python nosetests
 	# catkin_add_nosetests(test)
 endif()

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -238,10 +238,10 @@ void combinedHistogram(bool& hist_empty, Histogram& new_hist,
 }
 
 // costfunction for every free histogram cell
-double costFunction(int e, int z, nav_msgs::GridCells &path_waypoints,
-                    const Eigen::Vector3f &goal,
-                    const Eigen::Vector3f &position,
-                    const Eigen::Vector3f &position_old, double goal_cost_param,
+double costFunction(int e, int z, nav_msgs::GridCells& path_waypoints,
+                    const Eigen::Vector3f& goal,
+                    const Eigen::Vector3f& position,
+                    const Eigen::Vector3f& position_old, double goal_cost_param,
                     double smooth_cost_param,
                     double height_change_cost_param_adapted,
                     double height_change_cost_param, bool only_yawed) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -246,7 +246,11 @@ double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
                     double height_change_cost_param_adapted,
                     double height_change_cost_param, bool only_yawed) {
   double cost;
-  int waypoint_index = path_waypoints.cells.size();
+  int waypoint_index = path_waypoints.cells.size() - 1;
+  if (waypoint_index < 0) {
+    waypoint_index = 0;
+    path_waypoints.cells.push_back(position_old);
+  }
 
   double dist = (position - goal).norm();
   double dist_old = (position_old - goal).norm();

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -343,12 +343,13 @@ void findFreeDirections(
 
           // Elevation index < 0
           if (i < 0 && j >= 0 && j < z_dim) {
-            a = -i;
+            a = 0;
             b = z_dim - j - 1;
           }
           // Azimuth index < 0
           else if (j < 0 && i >= 0 && i < e_dim) {
             b = j + z_dim;
+            a = i;
           }
           // Elevation index > GRID_LENGTH_E
           else if (i >= e_dim && j >= 0 && j < z_dim) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -317,7 +317,7 @@ void findFreeDirections(
     const Histogram& histogram, double safety_radius,
     nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
     nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
-    const nav_msgs::GridCells& path_waypoints,
+    nav_msgs::GridCells& path_waypoints,
     std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
     const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -358,7 +358,7 @@ void findFreeDirections(
             b = j + z_dim;
             a = i;
           }
-          // Elevation index > GRID_LENGTH_E
+          // Elevation index > e_dim
           else if (i >= e_dim && j >= 0 && j < z_dim) {
             a = e_dim - (i % (e_dim - 1));
             b = j + (180 / resolution_alpha) - 1;
@@ -366,7 +366,7 @@ void findFreeDirections(
               b = b % (z_dim - 1);
             };
           }
-          // Azimuth index > GRID_LENGTH_Z
+          // Azimuth index > z_dim
           else if (j >= z_dim && i >= 0 && i < e_dim) {
             b = j - z_dim;
           }
@@ -376,10 +376,9 @@ void findFreeDirections(
             b = j;
           }
           // Elevation and azimuth index both < 0 OR elevation index >
-          // GRID_LENGTH_E and azimuth index <> GRID_LENGTH_Z
-          // OR elevation index < 0 and azimuth index > GRID_LENGTH_Z OR
-          // elevation index > GRID_LENGTH_E and azimuth index < 0.
-          // These cells are not part of the polar histogram.
+          // e_dim and azimuth index <> z_dim OR elevation index < 0 and
+          // azimuth index > z_dim OR elevation index > e_dim and azimuth index
+          // < 0. These cells are not part of the polar histogram.
           else {
             corner = true;
           }

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -238,10 +238,10 @@ void combinedHistogram(bool& hist_empty, Histogram& new_hist,
 }
 
 // costfunction for every free histogram cell
-double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
-                    const Eigen::Vector3f& goal,
-                    const Eigen::Vector3f& position,
-                    const Eigen::Vector3f& position_old, double goal_cost_param,
+double costFunction(int e, int z, nav_msgs::GridCells &path_waypoints,
+                    const Eigen::Vector3f &goal,
+                    const Eigen::Vector3f &position,
+                    const Eigen::Vector3f &position_old, double goal_cost_param,
                     double smooth_cost_param,
                     double height_change_cost_param_adapted,
                     double height_change_cost_param, bool only_yawed) {
@@ -249,7 +249,7 @@ double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
   int waypoint_index = path_waypoints.cells.size() - 1;
   if (waypoint_index < 0) {
     waypoint_index = 0;
-    path_waypoints.cells.push_back(position_old);
+    path_waypoints.cells.push_back(toPoint(position_old));
   }
 
   double dist = (position - goal).norm();

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -344,7 +344,10 @@ void findFreeDirections(
           // Elevation index < 0
           if (i < 0 && j >= 0 && j < z_dim) {
             a = 0;
-            b = z_dim - j - 1;
+            b = j + (180 / resolution_alpha) - 1;
+            if (b >= z_dim) {
+              b = b % (z_dim - 1);
+            }
           }
           // Azimuth index < 0
           else if (j < 0 && i >= 0 && i < e_dim) {
@@ -354,7 +357,10 @@ void findFreeDirections(
           // Elevation index > GRID_LENGTH_E
           else if (i >= e_dim && j >= 0 && j < z_dim) {
             a = e_dim - (i % (e_dim - 1));
-            b = z_dim - j - 1;
+            b = j + (180 / resolution_alpha) - 1;
+            if (b >= z_dim) {
+              b = b % (z_dim - 1);
+            };
           }
           // Azimuth index > GRID_LENGTH_Z
           else if (j >= z_dim && i >= 0 && i < e_dim) {

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -47,7 +47,7 @@ void combinedHistogram(bool& hist_empty, Histogram& new_hist,
                        int e_FOV_max);
 void compressHistogramElevation(Histogram& new_hist,
                                 const Histogram& input_hist);
-double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
+double costFunction(int e, int z, nav_msgs::GridCells& path_waypoints,
                     const Eigen::Vector3f& goal,
                     const Eigen::Vector3f& position,
                     const Eigen::Vector3f& position_old, double goal_cost_param,

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -58,7 +58,7 @@ void findFreeDirections(
     const Histogram& histogram, double safety_radius,
     nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
     nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
-    const nav_msgs::GridCells& path_waypoints,
+    nav_msgs::GridCells& path_waypoints,
     std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
     const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -245,34 +245,34 @@ TEST(PlannerFunctionsTests, findFreeDirectionsNoWrap) {
 
   // THEN: we should have one rejected cell and the 8 neightbooring cells
   // blocked
-  for (auto cell_blocked : path_blocked.cells) {
+  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
+       i++, j++) {
     std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
-        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
-                           cell_blocked_idx) != std::end(blocked));
+        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
+    EXPECT_EQ(blocked[j], cell_blocked_idx);
   }
 
-  for (auto cell_rejected : path_rejected.cells) {
-    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
-                  obstacle_idx_e) &&
-                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
-                      obstacle_idx_z));
+  for (int i = 0; i < path_rejected.cells.size(); i++) {
+    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
+                                                    resolution_alpha));
+    EXPECT_EQ(obstacle_idx_z,
+              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
   }
 
-  for (auto cell_candidate : path_candidates.cells) {
+  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
+       i++, j++) {
     std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
-        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
-                           cell_candidate_idx) != std::end(free));
+        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
+    EXPECT_EQ(cell_candidate_idx, free[j]);
   }
 
   EXPECT_EQ(1, path_rejected.cells.size());
-  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(blocked.size(), path_blocked.cells.size());
   EXPECT_EQ(
       std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
-          1 - 8,
+          1 - blocked.size(),
       path_candidates.cells.size());
 }
 
@@ -335,33 +335,34 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapLeft) {
   // THEN: we should get one rejected cell, the five neighboring cells blocked
   // plus three other blocked cells at the same elevation index and the last
   // azimuth index
-  for (auto cell_blocked : path_blocked.cells) {
+  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
+       i++, j++) {
     std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
-        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
-                           cell_blocked_idx) != std::end(blocked));
+        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
+    EXPECT_EQ(blocked[j], cell_blocked_idx);
   }
 
-  for (auto cell_rejected : path_rejected.cells) {
-    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
-                  obstacle_idx_e) &&
-                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
-                      obstacle_idx_z));
+  for (int i = 0; i < path_rejected.cells.size(); i++) {
+    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
+                                                    resolution_alpha));
+    EXPECT_EQ(obstacle_idx_z,
+              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
   }
 
-  for (auto cell_candidate : path_candidates.cells) {
+  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
+       i++, j++) {
     std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
-        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
-                           cell_candidate_idx) != std::end(free));
+        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
+    EXPECT_EQ(free[j], cell_candidate_idx);
   }
+
   EXPECT_EQ(1, path_rejected.cells.size());
-  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(blocked.size(), path_blocked.cells.size());
   EXPECT_EQ(
       std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
-          1 - 8,
+          1 - blocked.size(),
       path_candidates.cells.size());
 }
 
@@ -423,34 +424,34 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapRight) {
   // THEN: we should get one rejected cell, the five neighboring cells blocked
   // plus three other blocked cells at the same elevation index and the first
   // azimuth index
-  for (auto cell_blocked : path_blocked.cells) {
+  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
+       i++, j++) {
     std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
-        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
-                           cell_blocked_idx) != std::end(blocked));
+        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
+    EXPECT_EQ(blocked[j], cell_blocked_idx);
   }
 
-  for (auto cell_rejected : path_rejected.cells) {
-    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
-                  obstacle_idx_e) &&
-                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
-                      obstacle_idx_z));
+  for (int i = 0; i < path_rejected.cells.size(); i++) {
+    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
+                                                    resolution_alpha));
+    EXPECT_EQ(obstacle_idx_z,
+              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
   }
 
-  for (auto cell_candidate : path_candidates.cells) {
+  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
+       i++, j++) {
     std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
-        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
-                           cell_candidate_idx) != std::end(free));
+        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
+    EXPECT_EQ(free[j], cell_candidate_idx);
   }
 
   EXPECT_EQ(1, path_rejected.cells.size());
-  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(blocked.size(), path_blocked.cells.size());
   EXPECT_EQ(
       std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
-          1 - 8,
+          1 - blocked.size(),
       path_candidates.cells.size());
 }
 
@@ -514,34 +515,34 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapUp) {
   // THEN: we should get one rejected cell, the 14 neighboring cells blocked
   // plus 10 other blocked cells at the same elevation index and azimuth index
   // shifted by 180 degrees
-  for (auto cell_blocked : path_blocked.cells) {
+  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
+       i++, j++) {
     std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
-        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
-                           cell_blocked_idx) != std::end(blocked));
+        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
+    EXPECT_EQ(blocked[j], cell_blocked_idx);
   }
 
-  for (auto cell_rejected : path_rejected.cells) {
-    EXPECT_EQ(1, (obstacle_idx_e ==
-                  elevationAngletoIndex(cell_rejected.x, resolution_alpha)) &&
-                     (obstacle_idx_z ==
-                      azimuthAngletoIndex(cell_rejected.y, resolution_alpha)));
+  for (int i = 0; i < path_rejected.cells.size(); i++) {
+    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
+                                                    resolution_alpha));
+    EXPECT_EQ(obstacle_idx_z,
+              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
   }
 
-  for (auto cell_candidate : path_candidates.cells) {
+  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
+       i++, j++) {
     std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
-        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
-                           cell_candidate_idx) != std::end(free));
+        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
+    EXPECT_EQ(free[j], cell_candidate_idx);
   }
 
   EXPECT_EQ(1, path_rejected.cells.size());
-  EXPECT_EQ(24, path_blocked.cells.size());
+  EXPECT_EQ(blocked.size(), path_blocked.cells.size());
   EXPECT_EQ(
       std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
-          1 - 24,
+          1 - blocked.size(),
       path_candidates.cells.size());
 }
 
@@ -604,33 +605,33 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
   // THEN: we should get one rejected cell, the 5 neighboring cells blocked
   // plus 3 other blocked cells at the same elevation index and azimuth index
   // shifted by 180 degrees
-  for (auto cell_blocked : path_blocked.cells) {
+  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
+       i++, j++) {
     std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
-        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
-                           cell_blocked_idx) != std::end(blocked));
+        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
+    EXPECT_EQ(blocked[j], cell_blocked_idx);
   }
 
-  for (auto cell_rejected : path_rejected.cells) {
-    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
-                  obstacle_idx_e) &&
-                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
-                      obstacle_idx_z));
+  for (int i = 0; i < path_rejected.cells.size(); i++) {
+    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
+                                                    resolution_alpha));
+    EXPECT_EQ(obstacle_idx_z,
+              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
   }
 
-  for (auto cell_candidate : path_candidates.cells) {
+  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
+       i++, j++) {
     std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
-        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
-    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
-                           cell_candidate_idx) != std::end(free));
+        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
+        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
+    EXPECT_EQ(free[j], cell_candidate_idx);
   }
 
   EXPECT_EQ(1, path_rejected.cells.size());
-  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(blocked.size(), path_blocked.cells.size());
   EXPECT_EQ(
       std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
-          1 - 8,
+          1 - blocked.size(),
       path_candidates.cells.size());
 }

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 
 #include "../src/nodes/planner_functions.h"
 
@@ -79,5 +80,66 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
         EXPECT_DOUBLE_EQ(0.0, histogram_output.get_bin(e, z)) << z << ", " << e;
       }
     }
+  }
+}
+
+TEST(PlannerFunctions, calculateFOV) {
+  // GIVEN: the horizontal and vertical Field of View, the vehicle yaw and pitc
+  double h_fov = 90.0;
+  double v_fov = 45.0;
+  double yaw_z_greater_grid_length =
+      3.14;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min >= GRID_LENGTH_Z
+  double yaw_z_max_greater_grid =
+      -2.3;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min < GRID_LENGTH_Z
+  double yaw_z_min_smaller_zero = 3.9;  // z_FOV_min < 0 && z_FOV_max >= 0
+  double yaw_z_smaller_zero = 5.6;      // z_FOV_max < 0 && z_FOV_min < 0
+  double pitch = 0.0;
+
+  // WHEN: we calculate the Field of View
+  std::vector<int> z_FOV_idx_z_greater_grid_length;
+  std::vector<int> z_FOV_idx_z_max_greater_grid;
+  std::vector<int> z_FOV_idx3_z_min_smaller_zero;
+  std::vector<int> z_FOV_idx_z_smaller_zero;
+  int e_FOV_min;
+  int e_FOV_max;
+
+  calculateFOV(h_fov, v_fov, z_FOV_idx_z_greater_grid_length, e_FOV_min,
+               e_FOV_max, yaw_z_greater_grid_length, pitch);
+  calculateFOV(h_fov, v_fov, z_FOV_idx_z_max_greater_grid, e_FOV_min, e_FOV_max,
+               yaw_z_max_greater_grid, pitch);
+  calculateFOV(h_fov, v_fov, z_FOV_idx3_z_min_smaller_zero, e_FOV_min,
+               e_FOV_max, yaw_z_min_smaller_zero, pitch);
+  calculateFOV(h_fov, v_fov, z_FOV_idx_z_smaller_zero, e_FOV_min, e_FOV_max,
+               yaw_z_smaller_zero, pitch);
+
+  // THEN:
+  std::vector<int> output_z_greater_grid_length = {
+      7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21};
+  std::vector<int> output_z_max_greater_grid = {0, 1, 2,  3,  4,  5,  6, 7,
+                                                8, 9, 10, 11, 12, 58, 59};
+  std::vector<int> output_z_min_smaller_zero = {0, 1, 2,  3,  4,  5,  6, 7,
+                                                8, 9, 10, 11, 12, 13, 59};
+  std::vector<int> output_z_smaller_zero = {43, 44, 45, 46, 47, 48, 49, 50,
+                                            51, 52, 53, 54, 55, 56, 57, 58};
+
+  EXPECT_EQ(18, e_FOV_max);
+  EXPECT_EQ(10, e_FOV_min);
+  for (size_t i = 0; i < z_FOV_idx_z_greater_grid_length.size(); i++) {
+    EXPECT_EQ(output_z_greater_grid_length.at(i),
+              z_FOV_idx_z_greater_grid_length.at(i));
+  }
+
+  for (size_t i = 0; i < z_FOV_idx_z_max_greater_grid.size(); i++) {
+    EXPECT_EQ(output_z_max_greater_grid.at(i),
+              z_FOV_idx_z_max_greater_grid.at(i));
+  }
+
+  for (size_t i = 0; i < z_FOV_idx3_z_min_smaller_zero.size(); i++) {
+    EXPECT_EQ(output_z_min_smaller_zero.at(i),
+              z_FOV_idx3_z_min_smaller_zero.at(i));
+  }
+
+  for (size_t i = 0; i < z_FOV_idx_z_smaller_zero.size(); i++) {
+    EXPECT_EQ(output_z_smaller_zero.at(i), z_FOV_idx_z_smaller_zero.at(i));
   }
 }

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -207,7 +207,7 @@ TEST(PlannerFunctionsTests, findFreeDirectionsNoWrap) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
@@ -269,7 +269,7 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapLeft) {
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
 
   // all the variables below aren't used by the test
-	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
@@ -331,7 +331,7 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapRight) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
@@ -393,7 +393,7 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapUp) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
   const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
@@ -457,9 +457,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
-	const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
-	const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -511,7 +511,6 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
 }
 
 TEST(PlannerFunctionsTests, filterPointCloud) {
-
   // GIVEN: two point clouds
   const Eigen::Vector3f position(1.5f, 1.0f, 4.5f);
   Eigen::Vector3f closest(0.7f, 0.3f, -0.5f);
@@ -519,36 +518,41 @@ TEST(PlannerFunctionsTests, filterPointCloud) {
   p1.push_back(toXYZ(position + Eigen::Vector3f(1.1f, 0.8f, 0.1f)));
   p1.push_back(toXYZ(position + Eigen::Vector3f(2.2f, 1.0f, 1.0f)));
   p1.push_back(toXYZ(position + Eigen::Vector3f(1.0f, -3.0f, 1.0f)));
-  p1.push_back(toXYZ(position + Eigen::Vector3f(0.7f, 0.3f, -0.5f))); // < min_dist_backoff
+  p1.push_back(toXYZ(
+      position + Eigen::Vector3f(0.7f, 0.3f, -0.5f)));  // < min_dist_backoff
   p1.push_back(toXYZ(position + Eigen::Vector3f(-1.0f, 1.0f, 1.0f)));
   p1.push_back(toXYZ(position + Eigen::Vector3f(-1.0f, -1.1f, 3.5f)));
 
   pcl::PointCloud<pcl::PointXYZ> p2;
-  p2.push_back(toXYZ(position + Eigen::Vector3f(1.0f, 5.0f, 1.0f))); // > histogram_box.radius
-  p2.push_back(toXYZ(position + Eigen::Vector3f(100.0f, 5.0f, 1.0f))); // > histogram_box.radius
-  p2.push_back(toXYZ(position + Eigen::Vector3f(0.1f, 0.05f, 0.05f))); // < min_realsense_dist
+  p2.push_back(toXYZ(
+      position + Eigen::Vector3f(1.0f, 5.0f, 1.0f)));  // > histogram_box.radius
+  p2.push_back(
+      toXYZ(position +
+            Eigen::Vector3f(100.0f, 5.0f, 1.0f)));  // > histogram_box.radius
+  p2.push_back(toXYZ(
+      position + Eigen::Vector3f(0.1f, 0.05f, 0.05f)));  // < min_realsense_dist
 
   std::vector<pcl::PointCloud<pcl::PointXYZ>> complete_cloud;
-  complete_cloud.push_back(p1); complete_cloud.push_back(p2);
-  double min_cloud_size = 5.0;
+  complete_cloud.push_back(p1);
+  complete_cloud.push_back(p2);
   double min_dist_backoff = 1.0;
   Box histogram_box(5.0);
   histogram_box.setBoxLimits(toPoint(position), 4.5);
   double min_realsense_dist = 0.2;
 
   pcl::PointCloud<pcl::PointXYZ> cropped_cloud, cropped_cloud2;
-  Eigen::Vector3f closest_point,closest_point2;
+  Eigen::Vector3f closest_point, closest_point2;
   double distance_to_closest_point, distance_to_closest_point2;
   int counter_backoff, counter_backoff2;
 
   // WHEN: we filter the PointCloud with different values of min_cloud_size
   filterPointCloud(cropped_cloud, closest_point, distance_to_closest_point,
-      counter_backoff, complete_cloud, min_cloud_size, min_dist_backoff, histogram_box,
-      position, min_realsense_dist);
+                   counter_backoff, complete_cloud, 5.0, min_dist_backoff,
+                   histogram_box, position, min_realsense_dist);
 
   filterPointCloud(cropped_cloud2, closest_point2, distance_to_closest_point2,
-      counter_backoff2, complete_cloud, 20.0, min_dist_backoff, histogram_box,
-      position, min_realsense_dist);
+                   counter_backoff2, complete_cloud, 20.0, min_dist_backoff,
+                   histogram_box, position, min_realsense_dist);
 
   // THEN: we expect cropped_cloud to have 6 points and a backoff point, while
   // cropped_cloud2 to be empty
@@ -558,12 +562,11 @@ TEST(PlannerFunctionsTests, filterPointCloud) {
   EXPECT_FLOAT_EQ(closest.norm(), distance_to_closest_point);
   EXPECT_EQ(1, counter_backoff);
   for (int i = 0; i < p1.points.size(); i++) {
-    bool same_point = (p1.points[i].x == cropped_cloud.points[i].x) && (p1.points[i].y == cropped_cloud.points[i].y) &&
-         (p1.points[i].z == cropped_cloud.points[i].z);
-    EXPECT_EQ(1, same_point);
+    bool same_point = (p1.points[i].x == cropped_cloud.points[i].x) &&
+                      (p1.points[i].y == cropped_cloud.points[i].y) &&
+                      (p1.points[i].z == cropped_cloud.points[i].z);
+    ASSERT_TRUE(same_point);
   }
 
   EXPECT_EQ(0, cropped_cloud2.points.size());
-
-
 }

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -7,6 +7,24 @@
 
 using namespace avoidance;
 
+void check_indexes(nav_msgs::GridCells &test,
+                   std::vector<std::pair<int, int>> &truth, int resolution) {
+  for (int i = 0, j = 0; i < test.cells.size(), j < truth.size(); i++, j++) {
+    std::pair<int, int> cell_idx(
+        elevationAngletoIndex(test.cells[i].x, resolution),
+        azimuthAngletoIndex(test.cells[i].y, resolution));
+    EXPECT_EQ(truth[j], cell_idx);
+  }
+}
+
+void check_indexes(nav_msgs::GridCells &test, int truth_idx_e, int truth_idx_z,
+                   int resolution) {
+  for (int i = 0; i < test.cells.size(); i++) {
+    EXPECT_EQ(truth_idx_e, elevationAngletoIndex(test.cells[i].x, resolution));
+    EXPECT_EQ(truth_idx_z, azimuthAngletoIndex(test.cells[i].y, resolution));
+  }
+}
+
 TEST(PlannerFunctions, generateNewHistogramEmpty) {
   // GIVEN: an empty pointcloud
   pcl::PointCloud<pcl::PointXYZ> empty_cloud;
@@ -112,7 +130,7 @@ TEST(PlannerFunctions, calculateFOV) {
   calculateFOV(h_fov, v_fov, z_FOV_idx_z_smaller_zero, e_FOV_min, e_FOV_max,
                yaw_z_smaller_zero, pitch);
 
-  // THEN:
+  // THEN: we expect polar histogram indexes that are in the Field of View
   std::vector<int> output_z_greater_grid_length = {
       7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21};
   std::vector<int> output_z_max_greater_grid = {0, 1, 2,  3,  4,  5,  6, 7,
@@ -245,28 +263,10 @@ TEST(PlannerFunctionsTests, findFreeDirectionsNoWrap) {
 
   // THEN: we should have one rejected cell and the 8 neightbooring cells
   // blocked
-  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
-       i++, j++) {
-    std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
-    EXPECT_EQ(blocked[j], cell_blocked_idx);
-  }
-
-  for (int i = 0; i < path_rejected.cells.size(); i++) {
-    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
-                                                    resolution_alpha));
-    EXPECT_EQ(obstacle_idx_z,
-              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
-  }
-
-  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
-       i++, j++) {
-    std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
-    EXPECT_EQ(cell_candidate_idx, free[j]);
-  }
+  check_indexes(path_blocked, blocked, resolution_alpha);
+  check_indexes(path_candidates, free, resolution_alpha);
+  check_indexes(path_rejected, obstacle_idx_e, obstacle_idx_z,
+                resolution_alpha);
 
   EXPECT_EQ(1, path_rejected.cells.size());
   EXPECT_EQ(blocked.size(), path_blocked.cells.size());
@@ -335,28 +335,10 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapLeft) {
   // THEN: we should get one rejected cell, the five neighboring cells blocked
   // plus three other blocked cells at the same elevation index and the last
   // azimuth index
-  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
-       i++, j++) {
-    std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
-    EXPECT_EQ(blocked[j], cell_blocked_idx);
-  }
-
-  for (int i = 0; i < path_rejected.cells.size(); i++) {
-    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
-                                                    resolution_alpha));
-    EXPECT_EQ(obstacle_idx_z,
-              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
-  }
-
-  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
-       i++, j++) {
-    std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
-    EXPECT_EQ(free[j], cell_candidate_idx);
-  }
+  check_indexes(path_blocked, blocked, resolution_alpha);
+  check_indexes(path_candidates, free, resolution_alpha);
+  check_indexes(path_rejected, obstacle_idx_e, obstacle_idx_z,
+                resolution_alpha);
 
   EXPECT_EQ(1, path_rejected.cells.size());
   EXPECT_EQ(blocked.size(), path_blocked.cells.size());
@@ -424,28 +406,10 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapRight) {
   // THEN: we should get one rejected cell, the five neighboring cells blocked
   // plus three other blocked cells at the same elevation index and the first
   // azimuth index
-  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
-       i++, j++) {
-    std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
-    EXPECT_EQ(blocked[j], cell_blocked_idx);
-  }
-
-  for (int i = 0; i < path_rejected.cells.size(); i++) {
-    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
-                                                    resolution_alpha));
-    EXPECT_EQ(obstacle_idx_z,
-              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
-  }
-
-  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
-       i++, j++) {
-    std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
-    EXPECT_EQ(free[j], cell_candidate_idx);
-  }
+  check_indexes(path_blocked, blocked, resolution_alpha);
+  check_indexes(path_candidates, free, resolution_alpha);
+  check_indexes(path_rejected, obstacle_idx_e, obstacle_idx_z,
+                resolution_alpha);
 
   EXPECT_EQ(1, path_rejected.cells.size());
   EXPECT_EQ(blocked.size(), path_blocked.cells.size());
@@ -515,28 +479,10 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapUp) {
   // THEN: we should get one rejected cell, the 14 neighboring cells blocked
   // plus 10 other blocked cells at the same elevation index and azimuth index
   // shifted by 180 degrees
-  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
-       i++, j++) {
-    std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
-    EXPECT_EQ(blocked[j], cell_blocked_idx);
-  }
-
-  for (int i = 0; i < path_rejected.cells.size(); i++) {
-    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
-                                                    resolution_alpha));
-    EXPECT_EQ(obstacle_idx_z,
-              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
-  }
-
-  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
-       i++, j++) {
-    std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
-    EXPECT_EQ(free[j], cell_candidate_idx);
-  }
+  check_indexes(path_blocked, blocked, resolution_alpha);
+  check_indexes(path_candidates, free, resolution_alpha);
+  check_indexes(path_rejected, obstacle_idx_e, obstacle_idx_z,
+                resolution_alpha);
 
   EXPECT_EQ(1, path_rejected.cells.size());
   EXPECT_EQ(blocked.size(), path_blocked.cells.size());
@@ -605,28 +551,10 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
   // THEN: we should get one rejected cell, the 5 neighboring cells blocked
   // plus 3 other blocked cells at the same elevation index and azimuth index
   // shifted by 180 degrees
-  for (int i = 0, j = 0; i < path_blocked.cells.size(), j < blocked.size();
-       i++, j++) {
-    std::pair<int, int> cell_blocked_idx(
-        elevationAngletoIndex(path_blocked.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_blocked.cells[i].y, resolution_alpha));
-    EXPECT_EQ(blocked[j], cell_blocked_idx);
-  }
-
-  for (int i = 0; i < path_rejected.cells.size(); i++) {
-    EXPECT_EQ(obstacle_idx_e, elevationAngletoIndex(path_rejected.cells[i].x,
-                                                    resolution_alpha));
-    EXPECT_EQ(obstacle_idx_z,
-              azimuthAngletoIndex(path_rejected.cells[i].y, resolution_alpha));
-  }
-
-  for (int i = 0, j = 0; i < path_candidates.cells.size(), j < free.size();
-       i++, j++) {
-    std::pair<int, int> cell_candidate_idx(
-        elevationAngletoIndex(path_candidates.cells[i].x, resolution_alpha),
-        azimuthAngletoIndex(path_candidates.cells[i].y, resolution_alpha));
-    EXPECT_EQ(free[j], cell_candidate_idx);
-  }
+  check_indexes(path_blocked, blocked, resolution_alpha);
+  check_indexes(path_candidates, free, resolution_alpha);
+  check_indexes(path_rejected, obstacle_idx_e, obstacle_idx_z,
+                resolution_alpha);
 
   EXPECT_EQ(1, path_rejected.cells.size());
   EXPECT_EQ(blocked.size(), path_blocked.cells.size());

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -143,3 +143,494 @@ TEST(PlannerFunctions, calculateFOV) {
     EXPECT_EQ(output_z_smaller_zero.at(i), z_FOV_idx_z_smaller_zero.at(i));
   }
 }
+
+TEST(PlannerFunctionsTests, findAllFreeDirections) {
+  // GIVEN: empty histogram
+  Histogram empty_histogram = Histogram(ALPHA_RES);
+  double safety_radius = 15.0;
+  int resolution_alpha = ALPHA_RES;
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(empty_histogram, safety_radius, path_candidates,
+                     path_selected, path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: all directions should be classified as path_candidates
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha),
+      path_candidates.cells.size());
+  EXPECT_EQ(0, path_rejected.cells.size());
+  EXPECT_EQ(0, path_blocked.cells.size());
+}
+
+TEST(PlannerFunctionsTests, findFreeDirectionsNoWrap) {
+  // GIVEN: an histogram with a rejected cell, no wrapping of blocked cells
+  int resolution_alpha = 5;
+  double safety_radius = 5.0;
+  Histogram histogram = Histogram(resolution_alpha);
+  int obstacle_idx_e = 5;
+  int obstacle_idx_z = 10;
+  histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
+                    histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // expected output
+  std::vector<std::pair<int, int>> blocked;
+  std::vector<std::pair<int, int>> free;
+  for (int e = 0; e < (180 / resolution_alpha); e++) {
+    for (int z = 0; z < (360 / resolution_alpha); z++) {
+      if (!(z <= 11 && z >= 9 && e >= 4 && e <= 6)) {
+        free.push_back(std::make_pair(e, z));
+      } else {
+        if (!(e == obstacle_idx_e && z == obstacle_idx_z)) {
+          blocked.push_back(std::make_pair(e, z));
+        }
+      }
+    }
+  }
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(histogram, safety_radius, path_candidates, path_selected,
+                     path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: we should have one rejected cell and the 8 neightbooring cells
+  // blocked
+  for (auto cell_blocked : path_blocked.cells) {
+    std::pair<int, int> cell_blocked_idx(
+        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
+        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
+                           cell_blocked_idx) != std::end(blocked));
+  }
+
+  for (auto cell_rejected : path_rejected.cells) {
+    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
+                  obstacle_idx_e) &&
+                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
+                      obstacle_idx_z));
+  }
+
+  for (auto cell_candidate : path_candidates.cells) {
+    std::pair<int, int> cell_candidate_idx(
+        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
+        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
+                           cell_candidate_idx) != std::end(free));
+  }
+
+  EXPECT_EQ(1, path_rejected.cells.size());
+  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
+          1 - 8,
+      path_candidates.cells.size());
+}
+
+TEST(PlannerFunctionsTests, findFreeDirectionsWrapLeft) {
+  // GIVEN: a histogram with an obstacle at the first azimuth index
+  int resolution_alpha = 5;
+  double safety_radius = 5.0;
+  Histogram histogram = Histogram(resolution_alpha);
+  int obstacle_idx_e = 5;
+  int obstacle_idx_z = 0;
+  histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
+                    histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
+
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // expected output
+  std::vector<std::pair<int, int>> blocked;
+  std::vector<std::pair<int, int>> free;
+  for (int e = 0; e < (180 / resolution_alpha); e++) {
+    for (int z = 0; z < (360 / resolution_alpha); z++) {
+      if (!((z == 1 || z == 0 || z == 71) && e >= 4 && e <= 6)) {
+        free.push_back(std::make_pair(e, z));
+      } else {
+        if (!(e == obstacle_idx_e && z == obstacle_idx_z)) {
+          blocked.push_back(std::make_pair(e, z));
+        }
+      }
+    }
+  }
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(histogram, safety_radius, path_candidates, path_selected,
+                     path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: we should get one rejected cell, the five neighboring cells blocked
+  // plus three other blocked cells at the same elevation index and the last
+  // azimuth index
+  for (auto cell_blocked : path_blocked.cells) {
+    std::pair<int, int> cell_blocked_idx(
+        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
+        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
+                           cell_blocked_idx) != std::end(blocked));
+  }
+
+  for (auto cell_rejected : path_rejected.cells) {
+    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
+                  obstacle_idx_e) &&
+                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
+                      obstacle_idx_z));
+  }
+
+  for (auto cell_candidate : path_candidates.cells) {
+    std::pair<int, int> cell_candidate_idx(
+        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
+        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
+                           cell_candidate_idx) != std::end(free));
+  }
+  EXPECT_EQ(1, path_rejected.cells.size());
+  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
+          1 - 8,
+      path_candidates.cells.size());
+}
+
+TEST(PlannerFunctionsTests, findFreeDirectionsWrapRight) {
+  // GIVEN: a histogram with a obstacle at the last azimuth index
+  int resolution_alpha = 5;
+  double safety_radius = 5.0;
+  Histogram histogram = Histogram(resolution_alpha);
+  int obstacle_idx_e = 5;
+  int obstacle_idx_z = 71;
+  histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
+                    histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // expected output
+  std::vector<std::pair<int, int>> blocked;
+  std::vector<std::pair<int, int>> free;
+  for (int e = 0; e < (180 / resolution_alpha); e++) {
+    for (int z = 0; z < (360 / resolution_alpha); z++) {
+      if (!((z == 70 || z == 71 || z == 0) && e >= 4 && e <= 6)) {
+        free.push_back(std::make_pair(e, z));
+      } else {
+        if (!(e == obstacle_idx_e && z == obstacle_idx_z)) {
+          blocked.push_back(std::make_pair(e, z));
+        }
+      }
+    }
+  }
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(histogram, safety_radius, path_candidates, path_selected,
+                     path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: we should get one rejected cell, the five neighboring cells blocked
+  // plus three other blocked cells at the same elevation index and the first
+  // azimuth index
+  for (auto cell_blocked : path_blocked.cells) {
+    std::pair<int, int> cell_blocked_idx(
+        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
+        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
+                           cell_blocked_idx) != std::end(blocked));
+  }
+
+  for (auto cell_rejected : path_rejected.cells) {
+    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
+                  obstacle_idx_e) &&
+                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
+                      obstacle_idx_z));
+  }
+
+  for (auto cell_candidate : path_candidates.cells) {
+    std::pair<int, int> cell_candidate_idx(
+        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
+        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
+                           cell_candidate_idx) != std::end(free));
+  }
+
+  EXPECT_EQ(1, path_rejected.cells.size());
+  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
+          1 - 8,
+      path_candidates.cells.size());
+}
+
+TEST(PlannerFunctionsTests, findFreeDirectionsWrapUp) {
+  // GIVEN:a histogram with a obstacle at the first elevation index
+  int resolution_alpha = 8;
+  double safety_radius = 16.0;
+  Histogram histogram = Histogram(resolution_alpha);
+  int obstacle_idx_e = 0;
+  int obstacle_idx_z = 19;
+  histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
+                    histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // expected output
+  std::vector<std::pair<int, int>> blocked;
+  std::vector<std::pair<int, int>> free;
+
+  for (int e = 0; e < (180 / resolution_alpha); e++) {
+    for (int z = 0; z < (360 / resolution_alpha); z++) {
+      if (!(e >= 0 && e <= 2 && z >= 17 && z <= 21) &&
+          !(e >= 0 && e <= 1 && z >= 40 && z <= 44)) {
+        free.push_back(std::make_pair(e, z));
+      } else {
+        if (!(e == obstacle_idx_e && z == obstacle_idx_z)) {
+          blocked.push_back(std::make_pair(e, z));
+        }
+      }
+    }
+  }
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(histogram, safety_radius, path_candidates, path_selected,
+                     path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: we should get one rejected cell, the 14 neighboring cells blocked
+  // plus 10 other blocked cells at the same elevation index and azimuth index
+  // shifted by 180 degrees
+  for (auto cell_blocked : path_blocked.cells) {
+    std::pair<int, int> cell_blocked_idx(
+        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
+        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
+                           cell_blocked_idx) != std::end(blocked));
+  }
+
+  for (auto cell_rejected : path_rejected.cells) {
+    EXPECT_EQ(1, (obstacle_idx_e ==
+                  elevationAngletoIndex(cell_rejected.x, resolution_alpha)) &&
+                     (obstacle_idx_z ==
+                      azimuthAngletoIndex(cell_rejected.y, resolution_alpha)));
+  }
+
+  for (auto cell_candidate : path_candidates.cells) {
+    std::pair<int, int> cell_candidate_idx(
+        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
+        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
+                           cell_candidate_idx) != std::end(free));
+  }
+
+  EXPECT_EQ(1, path_rejected.cells.size());
+  EXPECT_EQ(24, path_blocked.cells.size());
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
+          1 - 24,
+      path_candidates.cells.size());
+}
+
+TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
+  // GIVEN: a histogram with a obstacle at the last elevation index
+  int resolution_alpha = 10;
+  double safety_radius = 10.0;
+  Histogram histogram = Histogram(resolution_alpha);
+  int obstacle_idx_e = 17;
+  int obstacle_idx_z = 4;
+  histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
+                    histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
+  // all the variables below aren't used by the test
+  geometry_msgs::Point goal;
+  goal.x = 2.0f;
+  goal.y = 0.0f;
+  goal.z = 2.0f;
+  geometry_msgs::PoseStamped position;
+  position.pose.position.x = 0.0f;
+  position.pose.position.y = 0.0f;
+  position.pose.position.z = 2.0f;
+  geometry_msgs::Point position_old;
+  position_old.x = -1.0f;
+  position_old.y = 0.0;
+  position_old.z = 2.0f;
+  double goal_cost_param = 2.0;
+  double smooth_cost_param = 1.5;
+  double height_change_cost_param_adapted = 4.0;
+  double height_change_cost_param = 4.0;
+  bool only_yawed = false;
+
+  // expected output
+  std::vector<std::pair<int, int>> blocked;
+  std::vector<std::pair<int, int>> free;
+  for (int e = 0; e < (180 / resolution_alpha); e++) {
+    for (int z = 0; z < (360 / resolution_alpha); z++) {
+      if (!((e == 16 || e == 17) && (z >= 3 && z <= 5)) &&
+          !(e == 17 && (z >= 21 && z <= 23))) {
+        free.push_back(std::make_pair(e, z));
+      } else {
+        if (!(e == obstacle_idx_e && z == obstacle_idx_z)) {
+          blocked.push_back(std::make_pair(e, z));
+        }
+      }
+    }
+  }
+
+  // WHEN: we look for free directions
+  nav_msgs::GridCells path_candidates, path_selected, path_rejected,
+      path_blocked, path_waypoints;
+  std::vector<float> cost_path_candidates;  // not needed
+
+  findFreeDirections(histogram, safety_radius, path_candidates, path_selected,
+                     path_rejected, path_blocked, path_waypoints,
+                     cost_path_candidates, goal, position, position_old,
+                     goal_cost_param, smooth_cost_param,
+                     height_change_cost_param_adapted, height_change_cost_param,
+                     only_yawed, resolution_alpha);
+
+  // THEN: we should get one rejected cell, the 5 neighboring cells blocked
+  // plus 3 other blocked cells at the same elevation index and azimuth index
+  // shifted by 180 degrees
+  for (auto cell_blocked : path_blocked.cells) {
+    std::pair<int, int> cell_blocked_idx(
+        elevationAngletoIndex(cell_blocked.x, resolution_alpha),
+        azimuthAngletoIndex(cell_blocked.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(blocked), std::end(blocked),
+                           cell_blocked_idx) != std::end(blocked));
+  }
+
+  for (auto cell_rejected : path_rejected.cells) {
+    EXPECT_EQ(1, (elevationAngletoIndex(cell_rejected.x, resolution_alpha) ==
+                  obstacle_idx_e) &&
+                     (azimuthAngletoIndex(cell_rejected.y, resolution_alpha) ==
+                      obstacle_idx_z));
+  }
+
+  for (auto cell_candidate : path_candidates.cells) {
+    std::pair<int, int> cell_candidate_idx(
+        elevationAngletoIndex(cell_candidate.x, resolution_alpha),
+        azimuthAngletoIndex(cell_candidate.y, resolution_alpha));
+    EXPECT_EQ(1, std::find(std::begin(free), std::end(free),
+                           cell_candidate_idx) != std::end(free));
+  }
+
+  EXPECT_EQ(1, path_rejected.cells.size());
+  EXPECT_EQ(8, path_blocked.cells.size());
+  EXPECT_EQ(
+      std::floor(360 / resolution_alpha) * std::floor(180 / resolution_alpha) -
+          1 - 8,
+      path_candidates.cells.size());
+}

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -168,18 +168,9 @@ TEST(PlannerFunctionsTests, findAllFreeDirections) {
   double safety_radius = 15.0;
   int resolution_alpha = ALPHA_RES;
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+  const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -216,18 +207,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsNoWrap) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -287,18 +269,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapLeft) {
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
 
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -358,18 +331,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapRight) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -429,18 +393,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapUp) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+  const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;
@@ -502,18 +457,9 @@ TEST(PlannerFunctionsTests, findFreeDirectionsWrapDown) {
   histogram.set_bin(obstacle_idx_e, obstacle_idx_z,
                     histogram.get_bin(obstacle_idx_e, obstacle_idx_z) + 1);
   // all the variables below aren't used by the test
-  geometry_msgs::Point goal;
-  goal.x = 2.0f;
-  goal.y = 0.0f;
-  goal.z = 2.0f;
-  geometry_msgs::PoseStamped position;
-  position.pose.position.x = 0.0f;
-  position.pose.position.y = 0.0f;
-  position.pose.position.z = 2.0f;
-  geometry_msgs::Point position_old;
-  position_old.x = -1.0f;
-  position_old.y = 0.0;
-  position_old.z = 2.0f;
+	const Eigen::Vector3f goal(2.0f, 0.0f, 2.0f);
+	const Eigen::Vector3f position(0.0f, 0.0f, 2.0f);
+	const Eigen::Vector3f position_old(-1.0f, 0.0f, 2.0f);
   double goal_cost_param = 2.0;
   double smooth_cost_param = 1.5;
   double height_change_cost_param_adapted = 4.0;


### PR DESCRIPTION
Review only commit 12d8f1a. Tests are still a work in progress.

While writing the test for `FindFreeDirections` I found out that the indexes for blocked cells are not correctly wrapping around the histogram.
The issues are present when the moving window azimuth index is greater than the grid and when the moving window elevation is smaller than 0.

Before:
![error_polar](https://user-images.githubusercontent.com/15078736/51201595-bf311180-18fc-11e9-87f6-88ac5612b131.png)
After:
![coorect_polar](https://user-images.githubusercontent.com/15078736/51201601-c2c49880-18fc-11e9-995d-e229a26ff7dd.png)


