### PR TITLE
Reduce RS frame rate in auto-generated launch file

### DIFF
--- a/local_planner/launch/local_planner_A700_1cam.launch
+++ b/local_planner/launch/local_planner_A700_1cam.launch
@@ -1,30 +1,20 @@
 <launch>
-
-
     <arg name="mavros_transformation" default="0" />
-    
-    <param name="use_sim_time" value="false" />
-
-    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
-          args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
-    <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
-          args="0.30 0.32 -0.11 0 0.052 0 fcu front_camera_link 10"/>
-                
-    <arg name="headless" default="false"/>
     <arg name="ns" default="/"/>
-    <arg name="build" default="px4_sitl_default"/>
     <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
     <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
-    <arg name="est" default="ekf2"/>
-    <arg name="serial_no_camera_front"    default="819112072871"/>
-    <arg name="serial_no_camera_down"    default="817512071697"/>
-    <arg name="serial_no_camera_left"    default="817612071531"/>
-    <arg name="serial_no_camera_right"    default="817512070752"/>
-    <arg name="depth_fps"            default="30"/>
-    <arg name="infra1_fps"           default="30"/>
-    <arg name="infra2_fps"           default="30"/>
+    <arg name="serial_no_front_camera" default="819112072871"/>
+    <arg name="depth_fps"  default="30"/>
+    <arg name="infra1_fps" default="30"/>
+    <arg name="infra2_fps" default="30"/>
+
+    <!-- Launch static transform publishers -->
+    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
+          args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
+          args="0.30 0.32 -0.11 0 0.052 0 fcu front_camera_link 10"/>
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">
@@ -39,33 +29,33 @@
         </include>
     </group>
 
-    <!-- Launch cameras -->  
+    <!-- Launch cameras -->
     <include file="$(find local_planner)/launch/rs_depthcloud.launch">
-      <arg name="namespace"             value="camera_front" />
+      <arg name="namespace"             value="front_camera" />
       <arg name="tf_prefix"             value="front_camera" />
-      <arg name="serial_no"             value="$(arg serial_no_camera_front)"/>
-    
+      <arg name="serial_no"             value="$(arg serial_no_front_camera)"/>
+
       <arg name="depth_fps"             value="$(arg depth_fps)"/>
       <arg name="infra1_fps"            value="$(arg infra1_fps)"/>
       <arg name="infra2_fps"            value="$(arg infra2_fps)"/>
 
-      <arg name="enable_pointcloud"     value="false"/>      
+      <arg name="enable_pointcloud"     value="false"/>
       <arg name="enable_imu"            value="false"/>
       <arg name="enable_fisheye"        value="false"/>
     </include>
-  
+
     <!-- Launch avoidance -->
     <env name="ROSCONSOLE_CONFIG_FILE" value="$(find local_planner)/resource/custom_rosconsole.conf"/>
     <rosparam command="load" file="$(find local_planner)/cfg/params.yaml"/>
-    <arg name="pointcloud_topics" default="[/camera_front/depth/points]"/>
+    <arg name="pointcloud_topics" default="[/front_camera/depth/points]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
+      <param name="goal_x_param" value="0" />
+      <param name="goal_y_param" value="0"/>
       <param name="goal_z_param" value="4" />
-      <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
+      <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
     </node>
-  
+
     <!-- switch off and on auto exposure of Realsense cameras, as it does not work on startup -->
     <node name="set_RS_param" pkg="local_planner" type="realsense_params.sh" />
 

--- a/local_planner/launch/local_planner_A700_3cam.launch
+++ b/local_planner/launch/local_planner_A700_3cam.launch
@@ -1,10 +1,19 @@
 <launch>
+    <arg name="mavros_transformation"  default="0" />
+    <arg name="ns"                     default="/"/>
+    <arg name="fcu_url"                default="udp://:14540@localhost:14557"/>
+    <arg name="gcs_url"                default="" />
+    <arg name="tgt_system"             default="1" />
+    <arg name="tgt_component"          default="1" />
+    <arg name="serial_no_front_camera" default="819112072871"/>
+    <arg name="serial_no_down_camera"  default="817512071697"/>
+    <arg name="serial_no_left_camera"  default="817512070752"/>
+    <arg name="serial_no_right_camera" default="817612070347"/>
+    <arg name="depth_fps"              default="30"/>
+    <arg name="infra1_fps"             default="30"/>
+    <arg name="infra2_fps"             default="30"/>
 
