### PR TITLE
Cost matrix: distance dependent cost

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -36,6 +36,7 @@ gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, a
 gen.add("send_obstacles_fcu_", bool_t, 0, "Send 2D obstacle representation to the FCU", True)
 
 # star_planner
+gen.add("min_node_dist_to_obstacle_", double_t,    0, "minimal distance of every node to any obstacle", 2.0,  0, 10)
 gen.add("childs_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)
 gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 10,  0, 200)
 gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -36,7 +36,7 @@ gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, a
 gen.add("send_obstacles_fcu_", bool_t, 0, "Send 2D obstacle representation to the FCU", True)
 
 # star_planner
-gen.add("childs_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)
+gen.add("children_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)
 gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 10,  0, 200)
 gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)
 gen.add("tree_discount_factor_",    double_t,    0, "Discount factor in tree cost function", 0.8,  0, 1)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -36,7 +36,6 @@ gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, a
 gen.add("send_obstacles_fcu_", bool_t, 0, "Send 2D obstacle representation to the FCU", True)
 
 # star_planner
-gen.add("min_node_dist_to_obstacle_", double_t,    0, "minimal distance of every node to any obstacle", 2.0,  0, 10)
 gen.add("childs_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)
 gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 10,  0, 200)
 gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)

--- a/local_planner/src/nodes/candidate_direction.h
+++ b/local_planner/src/nodes/candidate_direction.h
@@ -3,11 +3,11 @@
 namespace avoidance {
 
 struct candidateDirection {
-  double cost;
-  double elevation_angle;
-  double azimuth_angle;
+  float cost;
+  float elevation_angle;
+  float azimuth_angle;
 
-  candidateDirection(double c, double e, double z)
+  candidateDirection(float c, float e, float z)
       : cost(c), elevation_angle(e), azimuth_angle(z){};
 
   bool operator<(const candidateDirection& y) const { return cost < y.cost; }

--- a/local_planner/src/nodes/candidate_direction.h
+++ b/local_planner/src/nodes/candidate_direction.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace avoidance {
+
+struct candidateDirection {
+  double cost;
+  double elevation_angle;
+  double azimuth_angle;
+
+  candidateDirection(double c, double e, double z)
+      : cost(c), elevation_angle(e), azimuth_angle(z){};
+
+  bool operator<(const candidateDirection& y) const { return cost < y.cost; }
+
+  bool operator>(const candidateDirection& y) const { return cost > y.cost; }
+};
+}

--- a/local_planner/src/nodes/cost_parameters.h
+++ b/local_planner/src/nodes/cost_parameters.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace avoidance {
+
+struct costParameters {
+  float goal_cost_param = 2.f;
+  float smooth_cost_param = 1.5f;
+  float height_change_cost_param = 4.f;
+  float height_change_cost_param_adapted = 4.f;
+};
+}

--- a/local_planner/src/nodes/histogram.cpp
+++ b/local_planner/src/nodes/histogram.cpp
@@ -19,10 +19,8 @@ void Histogram::upsample() {
   resolution_ = resolution_ / 2;
   z_dim_ = 2 * z_dim_;
   e_dim_ = 2 * e_dim_;
-  Eigen::MatrixXi temp_age;
-  Eigen::MatrixXf temp_dist;
-  temp_age.resize(e_dim_, z_dim_);
-  temp_dist.resize(e_dim_, z_dim_);
+  Eigen::MatrixXi temp_age(e_dim_, z_dim_);
+  Eigen::MatrixXf temp_dist(e_dim_, z_dim_);
 
   for (int i = 0; i < e_dim_; ++i) {
     for (int j = 0; j < z_dim_; ++j) {

--- a/local_planner/src/nodes/histogram.cpp
+++ b/local_planner/src/nodes/histogram.cpp
@@ -3,9 +3,8 @@
 
 namespace avoidance {
 Histogram::Histogram(const int res)
-    : resolution_{res}, z_dim_{360 / resolution_}, e_dim_{180 / resolution_} {
-  age_.resize(e_dim_, z_dim_);
-  dist_.resize(e_dim_, z_dim_);
+    : resolution_{res}, z_dim_{360 / resolution_}, e_dim_{180 / resolution_},
+      age_(e_dim_, z_dim_), dist_(e_dim_, z_dim_){
   setZero();
 }
 
@@ -44,10 +43,8 @@ void Histogram::downsample() {
   resolution_ = 2 * resolution_;
   z_dim_ = z_dim_ / 2;
   e_dim_ = e_dim_ / 2;
-  Eigen::MatrixXi temp_age;
-  Eigen::MatrixXf temp_dist;
-  temp_age.resize(e_dim_, z_dim_);
-  temp_dist.resize(e_dim_, z_dim_);
+  Eigen::MatrixXi temp_age(e_dim_, z_dim_);
+  Eigen::MatrixXf temp_dist(e_dim_, z_dim_);
 
   for (int i = 0; i < e_dim_; ++i) {
     for (int j = 0; j < z_dim_; ++j) {

--- a/local_planner/src/nodes/histogram.cpp
+++ b/local_planner/src/nodes/histogram.cpp
@@ -12,9 +12,10 @@ Histogram::Histogram(const int res)
 Histogram::~Histogram() {}
 
 void Histogram::upsample() {
-
-  if(resolution_ != ALPHA_RES * 2){
-	 throw std::logic_error("Invalid use of function upsample(). This function can only be used on a half resolution histogram.");
+  if (resolution_ != ALPHA_RES * 2) {
+    throw std::logic_error(
+        "Invalid use of function upsample(). This function can only be used on "
+        "a half resolution histogram.");
   }
   resolution_ = resolution_ / 2;
   z_dim_ = 2 * z_dim_;
@@ -35,8 +36,10 @@ void Histogram::upsample() {
 }
 
 void Histogram::downsample() {
-  if(resolution_ != ALPHA_RES){
-	 throw std::logic_error("Invalid use of function downsample(). This function can only be used on a full resolution histogram.");
+  if (resolution_ != ALPHA_RES) {
+    throw std::logic_error(
+        "Invalid use of function downsample(). This function can only be used "
+        "on a full resolution histogram.");
   }
   resolution_ = 2 * resolution_;
   z_dim_ = z_dim_ / 2;

--- a/local_planner/src/nodes/histogram.cpp
+++ b/local_planner/src/nodes/histogram.cpp
@@ -50,20 +50,8 @@ void Histogram::downsample() {
     for (int j = 0; j < z_dim_; ++j) {
       int i_high_res = 2 * i;
       int j_high_res = 2 * j;
-
-      float mean_age =
-          (age_(i_high_res, j_high_res) + age_(i_high_res + 1, j_high_res) +
-           age_(i_high_res, j_high_res + 1) +
-           age_(i_high_res + 1, j_high_res + 1)) /
-          4.f;
-      double mean_dist =
-          (dist_(i_high_res, j_high_res) + dist_(i_high_res + 1, j_high_res) +
-           dist_(i_high_res, j_high_res + 1) +
-           dist_(i_high_res + 1, j_high_res + 1)) /
-          4.f;
-
-      temp_age(i, j) = static_cast<int>(mean_age);
-      temp_dist(i, j) = mean_dist;
+      temp_age(i, j) = static_cast<int>(age_.block(i_high_res, j_high_res, 2, 2).mean());
+      temp_dist(i, j) = dist_.block(i_high_res, j_high_res, 2, 2).mean();
     }
   }
   age_ = temp_age;

--- a/local_planner/src/nodes/histogram.h
+++ b/local_planner/src/nodes/histogram.h
@@ -2,10 +2,14 @@
 #define HISTOGRAM_H
 
 #include <math.h>
+#include <Eigen/Dense>
 #include <vector>
 
 namespace avoidance {
 
+// Be very careful choosing the resolution! Valid resolutions must fullfill: 180
+// % (2 * ALPHA_RES) = 0
+// Examples of valid resolution values: 1, 3, 5, 6, 10, 15, 18, 30, 45, 60
 const int ALPHA_RES = 6;
 const int GRID_LENGTH_Z = 360 / ALPHA_RES;
 const int GRID_LENGTH_E = 180 / ALPHA_RES;
@@ -13,44 +17,54 @@ const double H_FOV = 59.0;
 const double V_FOV = 46.0;
 
 class Histogram {
-  int resolution;
-  int z_dim;
-  int e_dim;
-  std::vector<std::vector<double> > bin;
-  std::vector<std::vector<double> > age;
-  std::vector<std::vector<double> > dist;
+  int resolution_;
+  int z_dim_;
+  int e_dim_;
+  Eigen::MatrixXi age_;
+  Eigen::MatrixXf dist_;
 
   inline void wrapIndex(int &x, int &y) const {
-    while (x < 0) x += e_dim;
-    while (x > e_dim - 1) x -= e_dim;
-    while (y < 0) y += z_dim;
-    while (y > z_dim - 1) y -= z_dim;
+    while (x < 0) x += e_dim_;
+    while (x > e_dim_ - 1) x -= e_dim_;
+    while (y < 0) y += z_dim_;
+    while (y > z_dim_ - 1) y -= z_dim_;
   }
 
  public:
   Histogram(const int res);
   ~Histogram();
 
-  inline double get_bin(int x, int y) const {
+  inline int get_age(int x, int y) const {
     wrapIndex(x, y);
-    return bin[x][y];
+    return age_(x, y);
   }
 
-  inline double get_age(int x, int y) const {
+  inline float get_dist(int x, int y) const {
     wrapIndex(x, y);
-    return age[x][y];
+    return dist_(x, y);
   }
 
-  inline double get_dist(int x, int y) const {
-    wrapIndex(x, y);
-    return dist[x][y];
-  }
+  inline void set_age(int x, int y, int value) { age_(x, y) = value; }
+  inline void set_dist(int x, int y, float value) { dist_(x, y) = value; }
 
-  inline void set_bin(int x, int y, double value) { bin[x][y] = value; }
-  inline void set_age(int x, int y, double value) { age[x][y] = value; }
-  inline void set_dist(int x, int y, double value) { dist[x][y] = value; }
-
+  /**
+  * @brief     Compute the upsampled version of the histogram
+  * @param[in] This object. Needs to be a histogram the larger bin size (ALPHA_RES * 2)
+  * @details   The histogram is upsampled to get the same histogram at regular bin size (ALPHA_RES).
+  *            This means the histogram matrix will be double the size in each dimension
+  * @returns   Modifies the object it is called from to have regular resolution
+  * @warning   Can only be called from a large bin size histogram
+  **/
   void upsample();
+
+  /**
+  * @brief     Compute the downsampled version of the histogram
+  * @param[in] this object. Needs to be a histogram with regular bin size (ALPHA_RES)
+  * @details   The histogram is downsampled to get the same histogram at larger bin size (ALPHA_RES/2).
+  *            This means the histogram matrix will be half the size in each dimension
+  * @returns   Modifies the object it is called from to have larger bins
+  * @warning   Can only be called from a regular bin size histogram
+  **/
   void downsample();
   void setZero();
 };

--- a/local_planner/src/nodes/histogram.h
+++ b/local_planner/src/nodes/histogram.h
@@ -7,8 +7,8 @@
 
 namespace avoidance {
 
-// Be very careful choosing the resolution! Valid resolutions must fullfill: 180
-// % (2 * ALPHA_RES) = 0
+// Be very careful choosing the resolution! Valid resolutions must fullfill:
+// 180 % (2 * ALPHA_RES) = 0
 // Examples of valid resolution values: 1, 3, 5, 6, 10, 15, 18, 30, 45, 60
 const int ALPHA_RES = 6;
 const int GRID_LENGTH_Z = 360 / ALPHA_RES;

--- a/local_planner/src/nodes/histogram.h
+++ b/local_planner/src/nodes/histogram.h
@@ -49,9 +49,12 @@ class Histogram {
 
   /**
   * @brief     Compute the upsampled version of the histogram
-  * @param[in] This object. Needs to be a histogram the larger bin size (ALPHA_RES * 2)
-  * @details   The histogram is upsampled to get the same histogram at regular bin size (ALPHA_RES).
-  *            This means the histogram matrix will be double the size in each dimension
+  * @param[in] This object. Needs to be a histogram the larger bin size
+  *(ALPHA_RES * 2)
+  * @details   The histogram is upsampled to get the same histogram at regular
+  *bin size (ALPHA_RES).
+  *            This means the histogram matrix will be double the size in each
+  *dimension
   * @returns   Modifies the object it is called from to have regular resolution
   * @warning   Can only be called from a large bin size histogram
   **/
@@ -59,9 +62,12 @@ class Histogram {
 
   /**
   * @brief     Compute the downsampled version of the histogram
-  * @param[in] this object. Needs to be a histogram with regular bin size (ALPHA_RES)
-  * @details   The histogram is downsampled to get the same histogram at larger bin size (ALPHA_RES/2).
-  *            This means the histogram matrix will be half the size in each dimension
+  * @param[in] this object. Needs to be a histogram with regular bin size
+  *(ALPHA_RES)
+  * @details   The histogram is downsampled to get the same histogram at larger
+  *bin size (ALPHA_RES/2).
+  *            This means the histogram matrix will be half the size in each
+  *dimension
   * @returns   Modifies the object it is called from to have larger bins
   * @warning   Can only be called from a regular bin size histogram
   **/

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -132,7 +132,7 @@ void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
   to_fcu_histogram_.setZero();
 
   propagateHistogram(propagated_histogram, reprojected_points_,
-                     reprojected_points_age_, pose_);
+                     reprojected_points_age_, toEigen(pose_.pose.position));
   generateNewHistogram(new_histogram, final_cloud_,
                        toEigen(pose_.pose.position));
   combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -57,7 +57,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
   min_dist_backoff_ = config.min_dist_backoff_;
   pointcloud_timeout_hover_ = config.pointcloud_timeout_hover_;
   pointcloud_timeout_land_ = config.pointcloud_timeout_land_;
-  childs_per_node_ = config.childs_per_node_;
+  children_per_node_ = config.children_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
   tree_node_distance_ = config.tree_node_distance_;
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -248,7 +248,7 @@ void LocalPlanner::determineStrategy() {
              e < goal_index.y() + relevance_margin_e_cells; e++) {
           for (int z = goal_index.x() - relevance_margin_z_cells;
                z < goal_index.x() + relevance_margin_z_cells; z++) {
-            if (polar_histogram_.get_dist(e, z) > 0.001) {
+            if (polar_histogram_.get_dist(e, z) > FLT_MIN) {
             	n_occupied_cells++;
             }
           }
@@ -379,7 +379,7 @@ void LocalPlanner::reprojectPoints(Histogram histogram) {
 
   for (int e = 0; e < GRID_LENGTH_E; e++) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
-      if (histogram.get_dist(e, z) > 0.001f) {
+      if (histogram.get_dist(e, z) > FLT_MIN) {
         n_points++;
         for (auto &i : p_pol) {
           i.r = histogram.get_dist(e, z);

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -249,7 +249,7 @@ void LocalPlanner::determineStrategy() {
           for (int z = goal_index.x() - relevance_margin_z_cells;
                z < goal_index.x() + relevance_margin_z_cells; z++) {
             if (polar_histogram_.get_dist(e, z) > FLT_MIN) {
-            	n_occupied_cells++;
+              n_occupied_cells++;
             }
           }
         }

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -109,7 +109,7 @@ class LocalPlanner {
 
   Histogram polar_histogram_ = Histogram(ALPHA_RES);
   Histogram to_fcu_histogram_ = Histogram(ALPHA_RES);
-  Eigen::MatrixXd cost_matrix_;
+  Eigen::MatrixXf cost_matrix_;
   std::vector<candidateDirection> candidate_vector_;
 
   void fitPlane();

--- a/local_planner/src/nodes/local_planner.h
+++ b/local_planner/src/nodes/local_planner.h
@@ -57,7 +57,7 @@ class LocalPlanner {
   size_t dist_incline_window_size_ = 50;
   int origin_;
   int tree_age_ = 0;
-  int childs_per_node_;
+  int children_per_node_;
   int n_expanded_nodes_;
   int reproj_age_;
   int counter_close_points_backoff_ = 0;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -33,7 +33,7 @@ LocalPlannerNode::LocalPlannerNode() {
   // disable memory if using more than one camera
   if (cameras_.size() > 1) {
     config_mutex_.lock();
-    rqt_param_config_.reproj_age_ = 0;
+    rqt_param_config_.reproj_age_ = std::min(10, rqt_param_config_.reproj_age_);
     config_mutex_.unlock();
     server_->updateConfig(rqt_param_config_);
     dynamicReconfigureCallback(rqt_param_config_, 1);

--- a/local_planner/src/nodes/local_planner_node.h
+++ b/local_planner/src/nodes/local_planner_node.h
@@ -168,11 +168,6 @@ class LocalPlannerNode {
   ros::Publisher marker_pub_;
   ros::Publisher path_actual_pub_;
   ros::Publisher path_waypoint_pub_;
-  ros::Publisher marker_rejected_pub_;
-  ros::Publisher marker_blocked_pub_;
-  ros::Publisher marker_candidates_pub_;
-  ros::Publisher marker_selected_pub_;
-  ros::Publisher marker_FOV_pub_;
   ros::Publisher marker_goal_pub_;
   ros::Publisher takeoff_pose_pub_;
   ros::Publisher offboard_pose_pub_;
@@ -205,14 +200,6 @@ class LocalPlannerNode {
   void readParams();
   void publishPlannerData();
   void publishPaths();
-  void initMarker(visualization_msgs::MarkerArray* marker,
-                  nav_msgs::GridCells& path, const float red, const float green,
-                  const float blue);
-  void publishMarkerBlocked(nav_msgs::GridCells& path_blocked);
-  void publishMarkerRejected(nav_msgs::GridCells& path_rejected);
-  void publishMarkerCandidates(nav_msgs::GridCells& path_candidates);
-  void publishMarkerSelected(nav_msgs::GridCells& path_selected);
-  void publishMarkerFOV(nav_msgs::GridCells& FOV_cells);
   void clickedPointCallback(const geometry_msgs::PointStamped& msg);
   void clickedGoalCallback(const geometry_msgs::PoseStamped& msg);
   void updateGoalCallback(const visualization_msgs::MarkerArray& msg);

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -111,18 +111,28 @@ void propagateHistogram(
     PolarPoint p_pol = cartesianToPolar(toEigen(reprojected_points.points[i]),
                                         toEigen(position.pose.position));
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, 2 * ALPHA_RES);
-    float point_distance = (toEigen(position.pose.position) - toEigen(reprojected_points.points[i])).norm();
+    float point_distance = (toEigen(position.pose.position) -
+                            toEigen(reprojected_points.points[i]))
+                               .norm();
 
     counter(p_ind.y(), p_ind.x()) += 1;
-    polar_histogram_est.set_age(p_ind.y(), p_ind.x(), polar_histogram_est.get_age(p_ind.y(), p_ind.x()) + reprojected_points_age[i]);
-    polar_histogram_est.set_dist(p_ind.y(), p_ind.x(), polar_histogram_est.get_dist(p_ind.y(), p_ind.x()) + point_distance);
+    polar_histogram_est.set_age(
+        p_ind.y(), p_ind.x(),
+        polar_histogram_est.get_age(p_ind.y(), p_ind.x()) +
+            reprojected_points_age[i]);
+    polar_histogram_est.set_dist(
+        p_ind.y(), p_ind.x(),
+        polar_histogram_est.get_dist(p_ind.y(), p_ind.x()) + point_distance);
   }
 
   for (int e = 0; e < GRID_LENGTH_E / 2; e++) {
     for (int z = 0; z < GRID_LENGTH_Z / 2; z++) {
       if (counter(e, z) >= 6) {
-        polar_histogram_est.set_dist(e, z, polar_histogram_est.get_dist(e, z)/ counter(e, z));
-        polar_histogram_est.set_age(e, z, static_cast<int>(polar_histogram_est.get_age(e, z)/ counter(e,z)));
+        polar_histogram_est.set_dist(
+            e, z, polar_histogram_est.get_dist(e, z) / counter(e, z));
+        polar_histogram_est.set_age(
+            e, z, static_cast<int>(polar_histogram_est.get_age(e, z) /
+                                   counter(e, z)));
       } else {  // not enough points to confidently block cell
         polar_histogram_est.set_dist(e, z, 0.f);
         polar_histogram_est.set_age(e, z, 0);
@@ -147,8 +157,9 @@ void generateNewHistogram(Histogram& polar_histogram,
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES);
 
     counter(p_ind.y(), p_ind.x()) += 1;
-    polar_histogram.set_dist(p_ind.y(), p_ind.x(),
-                             polar_histogram.get_dist(p_ind.y(), p_ind.x()) + dist);
+    polar_histogram.set_dist(
+        p_ind.y(), p_ind.x(),
+        polar_histogram.get_dist(p_ind.y(), p_ind.x()) + dist);
   }
 
   // Normalize and get mean in distance bins
@@ -231,7 +242,8 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
   for (int e_index = 0; e_index < GRID_LENGTH_E; e_index++) {
     for (int z_index = 0; z_index < GRID_LENGTH_Z; z_index++) {
       float obstacle_distance = histogram.get_dist(e_index, z_index);
-      PolarPoint p_pol = histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
+      PolarPoint p_pol =
+          histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
       cost_matrix(e_index, z_index) =
           costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position,
                        last_sent_waypoint, cost_params, only_yawed);
@@ -255,7 +267,8 @@ void getBestCandidatesFromCostMatrix(
 
   for (int row_index = 0; row_index < matrix.rows(); row_index++) {
     for (int col_index = 0; col_index < matrix.cols(); col_index++) {
-      PolarPoint p_pol = histogramIndexToPolar(row_index, col_index, ALPHA_RES, 1.0);
+      PolarPoint p_pol =
+          histogramIndexToPolar(row_index, col_index, ALPHA_RES, 1.0);
       float cost = matrix(row_index, col_index);
       candidateDirection candidate(cost, p_pol.e, p_pol.z);
 
@@ -352,12 +365,12 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 
 // costfunction for every free histogram cell
 float costFunction(double e_angle, double z_angle, float obstacle_distance,
-                    const Eigen::Vector3f& goal,
-                    const Eigen::Vector3f& position,
-                    const Eigen::Vector3f& last_sent_waypoint,
-                    costParameters cost_params, bool only_yawed) {
+                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed) {
   PolarPoint p_pol(e_angle, z_angle, 1.0);
-  Eigen::Vector3f projected_candidate = polarToCartesian(p_pol, toPoint(position));
+  Eigen::Vector3f projected_candidate =
+      polarToCartesian(p_pol, toPoint(position));
   Eigen::Vector3f projected_goal = goal;
   Eigen::Vector3f projected_last_wp = last_sent_waypoint;
 
@@ -449,8 +462,8 @@ bool getDirectionFromTree(
       tree_available = false;
     } else if (wp_idx == 0) {
       if (size == 2) {
-    	p_pol = cartesianToPolar(toEigen(path_node_positions[0]), position);
-    	p_pol.r = 0.0;
+        p_pol = cartesianToPolar(toEigen(path_node_positions[0]), position);
+        p_pol.r = 0.0;
       } else {
         tree_available = false;
       }

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -191,7 +191,7 @@ void combinedHistogram(bool& hist_empty, Histogram& new_hist,
           hist_empty = false;
         }
         if (propagated_hist.get_dist(e, z) > 0 &&
-            new_hist.get_dist(e, z) < 0.001) {
+            new_hist.get_dist(e, z) < FLT_MIN) {
           new_hist.set_dist(e, z, propagated_hist.get_dist(e, z));
         }
       }
@@ -286,8 +286,8 @@ void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius) {
        row_index < matrix_padded.rows() - smoothing_radius; row_index++) {
     for (int col_index = smoothing_radius;
          col_index < matrix_padded.cols() - smoothing_radius; col_index++) {
-      double original_val = matrix_padded(row_index, col_index);
-      double mean_val =
+      float original_val = matrix_padded(row_index, col_index);
+      float mean_val =
           matrix_padded
               .block(row_index - smoothing_radius, col_index - smoothing_radius,
                      2 * smoothing_radius + 1, 2 * smoothing_radius + 1)

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -222,10 +222,10 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
-                   Eigen::MatrixXd& cost_matrix) {
+                   Eigen::MatrixXf& cost_matrix) {
   // reset cost matrix to zero
   cost_matrix.resize(GRID_LENGTH_E, GRID_LENGTH_Z);
-  cost_matrix.fill(0.0);
+  cost_matrix.fill(0.f);
 
   // fill in cost matrix
   for (int e_index = 0; e_index < GRID_LENGTH_E; e_index++) {
@@ -247,7 +247,7 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
 }
 
 void getBestCandidatesFromCostMatrix(
-    const Eigen::MatrixXd& matrix, unsigned int number_of_candidates,
+    const Eigen::MatrixXf& matrix, unsigned int number_of_candidates,
     std::vector<candidateDirection>& candidate_vector) {
   std::priority_queue<candidateDirection, std::vector<candidateDirection>,
                       std::less<candidateDirection>>
@@ -256,7 +256,7 @@ void getBestCandidatesFromCostMatrix(
   for (int row_index = 0; row_index < matrix.rows(); row_index++) {
     for (int col_index = 0; col_index < matrix.cols(); col_index++) {
       PolarPoint p_pol = histogramIndexToPolar(row_index, col_index, ALPHA_RES, 1.0);
-      double cost = matrix(row_index, col_index);
+      float cost = matrix(row_index, col_index);
       candidateDirection candidate(cost, p_pol.e, p_pol.z);
 
       if (queue.size() < number_of_candidates) {
@@ -276,9 +276,9 @@ void getBestCandidatesFromCostMatrix(
   std::reverse(candidate_vector.begin(), candidate_vector.end());
 }
 
-void smoothPolarMatrix(Eigen::MatrixXd& matrix, unsigned int smoothing_radius) {
+void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius) {
   // pad matrix by smoothing radius respecting all wrapping rules
-  Eigen::MatrixXd matrix_padded;
+  Eigen::MatrixXf matrix_padded;
   padPolarMatrix(matrix, smoothing_radius, matrix_padded);
 
   // filter matrix (max-mean)
@@ -298,8 +298,8 @@ void smoothPolarMatrix(Eigen::MatrixXd& matrix, unsigned int smoothing_radius) {
   }
 }
 
-void padPolarMatrix(const Eigen::MatrixXd& matrix, unsigned int n_lines_padding,
-                    Eigen::MatrixXd& matrix_padded) {
+void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
+                    Eigen::MatrixXf& matrix_padded) {
   matrix_padded.resize(matrix.rows() + 2 * n_lines_padding,
                        matrix.cols() + 2 * n_lines_padding);
 
@@ -351,7 +351,7 @@ void padPolarMatrix(const Eigen::MatrixXd& matrix, unsigned int n_lines_padding,
 }
 
 // costfunction for every free histogram cell
-double costFunction(double e_angle, double z_angle, float obstacle_distance,
+float costFunction(double e_angle, double z_angle, float obstacle_distance,
                     const Eigen::Vector3f& goal,
                     const Eigen::Vector3f& position,
                     const Eigen::Vector3f& last_sent_waypoint,

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -103,15 +103,15 @@ void propagateHistogram(
     Histogram& polar_histogram_est,
     const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
     const std::vector<int>& reprojected_points_age,
-    const geometry_msgs::PoseStamped& position) {
+    const Eigen::Vector3f& position) {
   Eigen::MatrixXi counter(GRID_LENGTH_E / 2, GRID_LENGTH_Z / 2);
   counter.fill(0);
 
   for (size_t i = 0; i < reprojected_points.points.size(); i++) {
     PolarPoint p_pol = cartesianToPolar(toEigen(reprojected_points.points[i]),
-                                        toEigen(position.pose.position));
+                                        position);
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, 2 * ALPHA_RES);
-    float point_distance = (toEigen(position.pose.position) -
+    float point_distance = (position -
                             toEigen(reprojected_points.points[i]))
                                .norm();
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -250,11 +250,11 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
     }
   }
 
-  unsigned int smooth_radius = 3;
+  unsigned int smooth_radius = 1;
   smoothPolarMatrix(cost_matrix, smooth_radius);
-  smooth_radius = 2;
   smoothPolarMatrix(cost_matrix, smooth_radius);
-  smooth_radius = 1;
+  smoothPolarMatrix(cost_matrix, smooth_radius);
+  smoothPolarMatrix(cost_matrix, smooth_radius);
   smoothPolarMatrix(cost_matrix, smooth_radius);
 }
 

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -2,7 +2,9 @@
 #define LOCAL_PLANNER_FUNCTIONS_H
 
 #include "box.h"
+#include "candidate_direction.h"
 #include "common.h"
+#include "cost_parameters.h"
 #include "histogram.h"
 
 #include <Eigen/Dense>
@@ -16,13 +18,11 @@
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
 
+#include <queue>
 #include <vector>
 
 namespace avoidance {
 
-void initGridCells(nav_msgs::GridCells& cell);
-double adaptSafetyMarginHistogram(double dist_to_closest_point,
-                                  double cloud_size, double min_cloud_size);
 void filterPointCloud(
     pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
     Eigen::Vector3f& closest_point, double& distance_to_closest_point,
@@ -35,12 +35,11 @@ void calculateFOV(double h_FOV, double v_FOV, std::vector<int>& z_FOV_idx,
 void propagateHistogram(
     Histogram& polar_histogram_est,
     const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
-    const std::vector<double>& reprojected_points_age,
-    const std::vector<double>& reprojected_points_dist,
+    const std::vector<int>& reprojected_points_age,
     const geometry_msgs::PoseStamped& position);
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
-                          geometry_msgs::PoseStamped position);
+                          const Eigen::Vector3f& position);
 void combinedHistogram(bool& hist_empty, Histogram& new_hist,
                        const Histogram& propagated_hist,
                        bool waypoint_outside_FOV,
@@ -48,28 +47,23 @@ void combinedHistogram(bool& hist_empty, Histogram& new_hist,
                        int e_FOV_max);
 void compressHistogramElevation(Histogram& new_hist,
                                 const Histogram& input_hist);
-double costFunction(PolarPoint p_pol, nav_msgs::GridCells& path_waypoints,
+void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
+                   const Eigen::Vector3f& position,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed,
+                   Eigen::MatrixXd& cost_matrix);
+void getBestCandidatesFromCostMatrix(
+    const Eigen::MatrixXd& matrix, unsigned int number_of_candidates,
+    std::vector<candidateDirection>& candidate_vector);
+double costFunction(double e_angle, double z_angle, float obstacle_distance,
                     const Eigen::Vector3f& goal,
                     const Eigen::Vector3f& position,
-                    const Eigen::Vector3f& position_old, double goal_cost_param,
-                    double smooth_cost_param,
-                    double height_change_cost_param_adapted,
-                    double height_change_cost_param, bool only_yawed);
-void findFreeDirections(
-    const Histogram& histogram, double safety_radius,
-    nav_msgs::GridCells& path_candidates, nav_msgs::GridCells& path_selected,
-    nav_msgs::GridCells& path_rejected, nav_msgs::GridCells& path_blocked,
-    nav_msgs::GridCells& path_waypoints,
-    std::vector<float>& cost_path_candidates, const Eigen::Vector3f& goal,
-    const Eigen::Vector3f& position, const Eigen::Vector3f& position_old,
-    double goal_cost_param, double smooth_cost_param,
-    double height_change_cost_param_adapted, double height_change_cost_param,
-    bool only_yawed, int resolution_alpha);
-void printHistogram(Histogram hist, std::vector<int> z_FOV_idx, int e_FOV_min,
-                    int e_FOV_max, int e_chosen, int z_chosen,
-                    double resolution);
-bool calculateCostMap(const std::vector<float>& cost_path_candidates,
-                      std::vector<int>& cost_idx_sorted);
+                    const Eigen::Vector3f& last_sent_waypoint,
+                    costParameters cost_params, bool only_yawed);
+void smoothPolarMatrix(Eigen::MatrixXd& matrix, unsigned int smoothing_radius);
+void padPolarMatrix(const Eigen::MatrixXd& matrix, unsigned int n_lines_padding,
+                    Eigen::MatrixXd& matrix_padded);
+void printHistogram(Histogram& histogram);
 bool getDirectionFromTree(
     PolarPoint& p_pol,
     const std::vector<geometry_msgs::Point>& path_node_positions,

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -36,7 +36,7 @@ void propagateHistogram(
     Histogram& polar_histogram_est,
     const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
     const std::vector<int>& reprojected_points_age,
-    const geometry_msgs::PoseStamped& position);
+	const Eigen::Vector3f& position);
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           const Eigen::Vector3f& position);

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -51,18 +51,18 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
-                   Eigen::MatrixXd& cost_matrix);
+                   Eigen::MatrixXf& cost_matrix);
 void getBestCandidatesFromCostMatrix(
-    const Eigen::MatrixXd& matrix, unsigned int number_of_candidates,
+    const Eigen::MatrixXf& matrix, unsigned int number_of_candidates,
     std::vector<candidateDirection>& candidate_vector);
-double costFunction(double e_angle, double z_angle, float obstacle_distance,
+float costFunction(double e_angle, double z_angle, float obstacle_distance,
                     const Eigen::Vector3f& goal,
                     const Eigen::Vector3f& position,
                     const Eigen::Vector3f& last_sent_waypoint,
                     costParameters cost_params, bool only_yawed);
-void smoothPolarMatrix(Eigen::MatrixXd& matrix, unsigned int smoothing_radius);
-void padPolarMatrix(const Eigen::MatrixXd& matrix, unsigned int n_lines_padding,
-                    Eigen::MatrixXd& matrix_padded);
+void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius);
+void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
+                    Eigen::MatrixXf& matrix_padded);
 void printHistogram(Histogram& histogram);
 bool getDirectionFromTree(
     PolarPoint& p_pol,

--- a/local_planner/src/nodes/planner_functions.h
+++ b/local_planner/src/nodes/planner_functions.h
@@ -56,10 +56,9 @@ void getBestCandidatesFromCostMatrix(
     const Eigen::MatrixXf& matrix, unsigned int number_of_candidates,
     std::vector<candidateDirection>& candidate_vector);
 float costFunction(double e_angle, double z_angle, float obstacle_distance,
-                    const Eigen::Vector3f& goal,
-                    const Eigen::Vector3f& position,
-                    const Eigen::Vector3f& last_sent_waypoint,
-                    costParameters cost_params, bool only_yawed);
+                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed);
 void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius);
 void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
                     Eigen::MatrixXf& matrix_padded);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -154,15 +154,15 @@ void StarPlanner::buildLookAheadTree() {
     Histogram histogram = Histogram(ALPHA_RES);
 
     propagateHistogram(propagated_histogram, reprojected_points_,
-                       reprojected_points_age_, pose_);
-    generateNewHistogram(histogram, pointcloud_, toEigen(pose_.pose.position));
+                       reprojected_points_age_, origin_position);
+    generateNewHistogram(histogram, pointcloud_, origin_position);
     combinedHistogram(hist_is_empty, histogram, propagated_histogram, false,
                       z_FOV_idx, e_FOV_min, e_FOV_max);
 
     // calculate candidates
     Eigen::MatrixXf cost_matrix;
     std::vector<candidateDirection> candidate_vector;
-    getCostMatrix(histogram, goal_, toEigen(pose_.pose.position),
+    getCostMatrix(histogram, goal_, origin_position,
                   origin_origin_position, cost_params_, false, cost_matrix);
     getBestCandidatesFromCostMatrix(cost_matrix, childs_per_node_,
                                     candidate_vector);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -160,7 +160,7 @@ void StarPlanner::buildLookAheadTree() {
                       z_FOV_idx, e_FOV_min, e_FOV_max);
 
     // calculate candidates
-    Eigen::MatrixXd cost_matrix;
+    Eigen::MatrixXf cost_matrix;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, toEigen(pose_.pose.position),
                   origin_origin_position, cost_params_, false, cost_matrix);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -175,11 +175,12 @@ void StarPlanner::buildLookAheadTree() {
       int depth = tree_[origin].depth_ + 1;
       int childs = 0;
       for (candidateDirection candidate : candidate_vector) {
-    	PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle, tree_node_distance_);
+        PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle,
+                         tree_node_distance_);
 
         // check if another close node has been added
-    	Eigen::Vector3f node_location =
-    	              polarToCartesian(p_pol, toPoint(origin_position));
+        Eigen::Vector3f node_location =
+            polarToCartesian(p_pol, toPoint(origin_position));
         int close_nodes = 0;
         for (size_t i = 0; i < tree_.size(); i++) {
           double dist = (tree_[i].getPosition() - node_location).norm();
@@ -189,17 +190,17 @@ void StarPlanner::buildLookAheadTree() {
         }
 
         if (childs < childs_per_node_ && close_nodes == 0) {
-            tree_.push_back(TreeNode(origin, depth, node_location));
-            tree_.back().last_e_ = p_pol.e;
-            tree_.back().last_z_ = p_pol.z;
-            double h = treeHeuristicFunction(tree_.size() - 1);
-            double c = treeCostFunction(tree_.size() - 1);
-            tree_.back().heuristic_ = h;
-            tree_.back().total_cost_ =
-                tree_[origin].total_cost_ - tree_[origin].heuristic_ + c + h;
-            Eigen::Vector3f diff = node_location - origin_position;
-            tree_.back().yaw_ = atan2(diff.y(), diff.x());
-            childs++;
+          tree_.push_back(TreeNode(origin, depth, node_location));
+          tree_.back().last_e_ = p_pol.e;
+          tree_.back().last_z_ = p_pol.z;
+          double h = treeHeuristicFunction(tree_.size() - 1);
+          double c = treeCostFunction(tree_.size() - 1);
+          tree_.back().heuristic_ = h;
+          tree_.back().total_cost_ =
+              tree_[origin].total_cost_ - tree_[origin].heuristic_ + c + h;
+          Eigen::Vector3f diff = node_location - origin_position;
+          tree_.back().yaw_ = atan2(diff.y(), diff.x());
+          childs++;
         }
       }
     }

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -15,7 +15,6 @@ StarPlanner::~StarPlanner() {}
 // set parameters changed by dynamic rconfigure
 void StarPlanner::dynamicReconfigureSetStarParams(
     const avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
-  min_node_dist_to_obstacle_ = config.min_node_dist_to_obstacle_;
   childs_per_node_ = config.childs_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
   tree_node_distance_ = config.tree_node_distance_;

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -15,7 +15,7 @@ StarPlanner::~StarPlanner() {}
 // set parameters changed by dynamic rconfigure
 void StarPlanner::dynamicReconfigureSetStarParams(
     const avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
-  childs_per_node_ = config.childs_per_node_;
+  children_per_node_ = config.children_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
   tree_node_distance_ = config.tree_node_distance_;
   tree_discount_factor_ = config.tree_discount_factor_;
@@ -163,7 +163,7 @@ void StarPlanner::buildLookAheadTree() {
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position,
                   origin_origin_position, cost_params_, false, cost_matrix);
-    getBestCandidatesFromCostMatrix(cost_matrix, childs_per_node_,
+    getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 
     // add candidates as nodes
@@ -172,7 +172,7 @@ void StarPlanner::buildLookAheadTree() {
     } else {
       // insert new nodes
       int depth = tree_[origin].depth_ + 1;
-      int childs = 0;
+      int children = 0;
       for (candidateDirection candidate : candidate_vector) {
         PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle,
                          tree_node_distance_);
@@ -188,7 +188,7 @@ void StarPlanner::buildLookAheadTree() {
           }
         }
 
-        if (childs < childs_per_node_ && close_nodes == 0) {
+        if (children < children_per_node_ && close_nodes == 0) {
           tree_.push_back(TreeNode(origin, depth, node_location));
           tree_.back().last_e_ = p_pol.e;
           tree_.back().last_z_ = p_pol.z;
@@ -199,7 +199,7 @@ void StarPlanner::buildLookAheadTree() {
               tree_[origin].total_cost_ - tree_[origin].heuristic_ + c + h;
           Eigen::Vector3f diff = node_location - origin_position;
           tree_.back().yaw_ = atan2(diff.y(), diff.x());
-          childs++;
+          children++;
         }
       }
     }

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -65,10 +65,10 @@ double StarPlanner::treeCostFunction(int node_number) {
   PolarPoint goal_pol = cartesianToPolar(goal_, origin_position);
 
   double target_cost =
-      2 * indexAngleDifference(z, goal_pol.z) +
-      20 * indexAngleDifference(e, goal_pol.e);  // include effective direction?
+      1 * indexAngleDifference(z, goal_pol.z) +
+      10 * indexAngleDifference(e, goal_pol.e);  // include effective direction?
   double turning_cost =
-      1 *
+      5 *
       indexAngleDifference(z, tree_[0].yaw_);  // maybe include pitching cost?
 
   float last_e = tree_[origin].last_e_;
@@ -76,10 +76,6 @@ double StarPlanner::treeCostFunction(int node_number) {
 
   double smooth_cost = 5 * (2 * indexAngleDifference(z, last_z) +
                             5 * indexAngleDifference(e, last_e));
-  if (indexAngleDifference(z, last_z) > 100) {
-    smooth_cost = HUGE_VAL;
-  }
-
   double smooth_cost_to_old_tree = 0.0;
   if (tree_age_ < 10) {
     int partner_node_idx =
@@ -235,7 +231,19 @@ void StarPlanner::buildLookAheadTree() {
   path_node_origins_.push_back(0);
   tree_age_ = 0;
 
-  ROS_INFO("\033[0;35m[SP]Tree calculated in %2.2fms.\033[0m",
-           (std::clock() - start_time) / (double)(CLOCKS_PER_SEC / 1000));
+  ROS_INFO("\033[0;35m[SP]Tree (%.0f nodes, %.0f path nodes, %.0f expanded) calculated in %2.2fms.\033[0m",
+          (double)tree_.size(),
+          (double)path_node_positions_.size(),
+          (double)closed_set_.size(),
+          (std::clock() - start_time) / (double)(CLOCKS_PER_SEC / 1000));
+  for(int j = 0; j < path_node_positions_.size(); j++)
+  {
+        ROS_DEBUG("\033[0;35m[SP] node %.0f : [ %f, %f, %f]\033[0m",
+                 (double)j,
+                 (double)path_node_positions_[j].x,
+                 (double)path_node_positions_[j].y,
+                 (double)path_node_positions_[j].z);
+  }
+
 }
 }

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -26,7 +26,7 @@ class TreeNode;
 class StarPlanner {
   double h_FOV_ = 59.0;
   double v_FOV_ = 46.0;
-  int childs_per_node_ = 1;
+  int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   double tree_node_distance_ = 1.0;
   double tree_discount_factor_ = 0.8;

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -2,6 +2,7 @@
 #define STAR_PLANNER_H
 
 #include "box.h"
+#include "cost_parameters.h"
 #include "histogram.h"
 
 #include <Eigen/Dense>
@@ -27,32 +28,23 @@ class StarPlanner {
   double v_FOV_ = 46.0;
   int childs_per_node_ = 1;
   int n_expanded_nodes_ = 5;
+  double min_node_dist_to_obstacle_ = 2.0;
   double tree_node_distance_ = 1.0;
   double tree_discount_factor_ = 0.8;
-  double goal_cost_param_;
-  double smooth_cost_param_;
-  double height_change_cost_param_adapted_;
-  double height_change_cost_param_;
   double curr_yaw_;
-  double min_flight_height_;
-  double ground_margin_;
   double min_cloud_size_;
   double min_dist_backoff_;
   double min_realsense_dist_;
-  double ground_distance_ = 2.0;
 
-  std::vector<double> reprojected_points_age_;
-  std::vector<double> reprojected_points_dist_;
+  std::vector<int> reprojected_points_age_;
   std::vector<int> path_node_origins_;
 
-  std::vector<pcl::PointCloud<pcl::PointXYZ>> complete_cloud_;
+  pcl::PointCloud<pcl::PointXYZ> pointcloud_;
   pcl::PointCloud<pcl::PointXYZ> reprojected_points_;
 
   Eigen::Vector3f goal_;
   geometry_msgs::PoseStamped pose_;
-
-  nav_msgs::GridCells path_waypoints_;
-  Box histogram_box_;
+  costParameters cost_params_;
 
  public:
   std::vector<geometry_msgs::Point> path_node_positions_;
@@ -65,21 +57,15 @@ class StarPlanner {
   ~StarPlanner();
 
   void setParams(double min_cloud_size, double min_dist_backoff,
-                 const nav_msgs::GridCells& path_waypoints, double curr_yaw,
-                 double min_realsense_dist);
+                 double curr_yaw, double min_realsense_dist,
+                 costParameters cost_params);
   void setFOV(double h_FOV, double v_FOV);
   void setReprojectedPoints(
       const pcl::PointCloud<pcl::PointXYZ>& reprojected_points,
-      const std::vector<double>& reprojected_points_age,
-      const std::vector<double>& reprojected_points_dist);
-  void setCostParams(double goal_cost_param, double smooth_cost_param,
-                     double height_change_cost_param_adapted,
-                     double height_change_cost_param);
+      const std::vector<int>& reprojected_points_age);
   void setPose(const geometry_msgs::PoseStamped& pose);
-  void setBoxSize(const Box& histogram_box, double ground_distance);
   void setGoal(const geometry_msgs::Point& pose);
-  void setCloud(
-      const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud);
+  void setCloud(const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud);
   double treeCostFunction(int node_number);
   double treeHeuristicFunction(int node_number);
   void buildLookAheadTree();

--- a/local_planner/src/nodes/star_planner.h
+++ b/local_planner/src/nodes/star_planner.h
@@ -28,7 +28,6 @@ class StarPlanner {
   double v_FOV_ = 46.0;
   int childs_per_node_ = 1;
   int n_expanded_nodes_ = 5;
-  double min_node_dist_to_obstacle_ = 2.0;
   double tree_node_distance_ = 1.0;
   double tree_discount_factor_ = 0.8;
   double curr_yaw_;

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -1,8 +1,15 @@
 #include <gtest/gtest.h>
 #include <limits>
 #include "../src/nodes/common.h"
+#include "../src/nodes/histogram.h"
 
 using namespace avoidance;
+
+TEST(PlannerFunctions, HistogramResolution) {
+  // Test that the hardcoded histogram resolution ALPHA_RES is valid
+  ASSERT_GT(ALPHA_RES, 0);
+  ASSERT_EQ(180 % (2 * ALPHA_RES), 0);
+}
 
 TEST(Common, polar2DdistanceSameIsZero) {
   // GIVEN: two identical points

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -42,7 +42,7 @@ TEST(PlannerFunctions, generateNewHistogramEmpty) {
   // THEN: the histogram should be all zeros
   for (int e = 0; e < GRID_LENGTH_E; e++) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
-      EXPECT_LE(histogram_output.get_dist(e, z), 0.001);
+      EXPECT_LE(histogram_output.get_dist(e, z), FLT_MIN);
     }
   }
 }
@@ -97,7 +97,7 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
       if (e_found && z_found) {
         EXPECT_GE(histogram_output.get_dist(e, z), 0.0);
       } else {
-        EXPECT_LE(histogram_output.get_dist(e, z), 0.001);
+        EXPECT_LE(histogram_output.get_dist(e, z), FLT_MIN);
       }
     }
   }

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -37,7 +37,8 @@ TEST(PlannerFunctions, generateNewHistogramEmpty) {
   location.pose.position.z = 0;
 
   // WHEN: we build a histogram
-  generateNewHistogram(histogram_output, empty_cloud, toEigen(location.pose.position));
+  generateNewHistogram(histogram_output, empty_cloud,
+                       toEigen(location.pose.position));
 
   // THEN: the histogram should be all zeros
   for (int e = 0; e < GRID_LENGTH_E; e++) {
@@ -75,7 +76,8 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   }
 
   // WHEN: we build a histogram
-  generateNewHistogram(histogram_output, cloud, toEigen(location.pose.position));
+  generateNewHistogram(histogram_output, cloud,
+                       toEigen(location.pose.position));
 
   // THEN: the filled cells in the histogram should be one and the others be
   // zeros
@@ -275,14 +277,15 @@ TEST(PlannerFunctions, testDirectionTree) {
 }
 
 TEST(PlannerFunctions, padPolarMatrixAzimuthWrapping) {
-  // GIVEN: a matrix with known data. Where every cell has the value of its column index.
+  // GIVEN: a matrix with known data. Where every cell has the value of its
+  // column index.
   // And by how many lines should be padded
   int n_lines_padding = 3;
   Eigen::MatrixXf matrix;
   matrix.resize(GRID_LENGTH_E, GRID_LENGTH_Z);
   matrix.fill(1.0);
-  for(int c = 0; c < matrix.cols(); c++){
-	  matrix.col(c) = c * matrix.col(c);
+  for (int c = 0; c < matrix.cols(); c++) {
+    matrix.col(c) = c * matrix.col(c);
   }
 
   // WHEN: we pad the matrix
@@ -296,13 +299,20 @@ TEST(PlannerFunctions, padPolarMatrixAzimuthWrapping) {
   ASSERT_EQ(GRID_LENGTH_E + 2 * n_lines_padding, matrix_padded.rows());
   ASSERT_EQ(GRID_LENGTH_Z + 2 * n_lines_padding, matrix_padded.cols());
 
-  bool middle_part_correct = matrix_padded.block(n_lines_padding, n_lines_padding, matrix.rows(), matrix.cols()) == matrix;
+  bool middle_part_correct =
+      matrix_padded.block(n_lines_padding, n_lines_padding, matrix.rows(),
+                          matrix.cols()) == matrix;
   bool col_0_correct = matrix_padded.col(0) == matrix_padded.col(GRID_LENGTH_Z);
-  bool col_1_correct = matrix_padded.col(1) == matrix_padded.col(GRID_LENGTH_Z + 1);
-  bool col_2_correct = matrix_padded.col(2) == matrix_padded.col(GRID_LENGTH_Z + 2);
-  bool col_63_correct = matrix_padded.col(GRID_LENGTH_Z + 3) == matrix_padded.col(3);
-  bool col_64_correct = matrix_padded.col(GRID_LENGTH_Z + 4) == matrix_padded.col(4);
-  bool col_65_correct = matrix_padded.col(GRID_LENGTH_Z + 5) == matrix_padded.col(5);
+  bool col_1_correct =
+      matrix_padded.col(1) == matrix_padded.col(GRID_LENGTH_Z + 1);
+  bool col_2_correct =
+      matrix_padded.col(2) == matrix_padded.col(GRID_LENGTH_Z + 2);
+  bool col_63_correct =
+      matrix_padded.col(GRID_LENGTH_Z + 3) == matrix_padded.col(3);
+  bool col_64_correct =
+      matrix_padded.col(GRID_LENGTH_Z + 4) == matrix_padded.col(4);
+  bool col_65_correct =
+      matrix_padded.col(GRID_LENGTH_Z + 5) == matrix_padded.col(5);
 
   EXPECT_TRUE(middle_part_correct);
   EXPECT_TRUE(col_0_correct);
@@ -314,13 +324,14 @@ TEST(PlannerFunctions, padPolarMatrixAzimuthWrapping) {
 }
 
 TEST(PlannerFunctions, padPolarMatrixElevationWrapping) {
-  // GIVEN: a matrix with known data. Where every cell has the value of its column index.
+  // GIVEN: a matrix with known data. Where every cell has the value of its
+  // column index.
   // And by how many lines should be padded
   int n_lines_padding = 2;
   Eigen::MatrixXf matrix;
   matrix.resize(GRID_LENGTH_E, GRID_LENGTH_Z);
   matrix.fill(0.0);
-  int half_z = GRID_LENGTH_Z/2;
+  int half_z = GRID_LENGTH_Z / 2;
   int last_z = GRID_LENGTH_Z - 1;
   int last_e = GRID_LENGTH_E - 1;
 
@@ -345,17 +356,21 @@ TEST(PlannerFunctions, padPolarMatrixElevationWrapping) {
   ASSERT_EQ(GRID_LENGTH_E + 2 * n_lines_padding, matrix_padded.rows());
   ASSERT_EQ(GRID_LENGTH_Z + 2 * n_lines_padding, matrix_padded.cols());
 
-
-  bool middle_part_correct = matrix_padded.block(n_lines_padding, n_lines_padding, matrix.rows(), matrix.cols()) == matrix;
+  bool middle_part_correct =
+      matrix_padded.block(n_lines_padding, n_lines_padding, matrix.rows(),
+                          matrix.cols()) == matrix;
   bool val_1 = matrix_padded(1, half_z + n_lines_padding) == 1;
   bool val_2 = matrix_padded(1, half_z + n_lines_padding + 1) == 2;
   bool val_3 = matrix_padded(0, half_z + n_lines_padding) == 3;
   bool val_4 = matrix_padded(1, 2) == 4;
   bool val_5 = matrix_padded(0, 3) == 5;
   bool val_6 = matrix_padded(1, half_z - 1 + n_lines_padding) == 6;
-  bool val_7 = matrix_padded(last_e + 1 + n_lines_padding, half_z + n_lines_padding) == 7;
-  bool val_8 = matrix_padded(last_e + 2 + n_lines_padding, GRID_LENGTH_Z + n_lines_padding - 1) == 8;
-  bool val_9 = matrix_padded(last_e + 1 + n_lines_padding, half_z - 1 + n_lines_padding) == 9;
+  bool val_7 = matrix_padded(last_e + 1 + n_lines_padding,
+                             half_z + n_lines_padding) == 7;
+  bool val_8 = matrix_padded(last_e + 2 + n_lines_padding,
+                             GRID_LENGTH_Z + n_lines_padding - 1) == 8;
+  bool val_9 = matrix_padded(last_e + 1 + n_lines_padding,
+                             half_z - 1 + n_lines_padding) == 9;
 
   EXPECT_TRUE(middle_part_correct);
   EXPECT_TRUE(val_1);
@@ -397,29 +412,32 @@ TEST(PlannerFunctions, getBestCandidatesFromCostMatrix) {
 }
 
 TEST(PlannerFunctions, smoothPolarMatrix) {
-  // GIVEN: a smoothing radius and a known cost matrix with one costly cell, otherwise all zeros.
+  // GIVEN: a smoothing radius and a known cost matrix with one costly cell,
+  // otherwise all zeros.
   unsigned int smooth_radius = 2;
   Eigen::MatrixXf matrix;
   Eigen::MatrixXf matrix_old;
   matrix.resize(GRID_LENGTH_E, GRID_LENGTH_Z);
   matrix.fill(0);
 
-  int r_object = GRID_LENGTH_E/2;
-  int c_object = GRID_LENGTH_Z/2;
+  int r_object = GRID_LENGTH_E / 2;
+  int c_object = GRID_LENGTH_Z / 2;
   matrix(r_object, c_object) = 100;
 
   // WHEN: we calculate the smoothed matrix
   matrix_old = matrix;
   smoothPolarMatrix(matrix, smooth_radius);
 
-  // THEN: The smoothed matrix should be element-wise greater-equal than the input matrix
-  // and the elements inside the smoothing radius around the costly cell should be greater than before
-  for(int r = r_object - smooth_radius; r < r_object + smooth_radius; r ++){
-	  for(int c = c_object - smooth_radius; c < c_object + smooth_radius; c ++){
-		  if(!(r == r_object && c == c_object)){
-			  EXPECT_GT(matrix(r, c), matrix_old(r, c));
-		  }
-	  }
+  // THEN: The smoothed matrix should be element-wise greater-equal than the
+  // input matrix
+  // and the elements inside the smoothing radius around the costly cell should
+  // be greater than before
+  for (int r = r_object - smooth_radius; r < r_object + smooth_radius; r++) {
+    for (int c = c_object - smooth_radius; c < c_object + smooth_radius; c++) {
+      if (!(r == r_object && c == c_object)) {
+        EXPECT_GT(matrix(r, c), matrix_old(r, c));
+      }
+    }
   }
   bool greater_equal = (matrix.array() >= matrix_old.array()).all();
   EXPECT_TRUE(greater_equal);
@@ -440,7 +458,7 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
 
   // WHEN: we calculate the cost matrix from the input data
   getCostMatrix(histogram, goal, position, last_sent_waypoint, cost_params,
-                          false, cost_matrix);
+                false, cost_matrix);
 
   // THEN: The minimum cost should be in the direction of the goal
   PolarPoint best_pol = cartesianToPolar(goal, position);
@@ -455,24 +473,44 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   // And the cost should grow as we go away from the goal index
   int check_radius = 3;
   Eigen::MatrixXf matrix_padded;
-  //extend the matrix, as the goal direction might be at the border
+  // extend the matrix, as the goal direction might be at the border
   padPolarMatrix(cost_matrix, check_radius, matrix_padded);
 
   int best_index_padded_e = (int)minRow + check_radius;
   int best_index_padded_z = (int)minCol + check_radius;
 
-  //check that rows farther away have bigger cost. Leave out direct neighbor rows as the center might be split over cells
-  bool row1 = (matrix_padded.row(best_index_padded_e + 2).array() > matrix_padded.row(best_index_padded_e + 1).array()).all();
-  bool row2 = (matrix_padded.row(best_index_padded_e + 3).array() > matrix_padded.row(best_index_padded_e + 2).array()).all();
-  bool row3 = (matrix_padded.row(best_index_padded_e - 2).array() > matrix_padded.row(best_index_padded_e).array() - 1).all();
-  bool row4 = (matrix_padded.row(best_index_padded_e - 3).array() > matrix_padded.row(best_index_padded_e).array() - 2).all();
+  // check that rows farther away have bigger cost. Leave out direct neighbor
+  // rows as the center might be split over cells
+  bool row1 = (matrix_padded.row(best_index_padded_e + 2).array() >
+               matrix_padded.row(best_index_padded_e + 1).array())
+                  .all();
+  bool row2 = (matrix_padded.row(best_index_padded_e + 3).array() >
+               matrix_padded.row(best_index_padded_e + 2).array())
+                  .all();
+  bool row3 = (matrix_padded.row(best_index_padded_e - 2).array() >
+               matrix_padded.row(best_index_padded_e).array() - 1)
+                  .all();
+  bool row4 = (matrix_padded.row(best_index_padded_e - 3).array() >
+               matrix_padded.row(best_index_padded_e).array() - 2)
+                  .all();
 
-  //check that columns farther away have bigger cost. Leave out direct neighbor rows as the center might be split over cells
-  Eigen::MatrixXf matrix_padded2 = matrix_padded.block(3 , 0, cost_matrix.rows(), matrix_padded.cols());  //cut off padded top part
-  bool col1 = (matrix_padded2.col(best_index_padded_z + 2).array() > matrix_padded2.col(best_index_padded_z + 1).array()).all();
-  bool col2 = (matrix_padded2.col(best_index_padded_z + 3).array() > matrix_padded2.col(best_index_padded_z + 2).array()).all();
-  bool col3 = (matrix_padded2.col(best_index_padded_z - 2).array() > matrix_padded2.col(best_index_padded_z).array() - 1).all();
-  bool col4 = (matrix_padded2.col(best_index_padded_z - 3).array() > matrix_padded2.col(best_index_padded_z).array() - 2).all();
+  // check that columns farther away have bigger cost. Leave out direct neighbor
+  // rows as the center might be split over cells
+  Eigen::MatrixXf matrix_padded2 =
+      matrix_padded.block(3, 0, cost_matrix.rows(),
+                          matrix_padded.cols());  // cut off padded top part
+  bool col1 = (matrix_padded2.col(best_index_padded_z + 2).array() >
+               matrix_padded2.col(best_index_padded_z + 1).array())
+                  .all();
+  bool col2 = (matrix_padded2.col(best_index_padded_z + 3).array() >
+               matrix_padded2.col(best_index_padded_z + 2).array())
+                  .all();
+  bool col3 = (matrix_padded2.col(best_index_padded_z - 2).array() >
+               matrix_padded2.col(best_index_padded_z).array() - 1)
+                  .all();
+  bool col4 = (matrix_padded2.col(best_index_padded_z - 3).array() >
+               matrix_padded2.col(best_index_padded_z).array() - 2)
+                  .all();
 
   EXPECT_TRUE(col1);
   EXPECT_TRUE(col2);
@@ -499,55 +537,60 @@ TEST(Histogram, HistogramDownsampleCorrectUsage) {
   // WHEN: we downsample the histogram to have a larger bin size
   histogram.downsample();
 
-  // THEN: The downsampled histogram should fuse four cells of the regular resolution histogram into one
-  for (int i = 0; i < GRID_LENGTH_E/2; ++i) {
-      for (int j = 0; j < GRID_LENGTH_Z/2; ++j) {
-    	  if(i == 0 && j == 0){
-    		  EXPECT_FLOAT_EQ(1.3, histogram.get_dist(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
-    	  }else if(i == 1 && j == 1){
-    		  EXPECT_FLOAT_EQ(3, histogram.get_age(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
-    	  }else{
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
-    	  }
+  // THEN: The downsampled histogram should fuse four cells of the regular
+  // resolution histogram into one
+  for (int i = 0; i < GRID_LENGTH_E / 2; ++i) {
+    for (int j = 0; j < GRID_LENGTH_Z / 2; ++j) {
+      if (i == 0 && j == 0) {
+        EXPECT_FLOAT_EQ(1.3, histogram.get_dist(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
+      } else if (i == 1 && j == 1) {
+        EXPECT_FLOAT_EQ(3, histogram.get_age(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
+      } else {
+        EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
       }
+    }
   }
 }
 
 TEST(Histogram, HistogramUpsampleCorrectUsage) {
   // GIVEN: a histogram of the correct resolution
-  Histogram histogram = Histogram(ALPHA_RES*2);
+  Histogram histogram = Histogram(ALPHA_RES * 2);
   histogram.set_dist(0, 0, 1.3);
   histogram.set_age(1, 1, 3);
 
   // WHEN: we upsample the histogram to have regular bin size
   histogram.upsample();
 
-  // THEN: The upsampled histogram should split every cell of the lower resolution histogram into four cells
+  // THEN: The upsampled histogram should split every cell of the lower
+  // resolution histogram into four cells
   for (int i = 0; i < GRID_LENGTH_E; ++i) {
-      for (int j = 0; j < GRID_LENGTH_Z; ++j) {
-    	  if((i == 0 && j == 0) || (i == 1 && j == 0) || (i == 0 && j == 1) || (i == 1 && j == 1)){
-    		  EXPECT_FLOAT_EQ(1.3, histogram.get_dist(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
-    	  }else if((i == 2 && j == 2) || (i == 2 && j == 3) || (i == 3 && j == 2) || (i == 3 && j == 3)){
-    		  EXPECT_FLOAT_EQ(3, histogram.get_age(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
-    	  }else{
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
-    		  EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
-    	  }
+    for (int j = 0; j < GRID_LENGTH_Z; ++j) {
+      if ((i == 0 && j == 0) || (i == 1 && j == 0) || (i == 0 && j == 1) ||
+          (i == 1 && j == 1)) {
+        EXPECT_FLOAT_EQ(1.3, histogram.get_dist(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
+      } else if ((i == 2 && j == 2) || (i == 2 && j == 3) ||
+                 (i == 3 && j == 2) || (i == 3 && j == 3)) {
+        EXPECT_FLOAT_EQ(3, histogram.get_age(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
+      } else {
+        EXPECT_FLOAT_EQ(0.0, histogram.get_dist(i, j));
+        EXPECT_FLOAT_EQ(0.0, histogram.get_age(i, j));
       }
+    }
   }
 }
 
 TEST(Histogram, HistogramUpDownpsampleInorrectUsage) {
   // GIVEN: a histogram of the correct resolution
-  Histogram low_res_histogram = Histogram(ALPHA_RES*2);
+  Histogram low_res_histogram = Histogram(ALPHA_RES * 2);
   Histogram high_res_histogram = Histogram(ALPHA_RES);
 
-  // THEN: We expect the functions to throw if the input histogram has the wrong resolution
+  // THEN: We expect the functions to throw if the input histogram has the wrong
+  // resolution
   EXPECT_THROW(low_res_histogram.downsample(), std::logic_error);
   EXPECT_THROW(high_res_histogram.upsample(), std::logic_error);
 }


### PR DESCRIPTION
This PR changes the The histogram format and cost function completely. Here a few points that changed:

- The histogram is now stored as an Eigen::Matrix
- The histogram now contains only a distance and age layer, the binary is dropped
- The cost of each histogram cell is stored in a cost matrix
- A new cost-function is used, which contains the obstacle distance in the cost value
- To smooth the cost matrix (former safety radius) the matrix is padded (wrapping correctly around elevation and azimuth). and then a max median filter is used on it.
- A lot of tests for the new functions

We definitely have to flight test this before merging. It might fly a bit worse than before, as I did not yet spend too much time on re-tuning the costmatrix smoothing and costfunction.