### PR TITLE
Reduce includes

### DIFF
--- a/local_planner/src/nodes/avoidance_output.h
+++ b/local_planner/src/nodes/avoidance_output.h
@@ -1,0 +1,40 @@
+#pragma once
+
+
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/PoseStamped.h>
+
+#include <vector>
+
+namespace avoidance {
+
+enum waypoint_choice { hover, costmap, tryPath, direct, reachHeight, goBack };
+
+struct avoidanceOutput {
+  waypoint_choice waypoint_type;
+
+  geometry_msgs::PoseStamped pose;
+  bool obstacle_ahead;
+  bool reach_altitude;
+  double min_speed;
+  double max_speed;
+  double velocity_sigmoid_slope;
+  ros::Time last_path_time;
+
+  bool use_avoid_sphere;
+  int avoid_sphere_age;
+  geometry_msgs::Point avoid_centerpoint;
+  double avoid_radius;
+
+  geometry_msgs::Point back_off_point;
+  geometry_msgs::Point back_off_start_point;
+  double min_dist_backoff;
+
+  geometry_msgs::PoseStamped take_off_pose;
+  geometry_msgs::PoseStamped offboard_pose;
+
+  double costmap_direction_e;
+  double costmap_direction_z;
+  std::vector<geometry_msgs::Point> path_node_positions;
+};
+}

--- a/local_planner/src/nodes/avoidance_output.h
+++ b/local_planner/src/nodes/avoidance_output.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
 

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -6,8 +6,7 @@
 #include <geometry_msgs/Vector3Stamped.h>
 #include <Eigen/Core>
 