-
-    <arg name="mavros_transformation" default="0" />
-    
-    <param name="use_sim_time" value="false" />
-
+    <!-- Launch static transform publishers -->
     <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
           args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
@@ -15,22 +24,6 @@
           args="0.15 0.74 -0.11 1.3 0 3.14159 fcu left_camera_link 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_left_camera_rotated"
           args="0 0 0 3.1415 0 0 left_camera_color_optical_frame left_camera_rotated_link 10"/>
-                  
-    <arg name="headless" default="false"/>
-    <arg name="ns" default="/"/>
-    <arg name="build" default="px4_sitl_default"/>
-    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
-    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
-    <arg name="tgt_system" default="1" />
-    <arg name="tgt_component" default="1" />
-    <arg name="est" default="ekf2"/>
-    <arg name="serial_no_camera_front"    default="819112072871"/>
-    <arg name="serial_no_camera_down"    default="817512071697"/>
-    <arg name="serial_no_camera_left"    default="817512070752"/>
-    <arg name="serial_no_camera_right"    default="817612070347"/>
-    <arg name="depth_fps"            default="30"/>
-    <arg name="infra1_fps"           default="30"/>
-    <arg name="infra2_fps"           default="30"/>
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">
@@ -47,43 +40,43 @@
 
     <!-- Launch cameras -->
     <include file="$(find local_planner)/launch/rs_depthcloud.launch">
-      <arg name="namespace"             value="camera_front" />
+      <arg name="namespace"             value="front_camera" />
       <arg name="tf_prefix"             value="front_camera" />
-      <arg name="serial_no"             value="$(arg serial_no_camera_front)"/>
-    
+      <arg name="serial_no"             value="$(arg serial_no_front_camera)"/>
+
       <arg name="depth_fps"             value="$(arg depth_fps)"/>
       <arg name="infra1_fps"            value="$(arg infra1_fps)"/>
       <arg name="infra2_fps"            value="$(arg infra2_fps)"/>
 
-      <arg name="enable_pointcloud"     value="false"/>      
+      <arg name="enable_pointcloud"     value="false"/>
       <arg name="enable_imu"            value="false"/>
       <arg name="enable_fisheye"        value="false"/>
     </include>
-  
+
     <include file="$(find local_planner)/launch/rs_depthcloud.launch">
-      <arg name="namespace"             value="camera_right" />
+      <arg name="namespace"             value="right_camera" />
       <arg name="tf_prefix"             value="right_camera" />
-      <arg name="serial_no"             value="$(arg serial_no_camera_right)"/>
-    
+      <arg name="serial_no"             value="$(arg serial_no_right_camera)"/>
+
       <arg name="depth_fps"             value="$(arg depth_fps)"/>
       <arg name="infra1_fps"            value="$(arg infra1_fps)"/>
       <arg name="infra2_fps"            value="$(arg infra2_fps)"/>
 
-      <arg name="enable_pointcloud"     value="false"/>      
+      <arg name="enable_pointcloud"     value="false"/>
       <arg name="enable_imu"            value="false"/>
       <arg name="enable_fisheye"        value="false"/>
     </include>
-  
+
     <include file="$(find local_planner)/launch/rs_depthcloud.launch">
-      <arg name="namespace"             value="camera_left" />
+      <arg name="namespace"             value="left_camera" />
       <arg name="tf_prefix"             value="left_camera" />
-      <arg name="serial_no"             value="$(arg serial_no_camera_left)"/>
-    
+      <arg name="serial_no"             value="$(arg serial_no_left_camera)"/>
+
       <arg name="depth_fps"             value="$(arg depth_fps)"/>
       <arg name="infra1_fps"            value="$(arg infra1_fps)"/>
       <arg name="infra2_fps"            value="$(arg infra2_fps)"/>
 
-      <arg name="enable_pointcloud"     value="false"/>      
+      <arg name="enable_pointcloud"     value="false"/>
       <arg name="enable_imu"            value="false"/>
       <arg name="enable_fisheye"        value="false"/>
     </include>
@@ -91,15 +84,15 @@
     <!-- Launch avoidance -->
     <env name="ROSCONSOLE_CONFIG_FILE" value="$(find local_planner)/resource/custom_rosconsole.conf"/>
     <rosparam command="load" file="$(find local_planner)/cfg/params.yaml"/>
