### PR TITLE
Change subscribed node for local velocity

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Note that in the following instructions, we assume your catkin workspace (in whi
    mkdir -p ~/catkin_ws/src
    ```
 
-1. Install mavros. The package coming from the ROS repository should be fine. Just in case, instructions to install it from sources can be found here: https://dev.px4.io/en/ros/mavros_installation.html.
+1. Install mavros version 0.29.0 or above. Instructions to install it from sources can be found here: https://dev.px4.io/en/ros/mavros_installation.html. If you want to install using apt, be sure to check that the version is 0.29.0 or greater.
 
    ```bash
    sudo apt install ros-kinetic-mavros ros-kinetic-mavros-extras

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -43,8 +43,8 @@ LocalPlannerNode::LocalPlannerNode() {
       "/mavros/local_position/pose", 1, &LocalPlannerNode::positionCallback,
       this);
   velocity_sub_ = nh_.subscribe<const geometry_msgs::TwistStamped&>(
-      "/mavros/local_position/velocity", 1, &LocalPlannerNode::velocityCallback,
-      this);
+      "/mavros/local_position/velocity_local", 1,
+      &LocalPlannerNode::velocityCallback, this);
   state_sub_ =
       nh_.subscribe("/mavros/state", 1, &LocalPlannerNode::stateCallback, this);
   clicked_point_sub_ = nh_.subscribe(


### PR DESCRIPTION
Due to a change in MAVROS 0.28, the local planner with have a bias east in its smoothing function. This is/will be fixed in MAVROS 0.29, however the MAVROS node that needs to be subscribed to has changed.

See https://github.com/mavlink/mavros/pull/1160 and further discussion https://github.com/mavlink/mavros/pull/1142

@TSC21 FYI