-#include <pcl/point_cloud.h>
-#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/point_types.h>
 
 namespace avoidance {
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -1,8 +1,15 @@
 #include "local_planner.h"
 
+#include "common.h"
+#include "planner_functions.h"
+#include "star_planner.h"
+#include "tree_node.h"
+
+#include <sensor_msgs/image_encodings.h>
+
 namespace avoidance {
 
-LocalPlanner::LocalPlanner() {}
+LocalPlanner::LocalPlanner() : star_planner_(new StarPlanner()){}
 
 LocalPlanner::~LocalPlanner() {}
 
@@ -12,7 +19,7 @@ void LocalPlanner::setPose(const geometry_msgs::PoseStamped msg) {
   pose_.pose.position = msg.pose.position;
   pose_.pose.orientation = msg.pose.orientation;
   curr_yaw_ = tf::getYaw(msg.pose.orientation);
-  star_planner_.setPose(pose_);
+  star_planner_->setPose(pose_);
 
   if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
     take_off_pose_.header = msg.header;
@@ -67,7 +74,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
   adapt_cost_params_ = config.adapt_cost_params_;
   send_obstacles_fcu_ = config.send_obstacles_fcu_;
 
-  star_planner_.dynamicReconfigureSetStarParams(config, level);
+  star_planner_->dynamicReconfigureSetStarParams(config, level);
 
   ROS_DEBUG("\033[0;35m[OA] Dynamic reconfigure call \033[0m");
 }
@@ -89,7 +96,7 @@ geometry_msgs::Point LocalPlanner::getGoal() { return toPoint(goal_); }
 void LocalPlanner::applyGoal() {
   initGridCells(&path_waypoints_);
   path_waypoints_.cells.push_back(pose_.pose.position);
-  star_planner_.setGoal(toPoint(goal_));
+  star_planner_->setGoal(toPoint(goal_));
   goal_dist_incline_.clear();
 }
 
@@ -187,7 +194,7 @@ sensor_msgs::Image LocalPlanner::generateHistogramImage(Histogram &histogram) {
 }
 
 void LocalPlanner::determineStrategy() {
-  star_planner_.tree_age_++;
+  star_planner_->tree_age_++;
 
   if (disable_rise_to_goal_altitude_) {
     reach_altitude_ = true;
@@ -294,19 +301,19 @@ void LocalPlanner::determineStrategy() {
             velocity_mod_ < 0.1, ALPHA_RES);
 
         if (use_VFH_star_) {
-          star_planner_.setParams(min_cloud_size_, min_dist_backoff_,
+          star_planner_->setParams(min_cloud_size_, min_dist_backoff_,
                                   path_waypoints_, curr_yaw_,
                                   min_realsense_dist_);
-          star_planner_.setFOV(h_FOV_, v_FOV_);
-          star_planner_.setReprojectedPoints(reprojected_points_,
+          star_planner_->setFOV(h_FOV_, v_FOV_);
+          star_planner_->setReprojectedPoints(reprojected_points_,
                                              reprojected_points_age_,
                                              reprojected_points_dist_);
-          star_planner_.setCostParams(goal_cost_param_, smooth_cost_param_,
+          star_planner_->setCostParams(goal_cost_param_, smooth_cost_param_,
                                       height_change_cost_param_adapted_,
                                       height_change_cost_param_);
-          star_planner_.setBoxSize(histogram_box_, ground_distance_);
-          star_planner_.setCloud(complete_cloud_);
-          star_planner_.buildLookAheadTree();
+          star_planner_->setBoxSize(histogram_box_, ground_distance_);
+          star_planner_->setCloud(complete_cloud_);
+          star_planner_->buildLookAheadTree();
 
           waypoint_type_ = tryPath;
           last_path_time_ = ros::Time::now();
@@ -540,9 +547,9 @@ void LocalPlanner::setCurrentVelocity(const geometry_msgs::TwistStamped &vel) {
 void LocalPlanner::getTree(
     std::vector<TreeNode> &tree, std::vector<int> &closed_set,
     std::vector<geometry_msgs::Point> &path_node_positions) {
-  tree = star_planner_.tree_;
-  closed_set = star_planner_.closed_set_;
-  path_node_positions = star_planner_.path_node_positions_;
+  tree = star_planner_->tree_;
+  closed_set = star_planner_->closed_set_;
+  path_node_positions = star_planner_->path_node_positions_;
 }
 
 void LocalPlanner::sendObstacleDistanceDataToFcu(
@@ -571,7 +578,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() {
 
   out.costmap_direction_e = costmap_direction_e_;
   out.costmap_direction_z = costmap_direction_z_;
-  out.path_node_positions = star_planner_.path_node_positions_;
+  out.path_node_positions = star_planner_->path_node_positions_;
   return out;
 }
 }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -9,7 +9,7 @@
 
 namespace avoidance {
 
-LocalPlanner::LocalPlanner() : star_planner_(new StarPlanner()){}
+LocalPlanner::LocalPlanner() : star_planner_(new StarPlanner()) {}
 
 LocalPlanner::~LocalPlanner() {}
 
@@ -94,7 +94,7 @@ void LocalPlanner::setGoal(const geometry_msgs::Point &goal) {
 geometry_msgs::Point LocalPlanner::getGoal() { return toPoint(goal_); }
 
 void LocalPlanner::applyGoal() {
-  initGridCells(&path_waypoints_);
+  initGridCells(path_waypoints_);
   path_waypoints_.cells.push_back(pose_.pose.position);
   star_planner_->setGoal(toPoint(goal_));
   goal_dist_incline_.clear();
@@ -102,10 +102,10 @@ void LocalPlanner::applyGoal() {
 
 void LocalPlanner::runPlanner() {
   // reset candidates for visualization
-  initGridCells(&path_candidates_);
-  initGridCells(&path_rejected_);
-  initGridCells(&path_blocked_);
-  initGridCells(&path_selected_);
+  initGridCells(path_candidates_);
+  initGridCells(path_rejected_);
+  initGridCells(path_blocked_);
+  initGridCells(path_selected_);
   stop_in_front_active_ = false;
 
   ROS_INFO("\033[1;35m[OA] Planning started, using %i cameras\n \033[0m",
@@ -121,7 +121,7 @@ void LocalPlanner::runPlanner() {
   calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, yaw, pitch);
 
   // visualization of FOV in RViz
-  initGridCells(&FOV_cells_);
+  initGridCells(FOV_cells_);
   geometry_msgs::Point p;
   for (int j = e_FOV_min_; j <= e_FOV_max_; j++) {
     for (size_t i = 0; i < z_FOV_idx_.size(); i++) {
@@ -302,15 +302,15 @@ void LocalPlanner::determineStrategy() {
 
         if (use_VFH_star_) {
           star_planner_->setParams(min_cloud_size_, min_dist_backoff_,
-                                  path_waypoints_, curr_yaw_,
-                                  min_realsense_dist_);
+                                   path_waypoints_, curr_yaw_,
+                                   min_realsense_dist_);
           star_planner_->setFOV(h_FOV_, v_FOV_);
           star_planner_->setReprojectedPoints(reprojected_points_,
-                                             reprojected_points_age_,
-                                             reprojected_points_dist_);
+                                              reprojected_points_age_,
+                                              reprojected_points_dist_);
           star_planner_->setCostParams(goal_cost_param_, smooth_cost_param_,
-                                      height_change_cost_param_adapted_,
-                                      height_change_cost_param_);
+                                       height_change_cost_param_adapted_,
+                                       height_change_cost_param_);
           star_planner_->setBoxSize(histogram_box_, ground_distance_);
           star_planner_->setCloud(complete_cloud_);
           star_planner_->buildLookAheadTree();

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -1,8 +1,8 @@
 #ifndef LOCAL_PLANNER_LOCAL_PLANNER_H
 #define LOCAL_PLANNER_LOCAL_PLANNER_H
 
-#include "avoidance_output.h"
 #include <sensor_msgs/image_encodings.h>
+#include "avoidance_output.h"
 #include "box.h"
 #include "histogram.h"
 
@@ -129,7 +129,7 @@ class LocalPlanner {
   void updateObstacleDistanceMsg(Histogram hist);
   void updateObstacleDistanceMsg();
   void create2DObstacleRepresentation(const bool send_to_fcu);
-  sensor_msgs::Image generateHistogramImage(Histogram &histogram);
+  sensor_msgs::Image generateHistogramImage(Histogram& histogram);
 
  public:
   double h_FOV_ = 59.0;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -256,9 +256,9 @@ void LocalPlannerNode::updatePlannerInfo() {
   // update ground distance
   if (ros::Time::now() - ground_distance_msg_.header.stamp <
       ros::Duration(0.5)) {
-    local_planner_.ground_distance_ = ground_distance_msg_.bottom_clearance;
+    local_planner_->ground_distance_ = ground_distance_msg_.bottom_clearance;
   } else {
-    local_planner_.ground_distance_ = 2.0;  // in case where no range data is
+    local_planner_->ground_distance_ = 2.0;  // in case where no range data is
                                             // available assume vehicle is close
                                             // to ground
   }
@@ -502,16 +502,13 @@ void LocalPlannerNode::publishBox() {
   box.pose.position.x = drone_pos.pose.position.x;
   box.pose.position.y = drone_pos.pose.position.y;
   box.pose.position.z = drone_pos.pose.position.z;
-                        0.5 * (local_planner_->histogram_box_.zsize_up_ -
-                               local_planner_->histogram_box_.zsize_down_);
   box.pose.orientation.x = 0.0;
   box.pose.orientation.y = 0.0;
   box.pose.orientation.z = 0.0;
   box.pose.orientation.w = 1.0;
   box.scale.x = 2.0 * local_planner_->histogram_box_.radius_;
   box.scale.y = 2.0 * local_planner_->histogram_box_.radius_;
-  box.scale.z = local_planner_->histogram_box_.zsize_up_ +
-                local_planner_->histogram_box_.zsize_down_;
+  box.scale.z = 2.0 * local_planner_->histogram_box_.radius_;
   box.color.a = 0.5;
   box.color.r = 0.0;
   box.color.g = 1.0;
@@ -526,13 +523,13 @@ void LocalPlannerNode::publishBox() {
   plane.action = visualization_msgs::Marker::ADD;
   plane.pose.position.x = drone_pos.pose.position.x;
   plane.pose.position.y = drone_pos.pose.position.y;
-  plane.pose.position.z = local_planner_.histogram_box_.zmin_;
+  plane.pose.position.z = local_planner_->histogram_box_.zmin_;
   plane.pose.orientation.x = 0.0;
   plane.pose.orientation.y = 0.0;
   plane.pose.orientation.z = 0.0;
   plane.pose.orientation.w = 1.0;
-  plane.scale.x = 2.0 * local_planner_.histogram_box_.radius_;
-  plane.scale.y = 2.0 * local_planner_.histogram_box_.radius_;
+  plane.scale.x = 2.0 * local_planner_->histogram_box_.radius_;
+  plane.scale.y = 2.0 * local_planner_->histogram_box_.radius_;
   plane.scale.z = 0.001;
   plane.color.a = 0.5;
   plane.color.r = 0.0;
@@ -735,7 +732,7 @@ void LocalPlannerNode::distanceSensorCallback(
   }
 }
 void LocalPlannerNode::publishGround() {
-  geometry_msgs::PoseStamped drone_pos = local_planner_.getPosition();
+  geometry_msgs::PoseStamped drone_pos = local_planner_->getPosition();
   visualization_msgs::Marker plane;
   plane.header.frame_id = "local_origin";
   plane.header.stamp = ros::Time::now();
@@ -745,13 +742,13 @@ void LocalPlannerNode::publishGround() {
   plane.pose.position.x = drone_pos.pose.position.x;
   plane.pose.position.y = drone_pos.pose.position.y;
   plane.pose.position.z =
-      drone_pos.pose.position.z - local_planner_.ground_distance_;
+      drone_pos.pose.position.z - local_planner_->ground_distance_;
   plane.pose.orientation.x = 0.0;
   plane.pose.orientation.y = 0.0;
   plane.pose.orientation.z = 0.0;
   plane.pose.orientation.w = 1.0;
-  plane.scale.x = 2.0 * local_planner_.histogram_box_.radius_;
-  plane.scale.y = 2.0 * local_planner_.histogram_box_.radius_;
+  plane.scale.x = 2.0 * local_planner_->histogram_box_.radius_;
+  plane.scale.y = 2.0 * local_planner_->histogram_box_.radius_;
   plane.scale.z = 0.001;
   ;
   plane.color.a = 0.5;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -1,10 +1,24 @@
 #include "local_planner_node.h"
 
+#include "common.h"
+#include "local_planner.h"
+#include "planner_functions.h"
+#include "tree_node.h"
+#include "waypoint_generator.h"
+
 #include <boost/algorithm/string.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
 
 namespace avoidance {
 
 LocalPlannerNode::LocalPlannerNode() {
+  local_planner_.reset(new LocalPlanner());
+  wp_generator_.reset(new WaypointGenerator());
   nh_ = ros::NodeHandle("~");
   readParams();
 
@@ -106,14 +120,14 @@ LocalPlannerNode::LocalPlannerNode() {
   mavros_set_mode_client_ =
       nh_.serviceClient<mavros_msgs::SetMode>("/mavros/set_mode");
 
-  local_planner_.applyGoal();
+  local_planner_->applyGoal();
 }
 
 LocalPlannerNode::~LocalPlannerNode() { delete server_; }
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file
-  auto goal = local_planner_.getGoal();
+  auto goal = local_planner_->getGoal();
   nh_.param<double>("goal_x_param", goal.x, 9.0);
   nh_.param<double>("goal_y_param", goal.y, 13.0);
   nh_.param<double>("goal_z_param", goal.z, 3.5);
@@ -144,7 +158,7 @@ void LocalPlannerNode::readParams() {
   nh_.param<double>("min_speed_close_to_goal",
                     new_params.min_speed_close_to_goal, 0.5);
 
-  wp_generator_.param_ = new_params;
+  wp_generator_->param_ = new_params;
 }
 
 void LocalPlannerNode::initializeCameraSubscribers(
@@ -202,7 +216,7 @@ bool LocalPlannerNode::canUpdatePlannerInfo() {
 }
 void LocalPlannerNode::updatePlannerInfo() {
   // update the point cloud
-  local_planner_.complete_cloud_.clear();
+  local_planner_->complete_cloud_.clear();
   for (size_t i = 0; i < cameras_.size(); ++i) {
     sensor_msgs::PointCloud2 pc2cloud_world;
     pcl::PointCloud<pcl::PointXYZ> complete_cloud;
@@ -215,7 +229,7 @@ void LocalPlannerNode::updatePlannerInfo() {
                                    cameras_[i].newest_cloud_msg_,
                                    pc2cloud_world);
       pcl::fromROSMsg(pc2cloud_world, complete_cloud);
-      local_planner_.complete_cloud_.push_back(std::move(complete_cloud));
+      local_planner_->complete_cloud_.push_back(std::move(complete_cloud));
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s",
                 ex.what());
@@ -223,19 +237,19 @@ void LocalPlannerNode::updatePlannerInfo() {
   }
 
   // update position
-  local_planner_.setPose(newest_pose_);
+  local_planner_->setPose(newest_pose_);
 
   // Update velocity
-  local_planner_.setCurrentVelocity(vel_msg_);
+  local_planner_->setCurrentVelocity(vel_msg_);
 
   // update state
-  local_planner_.currently_armed_ = armed_;
-  local_planner_.offboard_ = offboard_;
-  local_planner_.mission_ = mission_;
+  local_planner_->currently_armed_ = armed_;
+  local_planner_->offboard_ = offboard_;
+  local_planner_->mission_ = mission_;
 
   // update goal
   if (new_goal_) {
-    local_planner_.setGoal(goal_msg_.pose.position);
+    local_planner_->setGoal(goal_msg_.pose.position);
     new_goal_ = false;
   }
 
@@ -341,7 +355,7 @@ void LocalPlannerNode::initMarker(visualization_msgs::MarkerArray* marker,
   m.id = 0;
   marker->markers.push_back(m);
 
-  geometry_msgs::PoseStamped drone_pos = local_planner_.getPosition();
+  geometry_msgs::PoseStamped drone_pos = local_planner_->getPosition();
 
   for (size_t i = 0; i < path.cells.size(); i++) {
     m.id = i + 1;
@@ -396,7 +410,7 @@ void LocalPlannerNode::publishGoal() {
   visualization_msgs::MarkerArray marker_goal;
   visualization_msgs::Marker m;
 
-  geometry_msgs::Point goal = local_planner_.getGoal();
+  geometry_msgs::Point goal = local_planner_->getGoal();
 
   m.header.frame_id = "local_origin";
   m.header.stamp = ros::Time::now();
@@ -421,9 +435,9 @@ void LocalPlannerNode::publishReachHeight() {
   m.header.frame_id = "local_origin";
   m.header.stamp = ros::Time::now();
   m.type = visualization_msgs::Marker::CUBE;
-  m.pose.position.x = local_planner_.take_off_pose_.pose.position.x;
-  m.pose.position.y = local_planner_.take_off_pose_.pose.position.y;
-  m.pose.position.z = local_planner_.starting_height_;
+  m.pose.position.x = local_planner_->take_off_pose_.pose.position.x;
+  m.pose.position.y = local_planner_->take_off_pose_.pose.position.y;
+  m.pose.position.z = local_planner_->starting_height_;
   m.pose.orientation.x = 0.0;
   m.pose.orientation.y = 0.0;
   m.pose.orientation.z = 0.0;
@@ -454,7 +468,7 @@ void LocalPlannerNode::publishReachHeight() {
   t.color.b = 0.0;
   t.lifetime = ros::Duration();
   t.id = 0;
-  t.pose.position = local_planner_.take_off_pose_.pose.position;
+  t.pose.position = local_planner_->take_off_pose_.pose.position;
   takeoff_pose_pub_.publish(t);
 
   visualization_msgs::Marker a;
@@ -471,13 +485,13 @@ void LocalPlannerNode::publishReachHeight() {
   a.color.b = 0.5;
   a.lifetime = ros::Duration();
   a.id = 0;
-  a.pose.position = local_planner_.offboard_pose_.pose.position;
+  a.pose.position = local_planner_->offboard_pose_.pose.position;
   offboard_pose_pub_.publish(a);
 }
 
 void LocalPlannerNode::publishBox() {
   visualization_msgs::MarkerArray marker_array;
-  geometry_msgs::PoseStamped drone_pos = local_planner_.getPosition();
+  geometry_msgs::PoseStamped drone_pos = local_planner_->getPosition();
 
   visualization_msgs::Marker box;
   box.header.frame_id = "local_origin";
@@ -488,13 +502,16 @@ void LocalPlannerNode::publishBox() {
   box.pose.position.x = drone_pos.pose.position.x;
   box.pose.position.y = drone_pos.pose.position.y;
   box.pose.position.z = drone_pos.pose.position.z;
+                        0.5 * (local_planner_->histogram_box_.zsize_up_ -
+                               local_planner_->histogram_box_.zsize_down_);
   box.pose.orientation.x = 0.0;
   box.pose.orientation.y = 0.0;
   box.pose.orientation.z = 0.0;
   box.pose.orientation.w = 1.0;
-  box.scale.x = 2.0 * local_planner_.histogram_box_.radius_;
-  box.scale.y = 2.0 * local_planner_.histogram_box_.radius_;
-  box.scale.z = 2.0 * local_planner_.histogram_box_.radius_;
+  box.scale.x = 2.0 * local_planner_->histogram_box_.radius_;
+  box.scale.y = 2.0 * local_planner_->histogram_box_.radius_;
+  box.scale.z = local_planner_->histogram_box_.zsize_up_ +
+                local_planner_->histogram_box_.zsize_down_;
   box.color.a = 0.5;
   box.color.r = 0.0;
   box.color.g = 1.0;
@@ -529,8 +546,8 @@ void LocalPlannerNode::publishBox() {
 void LocalPlannerNode::publishWaypoints(bool hover) {
   const ros::Time now = ros::Time::now();
 
-  wp_generator_.updateState(newest_pose_, goal_msg_, vel_msg_, hover, now);
-  waypointResult result = wp_generator_.getWaypoints();
+  wp_generator_->updateState(newest_pose_, goal_msg_, vel_msg_, hover, now);
+  waypointResult result = wp_generator_->getWaypoints();
 
   visualization_msgs::Marker sphere1;
   visualization_msgs::Marker sphere2;
@@ -608,7 +625,7 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
   // to mavros
 
   mavros_msgs::Trajectory obst_free_path = {};
-  if (local_planner_.use_vel_setpoints_) {
+  if (local_planner_->use_vel_setpoints_) {
     mavros_vel_setpoint_pub_.publish(result.velocity_waypoint);
     transformVelocityToTrajectory(obst_free_path, result.velocity_waypoint);
   } else {
@@ -619,7 +636,7 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
 }
 
 void LocalPlannerNode::publishHistogramImage() {
-  histogram_image_pub_.publish(local_planner_.histogram_image_);
+  histogram_image_pub_.publish(local_planner_->histogram_image_);
 }
 
 void LocalPlannerNode::publishTree() {
@@ -652,7 +669,7 @@ void LocalPlannerNode::publishTree() {
   std::vector<TreeNode> tree;
   std::vector<int> closed_set;
 
-  local_planner_.getTree(tree, closed_set, path_node_positions_);
+  local_planner_->getTree(tree, closed_set, path_node_positions_);
 
   for (size_t i = 0; i < closed_set.size(); i++) {
     int node_nr = closed_set[i];
@@ -683,7 +700,7 @@ void LocalPlannerNode::clickedGoalCallback(
   goal_msg_ = msg;
   /* Selecting the goal from Rviz sets x and y. Get the z coordinate set in
    * the launch file */
-  goal_msg_.pose.position.z = local_planner_.getGoal().z;
+  goal_msg_.pose.position.z = local_planner_->getGoal().z;
 }
 
 void LocalPlannerNode::updateGoalCallback(
@@ -745,7 +762,7 @@ void LocalPlannerNode::publishGround() {
 }
 
 void LocalPlannerNode::printPointInfo(double x, double y, double z) {
-  geometry_msgs::PoseStamped drone_pos = local_planner_.getPosition();
+  geometry_msgs::PoseStamped drone_pos = local_planner_->getPosition();
   int beta_z = floor(
       (atan2(x - drone_pos.pose.position.x, y - drone_pos.pose.position.y) *
        180.0 / M_PI));  //(-180. +180]
@@ -778,11 +795,11 @@ void LocalPlannerNode::cameraInfoCallback(
   // v_fov = 2 * atan (image_height / (2 * focal_length_y))
   // Assumption: if there are n cameras the total horizonal field of view is n
   // times the horizontal field of view of a single camera
-  local_planner_.h_FOV_ = static_cast<double>(cameras_.size()) * 2.0 *
-                          atan(msg->width / (2.0 * msg->K[0])) * 180.0 / M_PI;
-  local_planner_.v_FOV_ =
+  local_planner_->h_FOV_ = static_cast<double>(cameras_.size()) * 2.0 *
+                           atan(msg->width / (2.0 * msg->K[0])) * 180.0 / M_PI;
+  local_planner_->v_FOV_ =
       2.0 * atan(msg->height / (2.0 * msg->K[4])) * 180.0 / M_PI;
-  wp_generator_.setFOV(local_planner_.h_FOV_, local_planner_.v_FOV_);
+  wp_generator_->setFOV(local_planner_->h_FOV_, local_planner_->v_FOV_);
 }
 
 void LocalPlannerNode::publishSetpoint(const geometry_msgs::Twist& wp,
@@ -916,7 +933,7 @@ void LocalPlannerNode::transformVelocityToTrajectory(
 
 void LocalPlannerNode::publishPlannerData() {
   pcl::PointCloud<pcl::PointXYZ> final_cloud, reprojected_points;
-  local_planner_.getCloudsForVisualization(final_cloud, reprojected_points);
+  local_planner_->getCloudsForVisualization(final_cloud, reprojected_points);
   local_pointcloud_pub_.publish(final_cloud);
   reprojected_points_pub_.publish(reprojected_points);
 
@@ -926,12 +943,12 @@ void LocalPlannerNode::publishPlannerData() {
 
   nav_msgs::GridCells path_candidates, path_selected, path_rejected,
       path_blocked, FOV_cells;
-  local_planner_.getCandidateDataForVisualization(
+  local_planner_->getCandidateDataForVisualization(
       path_candidates, path_selected, path_rejected, path_blocked, FOV_cells);
 
-  if (local_planner_.send_obstacles_fcu_) {
+  if (local_planner_->send_obstacles_fcu_) {
     sensor_msgs::LaserScan distance_data_to_fcu;
-    local_planner_.sendObstacleDistanceDataToFcu(distance_data_to_fcu);
+    local_planner_->sendObstacleDistanceDataToFcu(distance_data_to_fcu);
     mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
   }
 
@@ -949,9 +966,9 @@ void LocalPlannerNode::publishPlannerData() {
 void LocalPlannerNode::dynamicReconfigureCallback(
     avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
   std::lock_guard<std::mutex> guard(running_mutex_);
-  local_planner_.dynamicReconfigureSetParams(config, level);
-  wp_generator_.setMinJerkLimit(config.min_jerk_limit_);
-  wp_generator_.setMaxJerkLimit(config.max_jerk_limit_);
+  local_planner_->dynamicReconfigureSetParams(config, level);
+  wp_generator_->setMinJerkLimit(config.min_jerk_limit_);
+  wp_generator_->setMaxJerkLimit(config.max_jerk_limit_);
   rqt_param_config_ = config;
 }
 
@@ -970,7 +987,7 @@ void LocalPlannerNode::threadFunction() {
       std::lock_guard<std::mutex> guard(running_mutex_);
       never_run_ = false;
       std::clock_t start_time = std::clock();
-      local_planner_.runPlanner();
+      local_planner_->runPlanner();
       publishPlannerData();
 
       ROS_DEBUG("\033[0;35m[OA]Planner calculation time: %2.2f ms \n \033[0m",

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -259,8 +259,7 @@ void LocalPlannerNode::updatePlannerInfo() {
     local_planner_->ground_distance_ = ground_distance_msg_.bottom_clearance;
   } else {
     local_planner_->ground_distance_ = 2.0;  // in case where no range data is
-                                            // available assume vehicle is close
-                                            // to ground
+    // available assume vehicle is close to ground
   }
 }
 

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -1,13 +1,9 @@
 #ifndef LOCAL_PLANNER_LOCAL_PLANNER_NODE_H
 #define LOCAL_PLANNER_LOCAL_PLANNER_NODE_H
 
-#include <math.h>
-#include <atomic>
-#include <condition_variable>
-#include <iostream>
-#include <mutex>
-#include <string>
-#include <thread>
+#include "avoidance/common_ros.h"
+#include "avoidance_output.h"
+#include "rviz_world_loader.h"
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseArray.h>
@@ -28,20 +24,26 @@
 #include <sensor_msgs/Range.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float64.h>
+#include <std_msgs/String.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
 #include <Eigen/Core>
 #include <boost/bind.hpp>
-#include "std_msgs/String.h"
 
-#include "avoidance/common_ros.h"
-#include "local_planner.h"
-#include "planner_functions.h"
-#include "rviz_world_loader.h"
-#include "waypoint_generator.h"
+#include <dynamic_reconfigure/server.h>
+#include <local_planner/LocalPlannerNodeConfig.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
 
 namespace avoidance {
+
+class LocalPlanner;
+class WaypointGenerator;
 
 struct cameraData {
   std::string topic_;
@@ -99,8 +101,8 @@ class LocalPlannerNode {
   ros::Time last_wp_time_;
   ros::Time t_status_sent_;
 
-  LocalPlanner local_planner_;
-  WaypointGenerator wp_generator_;
+  std::unique_ptr<LocalPlanner> local_planner_;
+  std::unique_ptr<WaypointGenerator> wp_generator_;
 
   ros::Publisher world_pub_;
   ros::Publisher drone_pub_;

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -1,4 +1,6 @@
+#include "local_planner.h"
 #include "local_planner_node.h"
+#include "waypoint_generator.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -11,7 +13,7 @@ int main(int argc, char** argv) {
   bool hover = false;
   bool landing = false;
   avoidanceOutput planner_output;
-  Node.local_planner_.disable_rise_to_goal_altitude_ =
+  Node.local_planner_->disable_rise_to_goal_altitude_ =
       Node.disable_rise_to_goal_altitude_;
   bool startup = true;
   Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_BOOT;
@@ -39,9 +41,9 @@ int main(int argc, char** argv) {
     // Check if all information was received
     ros::Time now = ros::Time::now();
     ros::Duration pointcloud_timeout_land =
-        ros::Duration(Node.local_planner_.pointcloud_timeout_land_);
+        ros::Duration(Node.local_planner_->pointcloud_timeout_land_);
     ros::Duration pointcloud_timeout_hover =
-        ros::Duration(Node.local_planner_.pointcloud_timeout_hover_);
+        ros::Duration(Node.local_planner_->pointcloud_timeout_hover_);
     ros::Duration since_last_cloud = now - Node.last_wp_time_;
     ros::Duration since_start = now - start_time;
 
@@ -99,10 +101,10 @@ int main(int argc, char** argv) {
           for (size_t i = 0; i < Node.cameras_.size(); i++) {
             Node.cameras_[i].received_ = false;
           }
-          Node.wp_generator_.setPlannerInfo(
-              Node.local_planner_.getAvoidanceOutput());
-          if (Node.local_planner_.stop_in_front_active_) {
-            Node.goal_msg_.pose.position = Node.local_planner_.getGoal();
+          Node.wp_generator_->setPlannerInfo(
+              Node.local_planner_->getAvoidanceOutput());
+          if (Node.local_planner_->stop_in_front_active_) {
+            Node.goal_msg_.pose.position = Node.local_planner_->getGoal();
           }
           Node.running_mutex_.unlock();
           // Wake up the planner

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -121,11 +121,12 @@ void calculateFOV(double h_fov, double v_fov, std::vector<int>& z_FOV_idx,
 }
 
 // Build histogram estimate from reprojected points
-void propagateHistogram(Histogram& polar_histogram_est,
-                        const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
-                        const std::vector<double>& reprojected_points_age,
-                        const std::vector<double>& reprojected_points_dist,
-                        geometry_msgs::PoseStamped position) {
+void propagateHistogram(
+    Histogram& polar_histogram_est,
+    const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
+    const std::vector<double>& reprojected_points_age,
+    const std::vector<double>& reprojected_points_dist,
+    geometry_msgs::PoseStamped position) {
   for (size_t i = 0; i < reprojected_points.points.size(); i++) {
     float e_angle = elevationAnglefromCartesian(
         toEigen(reprojected_points.points[i]), toEigen(position.pose.position));

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -122,9 +122,9 @@ void calculateFOV(double h_fov, double v_fov, std::vector<int>& z_FOV_idx,
 
 // Build histogram estimate from reprojected points
 void propagateHistogram(Histogram& polar_histogram_est,
-                        pcl::PointCloud<pcl::PointXYZ> reprojected_points,
-                        std::vector<double> reprojected_points_age,
-                        std::vector<double> reprojected_points_dist,
+                        const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
+                        const std::vector<double>& reprojected_points_age,
+                        const std::vector<double>& reprojected_points_dist,
                         geometry_msgs::PoseStamped position) {
   for (size_t i = 0; i < reprojected_points.points.size(); i++) {
     float e_angle = elevationAnglefromCartesian(
@@ -201,8 +201,9 @@ void generateNewHistogram(Histogram& polar_histogram,
 
 // Combine propagated histogram and new histogram to the final binary histogram
 void combinedHistogram(bool& hist_empty, Histogram& new_hist,
-                       Histogram propagated_hist, bool waypoint_outside_FOV,
-                       std::vector<int> z_FOV_idx, int e_FOV_min,
+                       const Histogram& propagated_hist,
+                       bool waypoint_outside_FOV,
+                       const std::vector<int>& z_FOV_idx, int e_FOV_min,
                        int e_FOV_max) {
   hist_empty = true;
   for (int e = 0; e < GRID_LENGTH_E; e++) {
@@ -285,7 +286,8 @@ double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
   return cost;
 }
 
-void compressHistogramElevation(Histogram& new_hist, Histogram input_hist) {
+void compressHistogramElevation(Histogram& new_hist,
+                                const Histogram& input_hist) {
   int vertical_FOV_range_sensor = 20;
   int lower_index = elevationAngletoIndex(
       -(float)(vertical_FOV_range_sensor / 2.0), ALPHA_RES);
@@ -310,7 +312,7 @@ void findFreeDirections(
     const Histogram& histogram, double safety_radius,
     nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
     nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
-    nav_msgs::GridCells path_waypoints,
+    const nav_msgs::GridCells& path_waypoints,
     std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
     const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,
@@ -409,7 +411,7 @@ void findFreeDirections(
 
 // calculate the free direction which has the smallest cost for the UAV to
 // travel to
-bool calculateCostMap(std::vector<float> cost_path_candidates,
+bool calculateCostMap(const std::vector<float>& cost_path_candidates,
                       std::vector<int>& cost_idx_sorted) {
   if (cost_path_candidates.empty()) {
     ROS_WARN("\033[1;31mbold Empty candidates vector!\033[0m\n");

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -45,8 +45,8 @@ void filterPointCloud(
   float distance;
   counter_backoff = 0;
 
-  for (size_t i = 0; i < complete_cloud.size(); ++i) {
-    for (const pcl::PointXYZ& xyz : complete_cloud[i]) {
+  for (const auto& cloud : complete_cloud) {
+    for (const pcl::PointXYZ& xyz : cloud) {
       // Check if the point is invalid
       if (!std::isnan(xyz.x) && !std::isnan(xyz.y) && !std::isnan(xyz.z)) {
         if (histogram_box.isPointWithinBox(xyz.x, xyz.y, xyz.z)) {
@@ -126,7 +126,7 @@ void propagateHistogram(
     const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
     const std::vector<double>& reprojected_points_age,
     const std::vector<double>& reprojected_points_dist,
-    geometry_msgs::PoseStamped position) {
+    const geometry_msgs::PoseStamped& position) {
   for (size_t i = 0; i < reprojected_points.points.size(); i++) {
     float e_angle = elevationAnglefromCartesian(
         toEigen(reprojected_points.points[i]), toEigen(position.pose.position));

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -1,5 +1,9 @@
 #include "planner_functions.h"
 
+#include "common.h"
+
+#include <ros/console.h>
+
 #include <numeric>
 
 namespace avoidance {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -9,13 +9,13 @@
 namespace avoidance {
 
 // initialize GridCell message
-void initGridCells(nav_msgs::GridCells *cell) {
-  cell->cells.clear();
-  cell->header.stamp = ros::Time::now();
-  cell->header.frame_id = "/local_origin";
-  cell->cell_width = ALPHA_RES;
-  cell->cell_height = ALPHA_RES;
-  cell->cells = {};
+void initGridCells(nav_msgs::GridCells& cell) {
+  cell.cells.clear();
+  cell.header.stamp = ros::Time::now();
+  cell.header.frame_id = "/local_origin";
+  cell.cell_width = ALPHA_RES;
+  cell.cell_height = ALPHA_RES;
+  cell.cells = {};
 }
 
 // adapt histogram safety margin around blocked cells to distance of pointcloud
@@ -33,12 +33,12 @@ double adaptSafetyMarginHistogram(double dist_to_closest_point,
 // trim the point cloud so that only points inside the bounding box are
 // considered
 void filterPointCloud(
-    pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
-    Eigen::Vector3f &closest_point, double &distance_to_closest_point,
-    int &counter_backoff,
-    const std::vector<pcl::PointCloud<pcl::PointXYZ>> &complete_cloud,
+    pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
+    Eigen::Vector3f& closest_point, double& distance_to_closest_point,
+    int& counter_backoff,
+    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
     double min_cloud_size, double min_dist_backoff, Box histogram_box,
-    const Eigen::Vector3f &position, double min_realsense_dist) {
+    const Eigen::Vector3f& position, double min_realsense_dist) {
   cropped_cloud.points.clear();
   cropped_cloud.width = 0;
   distance_to_closest_point = HUGE_VAL;
@@ -46,7 +46,7 @@ void filterPointCloud(
   counter_backoff = 0;
 
   for (size_t i = 0; i < complete_cloud.size(); ++i) {
-    for (const pcl::PointXYZ &xyz : complete_cloud[i]) {
+    for (const pcl::PointXYZ& xyz : complete_cloud[i]) {
       // Check if the point is invalid
       if (!std::isnan(xyz.x) && !std::isnan(xyz.y) && !std::isnan(xyz.z)) {
         if (histogram_box.isPointWithinBox(xyz.x, xyz.y, xyz.z)) {
@@ -78,8 +78,8 @@ void filterPointCloud(
 }
 
 // Calculate FOV. Azimuth angle is wrapped, elevation is not!
-void calculateFOV(double h_fov, double v_fov, std::vector<int> &z_FOV_idx,
-                  int &e_FOV_min, int &e_FOV_max, double yaw, double pitch) {
+void calculateFOV(double h_fov, double v_fov, std::vector<int>& z_FOV_idx,
+                  int& e_FOV_min, int& e_FOV_max, double yaw, double pitch) {
   double z_FOV_max =
       std::round((-yaw * 180.0 / M_PI + h_fov / 2.0 + 270.0) / ALPHA_RES) - 1;
   double z_FOV_min =
@@ -121,7 +121,7 @@ void calculateFOV(double h_fov, double v_fov, std::vector<int> &z_FOV_idx,
 }
 
 // Build histogram estimate from reprojected points
-void propagateHistogram(Histogram &polar_histogram_est,
+void propagateHistogram(Histogram& polar_histogram_est,
                         pcl::PointCloud<pcl::PointXYZ> reprojected_points,
                         std::vector<double> reprojected_points_age,
                         std::vector<double> reprojected_points_dist,
@@ -168,8 +168,8 @@ void propagateHistogram(Histogram &polar_histogram_est,
 }
 
 // Generate new histogram from pointcloud
-void generateNewHistogram(Histogram &polar_histogram,
-                          const pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
+void generateNewHistogram(Histogram& polar_histogram,
+                          const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           geometry_msgs::PoseStamped position) {
   for (auto xyz : cropped_cloud) {
     Eigen::Vector3f p = toEigen(xyz);
@@ -200,7 +200,7 @@ void generateNewHistogram(Histogram &polar_histogram,
 }
 
 // Combine propagated histogram and new histogram to the final binary histogram
-void combinedHistogram(bool &hist_empty, Histogram &new_hist,
+void combinedHistogram(bool& hist_empty, Histogram& new_hist,
                        Histogram propagated_hist, bool waypoint_outside_FOV,
                        std::vector<int> z_FOV_idx, int e_FOV_min,
                        int e_FOV_max) {
@@ -236,10 +236,10 @@ void combinedHistogram(bool &hist_empty, Histogram &new_hist,
 }
 
 // costfunction for every free histogram cell
-double costFunction(int e, int z, const nav_msgs::GridCells &path_waypoints,
-                    const Eigen::Vector3f &goal,
-                    const Eigen::Vector3f &position,
-                    const Eigen::Vector3f &position_old, double goal_cost_param,
+double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
+                    const Eigen::Vector3f& goal,
+                    const Eigen::Vector3f& position,
+                    const Eigen::Vector3f& position_old, double goal_cost_param,
                     double smooth_cost_param,
                     double height_change_cost_param_adapted,
                     double height_change_cost_param, bool only_yawed) {
@@ -285,7 +285,7 @@ double costFunction(int e, int z, const nav_msgs::GridCells &path_waypoints,
   return cost;
 }
 
-void compressHistogramElevation(Histogram &new_hist, Histogram input_hist) {
+void compressHistogramElevation(Histogram& new_hist, Histogram input_hist) {
   int vertical_FOV_range_sensor = 20;
   int lower_index = elevationAngletoIndex(
       -(float)(vertical_FOV_range_sensor / 2.0), ALPHA_RES);
@@ -307,12 +307,12 @@ void compressHistogramElevation(Histogram &new_hist, Histogram input_hist) {
 // search for free directions in the 2D polar histogram with a moving window
 // approach
 void findFreeDirections(
-    const Histogram &histogram, double safety_radius,
-    nav_msgs::GridCells &path_candidates, nav_msgs::GridCells &path_selected,
-    nav_msgs::GridCells &path_rejected, nav_msgs::GridCells &path_blocked,
+    const Histogram& histogram, double safety_radius,
+    nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
+    nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
     nav_msgs::GridCells path_waypoints,
-    std::vector<float> &cost_path_candidates, const Eigen::Vector3f &goal,
-    const Eigen::Vector3f &position, const Eigen::Vector3f &position_old,
+    std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
+    const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,
     double height_change_cost_param_adapted, double height_change_cost_param,
     bool only_yawed, int resolution_alpha) {
@@ -325,10 +325,10 @@ void findFreeDirections(
   geometry_msgs::Point p;
   cost_path_candidates.clear();
 
-  initGridCells(&path_candidates);
-  initGridCells(&path_rejected);
-  initGridCells(&path_blocked);
-  initGridCells(&path_selected);
+  initGridCells(path_candidates);
+  initGridCells(path_rejected);
+  initGridCells(path_blocked);
+  initGridCells(path_selected);
 
   // determine which bins are candidates
   for (int e = 0; e < e_dim; e++) {
@@ -410,7 +410,7 @@ void findFreeDirections(
 // calculate the free direction which has the smallest cost for the UAV to
 // travel to
 bool calculateCostMap(std::vector<float> cost_path_candidates,
-                      std::vector<int> &cost_idx_sorted) {
+                      std::vector<int>& cost_idx_sorted) {
   if (cost_path_candidates.empty()) {
     ROS_WARN("\033[1;31mbold Empty candidates vector!\033[0m\n");
     return 1;
@@ -450,9 +450,9 @@ void printHistogram(Histogram hist, std::vector<int> z_FOV_idx, int e_FOV_min,
 }
 
 bool getDirectionFromTree(
-    Eigen::Vector3f &p,
-    const std::vector<geometry_msgs::Point> &path_node_positions,
-    const Eigen::Vector3f &position) {
+    Eigen::Vector3f& p,
+    const std::vector<geometry_msgs::Point>& path_node_positions,
+    const Eigen::Vector3f& position) {
   int size = path_node_positions.size();
   bool tree_available = true;
 

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -31,11 +31,12 @@ void filterPointCloud(
     const Eigen::Vector3f& position, double min_realsense_dist);
 void calculateFOV(double h_FOV, double v_FOV, std::vector<int>& z_FOV_idx,
                   int& e_FOV_min, int& e_FOV_max, double yaw, double pitch);
-void propagateHistogram(Histogram& polar_histogram_est,
-                        const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
-                        const std::vector<double>& reprojected_points_age,
-                        const std::vector<double>& reprojected_points_dist,
-                        geometry_msgs::PoseStamped position);
+void propagateHistogram(
+    Histogram& polar_histogram_est,
+    const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
+    const std::vector<double>& reprojected_points_age,
+    const std::vector<double>& reprojected_points_dist,
+    geometry_msgs::PoseStamped position);
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           geometry_msgs::PoseStamped position);

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -19,45 +19,45 @@
 
 namespace avoidance {
 
-void initGridCells(nav_msgs::GridCells *cell);
+void initGridCells(nav_msgs::GridCells& cell);
 double adaptSafetyMarginHistogram(double dist_to_closest_point,
                                   double cloud_size, double min_cloud_size);
 void filterPointCloud(
-    pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
-    Eigen::Vector3f &closest_point, double &distance_to_closest_point,
-    int &counter_backoff,
-    const std::vector<pcl::PointCloud<pcl::PointXYZ>> &complete_cloud,
+    pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
+    Eigen::Vector3f& closest_point, double& distance_to_closest_point,
+    int& counter_backoff,
+    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
     double min_cloud_size, double min_dist_backoff, Box histogram_box,
-    const Eigen::Vector3f &position, double min_realsense_dist);
-void calculateFOV(double h_FOV, double v_FOV, std::vector<int> &z_FOV_idx,
-                  int &e_FOV_min, int &e_FOV_max, double yaw, double pitch);
-void propagateHistogram(Histogram &polar_histogram_est,
+    const Eigen::Vector3f& position, double min_realsense_dist);
+void calculateFOV(double h_FOV, double v_FOV, std::vector<int>& z_FOV_idx,
+                  int& e_FOV_min, int& e_FOV_max, double yaw, double pitch);
+void propagateHistogram(Histogram& polar_histogram_est,
                         pcl::PointCloud<pcl::PointXYZ> reprojected_points,
                         std::vector<double> reprojected_points_age,
                         std::vector<double> reprojected_points_dist,
                         geometry_msgs::PoseStamped position);
-void generateNewHistogram(Histogram &polar_histogram,
-                          const pcl::PointCloud<pcl::PointXYZ> &cropped_cloud,
+void generateNewHistogram(Histogram& polar_histogram,
+                          const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           geometry_msgs::PoseStamped position);
-void combinedHistogram(bool &hist_empty, Histogram &new_hist,
+void combinedHistogram(bool& hist_empty, Histogram& new_hist,
                        Histogram propagated_hist, bool waypoint_outside_FOV,
                        std::vector<int> z_FOV_idx, int e_FOV_min,
                        int e_FOV_max);
-void compressHistogramElevation(Histogram &new_hist, Histogram input_hist);
-double costFunction(int e, int z, const nav_msgs::GridCells &path_waypoints,
-                    const Eigen::Vector3f &goal,
-                    const Eigen::Vector3f &position,
-                    const Eigen::Vector3f &position_old, double goal_cost_param,
+void compressHistogramElevation(Histogram& new_hist, Histogram input_hist);
+double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
+                    const Eigen::Vector3f& goal,
+                    const Eigen::Vector3f& position,
+                    const Eigen::Vector3f& position_old, double goal_cost_param,
                     double smooth_cost_param,
                     double height_change_cost_param_adapted,
                     double height_change_cost_param, bool only_yawed);
 void findFreeDirections(
-    const Histogram &histogram, double safety_radius,
-    nav_msgs::GridCells &path_candidates, nav_msgs::GridCells &path_selected,
-    nav_msgs::GridCells &path_rejected, nav_msgs::GridCells &path_blocked,
+    const Histogram& histogram, double safety_radius,
+    nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
+    nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
     nav_msgs::GridCells path_waypoints,
-    std::vector<float> &cost_path_candidates, const Eigen::Vector3f &goal,
-    const Eigen::Vector3f &position, const Eigen::Vector3f &position_old,
+    std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
+    const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,
     double height_change_cost_param_adapted, double height_change_cost_param,
     bool only_yawed, int resolution_alpha);
@@ -65,10 +65,10 @@ void printHistogram(Histogram hist, std::vector<int> z_FOV_idx, int e_FOV_min,
                     int e_FOV_max, int e_chosen, int z_chosen,
                     double resolution);
 bool calculateCostMap(std::vector<float> cost_path_candidates,
-                      std::vector<int> &cost_idx_sorted);
+                      std::vector<int>& cost_idx_sorted);
 bool getDirectionFromTree(
-    Eigen::Vector3f &p,
-    const std::vector<geometry_msgs::Point> &path_node_positions,
-    const Eigen::Vector3f &position);
+    Eigen::Vector3f& p,
+    const std::vector<geometry_msgs::Point>& path_node_positions,
+    const Eigen::Vector3f& position);
 }
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -1,44 +1,21 @@
 #ifndef LOCAL_PLANNER_FUNCTIONS_H
 #define LOCAL_PLANNER_FUNCTIONS_H
 
-#include <math.h>
-#include <Eigen/Dense>
-#include <deque>
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <string>
-#include <vector>
-
-#include <tf/transform_listener.h>
-
 #include "box.h"
-#include "common.h"
 #include "histogram.h"
+
+#include <Eigen/Dense>
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Vector3Stamped.h>
 
-#include <pcl/ModelCoefficients.h>
-#include <pcl/filters/crop_box.h>
-#include <pcl/filters/extract_indices.h>
-#include <pcl/filters/statistical_outlier_removal.h>
-#include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <pcl/point_types.h>
-#include <pcl/sample_consensus/method_types.h>
-#include <pcl/sample_consensus/model_types.h>
-#include <pcl/sample_consensus/sac_model_perpendicular_plane.h>
-#include <pcl/segmentation/sac_segmentation.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-#include <pcl_ros/transforms.h>
 
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
+
+#include <vector>
 
 namespace avoidance {
 

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -36,7 +36,7 @@ void propagateHistogram(
     const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
     const std::vector<double>& reprojected_points_age,
     const std::vector<double>& reprojected_points_dist,
-    geometry_msgs::PoseStamped position);
+    const geometry_msgs::PoseStamped& position);
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           geometry_msgs::PoseStamped position);

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -32,18 +32,20 @@ void filterPointCloud(
 void calculateFOV(double h_FOV, double v_FOV, std::vector<int>& z_FOV_idx,
                   int& e_FOV_min, int& e_FOV_max, double yaw, double pitch);
 void propagateHistogram(Histogram& polar_histogram_est,
-                        pcl::PointCloud<pcl::PointXYZ> reprojected_points,
-                        std::vector<double> reprojected_points_age,
-                        std::vector<double> reprojected_points_dist,
+                        const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
+                        const std::vector<double>& reprojected_points_age,
+                        const std::vector<double>& reprojected_points_dist,
                         geometry_msgs::PoseStamped position);
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           geometry_msgs::PoseStamped position);
 void combinedHistogram(bool& hist_empty, Histogram& new_hist,
-                       Histogram propagated_hist, bool waypoint_outside_FOV,
-                       std::vector<int> z_FOV_idx, int e_FOV_min,
+                       const Histogram& propagated_hist,
+                       bool waypoint_outside_FOV,
+                       const std::vector<int>& z_FOV_idx, int e_FOV_min,
                        int e_FOV_max);
-void compressHistogramElevation(Histogram& new_hist, Histogram input_hist);
+void compressHistogramElevation(Histogram& new_hist,
+                                const Histogram& input_hist);
 double costFunction(int e, int z, const nav_msgs::GridCells& path_waypoints,
                     const Eigen::Vector3f& goal,
                     const Eigen::Vector3f& position,
@@ -55,7 +57,7 @@ void findFreeDirections(
     const Histogram& histogram, double safety_radius,
     nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
     nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
-    nav_msgs::GridCells path_waypoints,
+    const nav_msgs::GridCells& path_waypoints,
     std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
     const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
     double goal_cost_param, double smooth_cost_param,
@@ -64,7 +66,7 @@ void findFreeDirections(
 void printHistogram(Histogram hist, std::vector<int> z_FOV_idx, int e_FOV_min,
                     int e_FOV_max, int e_chosen, int z_chosen,
                     double resolution);
-bool calculateCostMap(std::vector<float> cost_path_candidates,
+bool calculateCostMap(const std::vector<float>& cost_path_candidates,
                       std::vector<int>& cost_idx_sorted);
 bool getDirectionFromTree(
     Eigen::Vector3f& p,

--- a/local_planner/src/nodes/rviz_world_loader.cpp
+++ b/local_planner/src/nodes/rviz_world_loader.cpp
@@ -1,5 +1,7 @@
 #include "rviz_world_loader.h"
 
+#include <ros/console.h>
+
 namespace avoidance {
 
 // extraction operators

--- a/local_planner/src/nodes/rviz_world_loader.h
+++ b/local_planner/src/nodes/rviz_world_loader.h
@@ -9,7 +9,7 @@
 #include "yaml-cpp/yaml.h"
 
 #include <geometry_msgs/PoseStamped.h>
-#include <ros/ros.h>
+
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -1,10 +1,8 @@
 #include "star_planner.h"
 
-
 #include "common.h"
 #include "planner_functions.h"
 #include "tree_node.h"
-
 
 #include <ros/console.h>
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -1,5 +1,13 @@
 #include "star_planner.h"
 
+
+#include "common.h"
+#include "planner_functions.h"
+#include "tree_node.h"
+
+
+#include <ros/console.h>
+
 namespace avoidance {
 
 StarPlanner::StarPlanner() : tree_age_(0) {}

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -1,57 +1,27 @@
 #ifndef STAR_PLANNER_H
 #define STAR_PLANNER_H
 
-#include <math.h>
-#include <vector>
+
 #include "box.h"
-#include "common.h"
 #include "histogram.h"
-#include "planner_functions.h"
-#include "tree_node.h"
 
-#include <math.h>
 #include <Eigen/Dense>
-#include <deque>
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <string>
-#include <vector>
 
-#include <ros/ros.h>
-
-#include <pcl/ModelCoefficients.h>
-#include <pcl/filters/crop_box.h>
-#include <pcl/filters/extract_indices.h>
-#include <pcl/filters/statistical_outlier_removal.h>
-#include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <pcl/point_types.h>
-#include <pcl/sample_consensus/method_types.h>
-#include <pcl/sample_consensus/model_types.h>
-#include <pcl/sample_consensus/sac_model_perpendicular_plane.h>
-#include <pcl/segmentation/sac_segmentation.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
-#include <pcl_ros/transforms.h>
-
-#include <tf/transform_listener.h>
-
-#include <sensor_msgs/PointCloud2.h>
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Vector3Stamped.h>
 
 #include <nav_msgs/GridCells.h>
-#include <nav_msgs/Path.h>
 
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
 
+#include <vector>
+
 namespace avoidance {
+class TreeNode;
 
 class StarPlanner {
   double h_FOV_ = 59.0;

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -1,7 +1,6 @@
 #ifndef STAR_PLANNER_H
 #define STAR_PLANNER_H
 
-
 #include "box.h"
 #include "histogram.h"
 

--- a/local_planner/src/nodes/tree_node.h
+++ b/local_planner/src/nodes/tree_node.h
@@ -1,8 +1,7 @@
 #ifndef TREE_NODE_H
 #define TREE_NODE_H
 
-#include <math.h>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <vector>
 
 namespace avoidance {

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -1,5 +1,10 @@
 #include "waypoint_generator.h"
 
+#include "common.h"
+#include "planner_functions.h"
+
+#include <tf/transform_listener.h>
+
 namespace avoidance {
 
 WaypointGenerator::WaypointGenerator() {}

--- a/local_planner/src/nodes/waypoint_generator.h
+++ b/local_planner/src/nodes/waypoint_generator.h
@@ -1,25 +1,18 @@
 #ifndef WAYPOINT_GENERATOR_H
 #define WAYPOINT_GENERATOR_H
 
-#include <math.h>
+#include "avoidance_output.h"
+
 #include <Eigen/Dense>
-#include <chrono>
-#include <fstream>
-#include <iostream>
-#include <limits>
-#include <string>
-#include <vector>
-
-#include <ros/ros.h>
-
-#include "common.h"
-#include "local_planner.h"
-#include "planner_functions.h"
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Twist.h>
-#include <geometry_msgs/Vector3Stamped.h>
+#include <geometry_msgs/TwistStamped.h>
+
+#include <ros/time.h>
+
+#include <string>
+#include <vector>
 
 namespace avoidance {
 

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "../src/nodes/planner_functions.h"
+#include "../src/nodes/common.h"
 
 using namespace avoidance;
 

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "../src/nodes/planner_functions.h"
+
 #include "../src/nodes/common.h"
 
 using namespace avoidance;


### PR DESCRIPTION
Reduce the number of un-needed includes and chained dependencies, which should help to keep compile times reasonable as the codebase grows.

I also pulled the output from the local planner into a separate file so that not everything depends on the local planner when it doesn't need to.