-    <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
+    <arg name="pointcloud_topics" default="[/front_camera/depth/points,/left_camera/depth/points,/right_camera/depth/points]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
+      <param name="goal_x_param" value="0" />
+      <param name="goal_y_param" value="0"/>
       <param name="goal_z_param" value="4" />
-      <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam> 
+      <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
     </node>
-    
+
     <!-- switch off and on auto exposure of Realsense cameras, as it does not work on startup -->
     <node name="set_RS_param" pkg="local_planner" type="realsense_params.sh" />
 

--- a/local_planner/launch/local_planner_aero.launch
+++ b/local_planner/launch/local_planner_aero.launch
@@ -1,28 +1,17 @@
 <launch>
-
-
     <arg name="mavros_transformation" default="0" />
-    
-    <param name="use_sim_time" value="false" />
+    <arg name="ns" default="/"/>
+    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
+    <arg name="tgt_system" default="1" />
+    <arg name="tgt_component" default="1" />
 
+    <!-- Launch static transform publishers -->
     <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
           args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 0 0 0 fcu camera_link 10"/>
-          
-          
-          
-    <arg name="headless" default="false"/>
-    <arg name="ns" default="/"/>
-    <arg name="build" default="px4_sitl_default"/>
-    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
-    <!-- <arg name="fcu_url" default="udp://:14547@localhost:14550"/> -->
-    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
-    <arg name="tgt_system" default="1" />
-    <arg name="tgt_component" default="1" />
-    <!--<arg name="mavros_transformation" default="-1.57" /> -->
-    <arg name="est" default="ekf2"/>
-    
+
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">
         <include file="$(find mavros)/launch/node.launch">
@@ -36,7 +25,7 @@
         </include>
     </group>
 
-  
+  <!-- Launch Realsense Camera -->
   <include file="$(find realsense_camera)/launch/r200_nodelet_rgbd.launch" >
   </include>
 
@@ -45,8 +34,8 @@
   <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
 
   <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-    <param name="goal_x_param" value="15" />
-    <param name="goal_y_param" value="15"/>
+    <param name="goal_x_param" value="0" />
+    <param name="goal_y_param" value="0"/>
     <param name="goal_z_param" value="4" />
     <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
   </node>

--- a/local_planner/launch/local_planner_aeroD415.launch
+++ b/local_planner/launch/local_planner_aeroD415.launch
@@ -1,15 +1,13 @@
 <launch>
+  <arg name="ns" default="/"/>
+  <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+  <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
+  <arg name="tgt_system" default="1" />
+  <arg name="tgt_component" default="1" />
 
-    <param name="use_sim_time" value="false" />
-
-    <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
+  <!-- Launch static transform publishers -->
+  <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 0 0 0 fcu camera_link 10"/>
-
-    <arg name="ns" default="/"/>
-    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
-    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
-    <arg name="tgt_system" default="1" />
-    <arg name="tgt_component" default="1" />
 
     <!-- Launch MavROS -->
     <group ns="$(arg ns)">
@@ -34,8 +32,8 @@
 
   <!-- Launch Local Planner -->
   <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-    <param name="goal_x_param" value="15" />
-    <param name="goal_y_param" value="15"/>
+    <param name="goal_x_param" value="0" />
+    <param name="goal_y_param" value="0"/>
     <param name="goal_z_param" value="4" />
     <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
   </node>

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -49,9 +49,9 @@ for camera in $CAMERA_CONFIGS; do
 				<arg name="namespace"             value="$1" />
 				<arg name="tf_prefix"             value="$1" />
 				<arg name="serial_no"             value="$2"/>
-				<arg name="depth_fps"             value="$CAMERA_FRAME_RATE"/>
-				<arg name="infra1_fps"            value="$CAMERA_FRAME_RATE"/>
-				<arg name="infra2_fps"            value="$CAMERA_FRAME_RATE"/>
+				<arg name="depth_fps"             value="$DEPTH_CAMERA_FRAME_RATE"/>
+				<arg name="infra1_fps"            value="$DEPTH_CAMERA_FRAME_RATE"/>
+				<arg name="infra2_fps"            value="$DEPTH_CAMERA_FRAME_RATE"/>
 				<arg name="enable_pointcloud"     value="false"/>
 				<arg name="enable_imu"            value="false"/>
 				<arg name="enable_fisheye"        value="false"/>

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -28,6 +28,11 @@ cat > local_planner/launch/avoidance.launch <<- EOM
     <!-- Launch cameras -->
 EOM
 
