### PR TITLE
Polar point to histogram index conversion update

### DIFF
--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -52,23 +52,21 @@ PolarPoint cartesianToPolar(double x, double y, double z,
 }
 
 Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res) {
-  // TODO change logic here, as 0,0 are valid index
+
   Eigen::Vector2i ev2(0, 0);
   PolarPoint p_wrapped = wrapPolar(p_pol);
-  // elevation angle to y-axis histogram index
+  //elevation angle to y-axis histogram index
   if (p_wrapped.e == 90.0f) {
-    p_wrapped.e = 89.0f;
+    p_wrapped.e = 89.9f; ///set to edge of last valid bin
   }
-  p_wrapped.e += 90.0f;
-  p_wrapped.e = p_wrapped.e + (res - (static_cast<int>(p_wrapped.e) % res));
-  ev2.y() = p_wrapped.e / res - 1;
+ // maps elevation -90° to bin 0 and +90° to the highest bin (N-1) 
+  ev2.y() = floor(p_wrapped.e / res + 90.f / res);
   // azimuth angle to x-axis histogram index
   if (p_wrapped.z == 180.0f) {
     p_wrapped.z = -180.0f;
   }
-  p_wrapped.z += 180.0f;
-  p_wrapped.z = p_wrapped.z + (res - (static_cast<int>(p_wrapped.z) % res));
-  ev2.x() = p_wrapped.z / res - 1;
+ // maps elevation -180° to bin 0 and +180° to the highest bin (N-1)
+  ev2.x() = floor(p_wrapped.z / res + 180.f / res);
   return ev2;
 }
 