+# Set the frame rate to 15 if it is undefined
+if [ -z $DEPTH_CAMERA_FRAME_RATE ]; then
+  DEPTH_CAMERA_FRAME_RATE=15
+fi
+
 # The CAMERA_CONFIGS string has semi-colon separated camera configurations
 IFS=";"
 for camera in $CAMERA_CONFIGS; do

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -1,23 +1,16 @@
 #!/bin/bash
 cat > local_planner/launch/avoidance.launch <<- EOM
 <launch>
-
-
     <arg name="mavros_transformation" default="0" />
-
-    <param name="use_sim_time" value="false" />
-
-    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
-          args="0 0 0 \$(arg mavros_transformation) 0 0 world local_origin 10"/>
-
-    <arg name="headless" default="false"/>
     <arg name="ns" default="/"/>
-    <arg name="build" default="px4_sitl_default"/>
     <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
     <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
-    <arg name="est" default="ekf2"/>
+
+    <!-- Launch static tf publisher -->
+    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
+          args="0 0 0 \$(arg mavros_transformation) 0 0 world local_origin 10"/>
 
     <!-- Launch MavROS -->
     <group ns="\$(arg ns)">

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -67,8 +67,8 @@ cat >> local_planner/launch/avoidance.launch <<- EOM
     <arg name="pointcloud_topics" default="[$camera_topics]"/>
 
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen" >
-      <param name="goal_x_param" value="15" />
-      <param name="goal_y_param" value="15"/>
+      <param name="goal_x_param" value="0" />
+      <param name="goal_y_param" value="0"/>
       <param name="goal_z_param" value="4" />
       <rosparam param="pointcloud_topics" subst_value="True">\$(arg pointcloud_topics)</rosparam>
     </node>

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -18,9 +18,9 @@ cat > local_planner/launch/avoidance.launch <<- EOM
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="est" default="ekf2"/>
-    <arg name="depth_fps"            default="30"/>
-    <arg name="infra1_fps"           default="30"/>
-    <arg name="infra2_fps"           default="30"/>
+    <arg name="depth_fps"            default="15"/>
+    <arg name="infra1_fps"           default="15"/>
+    <arg name="infra2_fps"           default="15"/>
 
     <!-- Launch MavROS -->
     <group ns="\$(arg ns)">

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -18,9 +18,6 @@ cat > local_planner/launch/avoidance.launch <<- EOM
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
     <arg name="est" default="ekf2"/>
-    <arg name="depth_fps"            default="15"/>
-    <arg name="infra1_fps"           default="15"/>
-    <arg name="infra2_fps"           default="15"/>
 
     <!-- Launch MavROS -->
     <group ns="\$(arg ns)">
@@ -59,9 +56,9 @@ for camera in $CAMERA_CONFIGS; do
 				<arg name="namespace"             value="$1" />
 				<arg name="tf_prefix"             value="$1" />
 				<arg name="serial_no"             value="$2"/>
-				<arg name="depth_fps"             value="\$(arg depth_fps)"/>
-				<arg name="infra1_fps"            value="\$(arg infra1_fps)"/>
-				<arg name="infra2_fps"            value="\$(arg infra2_fps)"/>
+				<arg name="depth_fps"             value="$CAMERA_FRAME_RATE"/>
+				<arg name="infra1_fps"            value="$CAMERA_FRAME_RATE"/>
+				<arg name="infra2_fps"            value="$CAMERA_FRAME_RATE"/>
 				<arg name="enable_pointcloud"     value="false"/>
 				<arg name="enable_imu"            value="false"/>
 				<arg name="enable_fisheye"        value="false"/>


### PR DESCRIPTION
This PR cleans up some of the launch files. Particularly, it
- Changes the RealSense to be set by an environment variable in the auto-generated launch file
- While my PR for default goal removal is pending (#169) this PR at least changes it to the origin at 4m
altitude, as this is usually a reasonable take off point, while the 15/15/4 is quite random and frankly dangerous
- Removes unused SITL arguments from hardware launch files
- Some white space clean up and formatting