@@ -76,8 +74,8 @@ PolarPoint wrapPolar(PolarPoint p_pol) {
   // elevation valid [-90,90)
   // when abs(elevation) > 90, wrap elevation angle
   //  azimuth changes for 180 each time
-  while (abs(p_pol.e) > 90.0f) {
-    if (p_pol.e > 90.0f) {
+  while (abs(p_pol.e) >90.0f) {
+    if (p_pol.e >90.0f) {
       p_pol.e = 180.0f - p_pol.e;
       p_pol.z = p_pol.z - 180.0f;
     } else if (p_pol.e < -90.0) {

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -72,7 +72,6 @@ Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res) {
   return ev2;
 }
 
-
 PolarPoint wrapPolar(PolarPoint p_pol) {
   // elevation valid [-90,90)
   // when abs(elevation) > 90, wrap elevation angle
@@ -140,7 +139,6 @@ void wrapAngleToPlusMinus180(float& angle) {
     angle += 360.0;
   }
 }
-
 
 double getAngularVelocity(double desired_yaw, double curr_yaw) {
   wrapAngleToPlusMinusPI(desired_yaw);

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -77,11 +77,10 @@ Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res);
 * @brief     support function for polarToHistogramIndex
 *            when abs(elevation) > 90, wrap elevation angle into valid
 *            region and azimuth angle changes for +/-180 deg each time
-* @param[in] p_pol Polar point
-* @param[out]polar point with elevation angle [-90,90)
-*            azimuth valid [-180,180)
+* @param[in/out]p_pol Polar point with elevation angle [-90,90) and
+*            azimuth angle [-180,180)
 **/
-PolarPoint wrapPolar(PolarPoint p_pol);
+void wrapPolar(PolarPoint& p_pol);
 /**
 * @brief     Compute the yaw angle between current position and point
 * @returns   angle between two points in rad

--- a/local_planner/src/nodes/common.h
+++ b/local_planner/src/nodes/common.h
@@ -73,7 +73,15 @@ PolarPoint cartesianToPolar(double x, double y, double z,
 **/
 
 Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res);
-
+/**
+* @brief     support function for polarToHistogramIndex
+*            when abs(elevation) > 90, wrap elevation angle into valid
+*            region and azimuth angle changes for +/-180 deg each time
+* @param[in] p_pol Polar point
+* @param[out]polar point with elevation angle [-90,90)
+*            azimuth valid [-180,180)
+**/
+PolarPoint wrapPolar(PolarPoint p_pol);
 /**
 * @brief     Compute the yaw angle between current position and point
 * @returns   angle between two points in rad
@@ -102,7 +110,11 @@ double velocityLinear(double max_vel, double slope, double v_old,
 * @param[in, out] angle to be wrapped  [rad]
 **/
 void wrapAngleToPlusMinusPI(double& angle);
-
+/**
+* @brief     wrappes the input angle in to plus minus 180 deg space
+* @param[in, out] angle to be wrapped  [deg]
+**/
+void wrapAngleToPlusMinus180(float& angle);
 /**
 * @brief     computes an angular velocity to reach the desired_yaw
 * @param[in] adesired_yaw  [rad]

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -126,14 +126,14 @@ TEST(Common, elevationAnglefromCartesian) {
 
 TEST(Common, polarToHistogramIndex) {
   // GIVEN: the polar point and the histogram resolution
-  PolarPoint p_pol_1(0.f,0.f,0.f);
+  PolarPoint p_pol_1(0.f, 0.f, 0.f);
   PolarPoint p_pol_2(34.0f, 34.0f, 0.0f);
   PolarPoint p_pol_3(90.0f, 180.0f, 0.0f);
-  PolarPoint p_pol_4(-90.0f, -180.0f,0.0f);
+  PolarPoint p_pol_4(-90.0f, -180.0f, 0.0f);
   // wrapped around, influences the azimuth by 180 deg
   PolarPoint p_pol_5(454.f, -160.f, 0.0f);
   // wrapped around, no influence on azimuth
-  PolarPoint p_pol_6(400.f, -270.f,0.0f);
+  PolarPoint p_pol_6(400.f, -270.f, 0.0f);
 
   const float resolution_1 = 3.f;
   const float resolution_2 = 12.f;

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -126,24 +126,15 @@ TEST(Common, elevationAnglefromCartesian) {
 
 TEST(Common, polarToHistogramIndex) {
   // GIVEN: the polar point and the histogram resolution
-  PolarPoint p_pol_1 = {};
-  PolarPoint p_pol_2 = {};
-  PolarPoint p_pol_3 = {};
-  PolarPoint p_pol_4 = {};
-  PolarPoint p_pol_5 = {};
-  PolarPoint p_pol_6 = {};
-  p_pol_1.e = 0.f;
-  p_pol_2.e = 34.f;
-  p_pol_3.e = 90.f;
-  p_pol_4.e = -90.f;
-  p_pol_5.e = 454.f;  // wrapped around, influences the azimuth by 180 deg
-  p_pol_6.e = 400.f;  // wrapped around, no influence on azimuth
-  p_pol_1.z = 0.f;
-  p_pol_2.z = 34.f;
-  p_pol_3.z = 180.f;
-  p_pol_4.z = -180.f;
-  p_pol_5.z = -160.f;
-  p_pol_6.z = -270.f;  // wrwapped around
+  PolarPoint p_pol_1(0.f,0.f,0.f);
+  PolarPoint p_pol_2(34.0f, 34.0f, 0.0f);
+  PolarPoint p_pol_3(90.0f, 180.0f, 0.0f);
+  PolarPoint p_pol_4(-90.0f, -180.0f,0.0f);
+  // wrapped around, influences the azimuth by 180 deg
+  PolarPoint p_pol_5(454.f, -160.f, 0.0f);
+  // wrapped around, no influence on azimuth
+  PolarPoint p_pol_6(400.f, -270.f,0.0f);
+
   const float resolution_1 = 3.f;
   const float resolution_2 = 12.f;
 

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -124,7 +124,6 @@ TEST(Common, elevationAnglefromCartesian) {
   EXPECT_FLOAT_EQ(-50.194428, angle_non_zero_origin);
 }
 
-
 TEST(Common, polarToHistogramIndex) {
   // GIVEN: the polar point and the histogram resolution
   PolarPoint p_pol_1 = {};
@@ -148,7 +147,6 @@ TEST(Common, polarToHistogramIndex) {
   const float resolution_1 = 3.f;
   const float resolution_2 = 12.f;
 
-
   // WHEN: we convert the polar point to a histogram index
   const Eigen::Vector2i index_1 = polarToHistogramIndex(p_pol_1, resolution_1);
   const Eigen::Vector2i index_2 = polarToHistogramIndex(p_pol_2, resolution_1);
@@ -162,7 +160,7 @@ TEST(Common, polarToHistogramIndex) {
       polarToHistogramIndex(p_pol_6, resolution_2);  // wrapped
 
   // THEN: the  histogram index should be ..
-  // elevation angle 
+  // elevation angle
   EXPECT_EQ(30, index_1.y());
   EXPECT_EQ(41, index_2.y());
   EXPECT_EQ(7, index_3.y());

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -386,3 +386,44 @@ TEST(Common, IndexPolarIndex) {
     }
   }
 }
+
+TEST(Common, wrapPolar) {
+  // GIVEN: some polar points with elevation and azimuth angles which need to be
+  // wrapped
+  float rad = 1.0f;
+  PolarPoint p_pol_1(110.f, 0.f, rad);   // wrap  elevation with jump in azimuth
+  PolarPoint p_pol_2(0.f, 200.f, rad);   // wrap azimuth
+  PolarPoint p_pol_3(-180.f, 0.f, rad);  // wrap elevation with jump in azimuth
+  PolarPoint p_pol_4(0.f, -1230.f, rad);  // wrap azimuth multiple times
+  // wrap elevation, no change in azimuth
+  PolarPoint p_pol_5(-330.f, 140.f, rad);
+  // wrap azimuth, no change in elevation
+  PolarPoint p_pol_6(40.f, 600.f, rad);
+
+  // WHEN: the angles are wrapped
+  wrapPolar(p_pol_1);
+  wrapPolar(p_pol_2);
+  wrapPolar(p_pol_3);
+  wrapPolar(p_pol_4);
+  wrapPolar(p_pol_5);
+  wrapPolar(p_pol_6);
+
+  // THEN: the polar points should have the angles
+  EXPECT_FLOAT_EQ(70.f, p_pol_1.e);
+  EXPECT_FLOAT_EQ(-180.f, p_pol_1.z);
+
+  EXPECT_FLOAT_EQ(0.f, p_pol_2.e);
+  EXPECT_FLOAT_EQ(-160.f, p_pol_2.z);
+
+  EXPECT_FLOAT_EQ(0.f, p_pol_3.e);
+  EXPECT_FLOAT_EQ(-180.f, p_pol_3.z);
+
+  EXPECT_FLOAT_EQ(0.f, p_pol_4.e);
+  EXPECT_FLOAT_EQ(-150.f, p_pol_4.z);
+
+  EXPECT_FLOAT_EQ(30.f, p_pol_5.e);
+  EXPECT_FLOAT_EQ(140.f, p_pol_5.z);
+
+  EXPECT_FLOAT_EQ(40.f, p_pol_6.e);
+  EXPECT_FLOAT_EQ(-120.f, p_pol_6.z);
+}

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -124,103 +124,62 @@ TEST(Common, elevationAnglefromCartesian) {
   EXPECT_FLOAT_EQ(-50.194428, angle_non_zero_origin);
 }
 
-TEST(Common, elevationAngletoIndex) {
-  // GIVEN: the elevation angle of a point and the histogram resolution
-  PolarPoint p_pol_1 = {};
-  p_pol_1.e = 0.f;
-  PolarPoint p_pol_2 = {};
-  p_pol_2.e = 34.f;
-  PolarPoint p_pol_3 = {};
-  p_pol_3.e = 90.f;
-  PolarPoint p_pol_4 = {};
-  p_pol_4.e = -90.f;
-  const float resolution_1 = 3.f;
-  const float resolution_2 = 12.f;
-  PolarPoint p_pol_invalid_1 = {};
-  p_pol_invalid_1.e = 94.f;
-  PolarPoint p_pol_invalid_2 = {};
-  p_pol_invalid_2.e = -999.f;
-  const float resolution_invalid_1 = 0.f;
-  const float resolution_invalid_2 = -1.f;
 
-  // WHEN: we convert the elevation angle to a histogram index
-  const int index_1 = polarToHistogramIndex(p_pol_1, resolution_1).y();
-  const int index_2 = polarToHistogramIndex(p_pol_2, resolution_1).y();
-  const int index_3 = polarToHistogramIndex(p_pol_1, resolution_2).y();
-  const int index_4 = polarToHistogramIndex(p_pol_2, resolution_2).y();
-  const int index_5 = polarToHistogramIndex(p_pol_3, resolution_2).y();
-  const int index_6 = polarToHistogramIndex(p_pol_4, resolution_2).y();
-  const int index_invalid_1 =
-      polarToHistogramIndex(p_pol_invalid_1, resolution_1).y();
-  const int index_invalid_2 =
-      polarToHistogramIndex(p_pol_invalid_2, resolution_1).y();
-  const int index_invalid_3 =
-      polarToHistogramIndex(p_pol_1, resolution_invalid_1).y();
-  const int index_invalid_4 =
-      polarToHistogramIndex(p_pol_1, resolution_invalid_2).y();
-
-  // THEN: the vertical histogram index should be ..
-  EXPECT_EQ(30, index_1);
-  EXPECT_EQ(41, index_2);
-  EXPECT_EQ(7, index_3);
-  EXPECT_EQ(10, index_4);
-  EXPECT_EQ(14, index_5);
-  EXPECT_EQ(0, index_6);
-  EXPECT_EQ(0, index_invalid_1);
-  EXPECT_EQ(0, index_invalid_2);
-  EXPECT_EQ(0, index_invalid_3);
-  EXPECT_EQ(0, index_invalid_4);
-}
-TEST(Common, azimuthAngletoIndex) {
-  // GIVEN: the azimuth angle of a point and the histogram resolution
+TEST(Common, polarToHistogramIndex) {
+  // GIVEN: the polar point and the histogram resolution
   PolarPoint p_pol_1 = {};
   PolarPoint p_pol_2 = {};
   PolarPoint p_pol_3 = {};
   PolarPoint p_pol_4 = {};
   PolarPoint p_pol_5 = {};
-  PolarPoint p_pol_invalid_1 = {};
-  PolarPoint p_pol_invalid_2 = {};
+  PolarPoint p_pol_6 = {};
+  p_pol_1.e = 0.f;
+  p_pol_2.e = 34.f;
+  p_pol_3.e = 90.f;
+  p_pol_4.e = -90.f;
+  p_pol_5.e = 454.f;  // wrapped around, influences the azimuth by 180 deg
+  p_pol_6.e = 400.f;  // wrapped around, no influence on azimuth
   p_pol_1.z = 0.f;
   p_pol_2.z = 34.f;
   p_pol_3.z = 180.f;
-  p_pol_4.z = 179.f;
-  p_pol_5.z = -180.f;
+  p_pol_4.z = -180.f;
+  p_pol_5.z = -160.f;
+  p_pol_6.z = -270.f;  // wrwapped around
   const float resolution_1 = 3.f;
   const float resolution_2 = 12.f;
-  p_pol_invalid_1.z = 194.f;
-  p_pol_invalid_2.z = -999.f;
-  const float resolution_invalid_1 = 0.f;
-  const float resolution_invalid_2 = -1.f;
 
-  // WHEN: we convert the azimuth angle to a histogram index
-  const int index_1 = polarToHistogramIndex(p_pol_1, resolution_1).x();
-  const int index_2 = polarToHistogramIndex(p_pol_2, resolution_1).x();
-  const int index_3 = polarToHistogramIndex(p_pol_1, resolution_2).x();
-  const int index_4 = polarToHistogramIndex(p_pol_2, resolution_2).x();
-  const int index_5 = polarToHistogramIndex(p_pol_3, resolution_2).x();
-  const int index_6 = polarToHistogramIndex(p_pol_4, resolution_2).x();
-  const int index_7 = polarToHistogramIndex(p_pol_5, resolution_2).x();
-  const int index_invalid_1 =
-      polarToHistogramIndex(p_pol_invalid_1, resolution_1).x();
-  const int index_invalid_2 =
-      polarToHistogramIndex(p_pol_invalid_1, resolution_1).x();
-  const int index_invalid_3 =
-      polarToHistogramIndex(p_pol_1, resolution_invalid_1).x();
-  const int index_invalid_4 =
-      polarToHistogramIndex(p_pol_1, resolution_invalid_2).x();
 
-  // THEN: the horizontal histogram index should be ..
-  EXPECT_EQ(60, index_1);
-  EXPECT_EQ(71, index_2);
-  EXPECT_EQ(15, index_3);
-  EXPECT_EQ(17, index_4);
-  EXPECT_EQ(0, index_5);
-  EXPECT_EQ(29, index_6);
-  EXPECT_EQ(0, index_7);
-  EXPECT_EQ(0, index_invalid_1);
-  EXPECT_EQ(0, index_invalid_2);
-  EXPECT_EQ(0, index_invalid_3);
-  EXPECT_EQ(0, index_invalid_4);
+  // WHEN: we convert the polar point to a histogram index
+  const Eigen::Vector2i index_1 = polarToHistogramIndex(p_pol_1, resolution_1);
+  const Eigen::Vector2i index_2 = polarToHistogramIndex(p_pol_2, resolution_1);
+  const Eigen::Vector2i index_3 = polarToHistogramIndex(p_pol_1, resolution_2);
+  const Eigen::Vector2i index_4 = polarToHistogramIndex(p_pol_2, resolution_2);
+  const Eigen::Vector2i index_5 = polarToHistogramIndex(p_pol_3, resolution_2);
+  const Eigen::Vector2i index_6 = polarToHistogramIndex(p_pol_4, resolution_2);
+  const Eigen::Vector2i index_7 =
+      polarToHistogramIndex(p_pol_5, resolution_1);  // wrapped
+  const Eigen::Vector2i index_8 =
+      polarToHistogramIndex(p_pol_6, resolution_2);  // wrapped
+
+  // THEN: the  histogram index should be ..
+  // elevation angle 
+  EXPECT_EQ(30, index_1.y());
+  EXPECT_EQ(41, index_2.y());
+  EXPECT_EQ(7, index_3.y());
+  EXPECT_EQ(10, index_4.y());
+  EXPECT_EQ(14, index_5.y());
+  EXPECT_EQ(0, index_6.y());
+  EXPECT_EQ(58, index_7.y());
+  EXPECT_EQ(10, index_8.y());
+  // azimuth angle
+  EXPECT_EQ(60, index_1.x());
+  EXPECT_EQ(71, index_2.x());
+  EXPECT_EQ(15, index_3.x());
+  EXPECT_EQ(17, index_4.x());
+  EXPECT_EQ(0, index_5.x());
+  EXPECT_EQ(0, index_6.x());
+  EXPECT_EQ(66, index_7.x());
+  EXPECT_EQ(22, index_8.x());
 }
 
 TEST(Common, polarToCartesian) {


### PR DESCRIPTION
before elevation angle and azimuth angle were converted separately to histogram index. 
    - the logic for azimuth angle larger than 180 deg and smaller than -180 deg were converted to index 0, which is a valid index.  
   -  the logic for elevation angle larger than 90 deg and smaller than -90 deg were converted to index 0, which is a valid index. 

after change: 
- wrap any elevation and azimuth angle input to valid elevation (-90,90]  and azimuth (-180, 180] angles 
- if the elevation angle was not in the valid angle region before and needs to be wrapped over the top or under neath, the azimuth angle is accordingly wrapped 180 degrees due to the jump
- if the azimuth angle needs to be wrapped, the elevation angle won't be changed as no jump occurred


- depending tests were adapted
- tested in sitl
