### PR TITLE
Pr fix auto exposure

### DIFF
--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -85,3 +85,20 @@ cat >> local_planner/launch/avoidance.launch <<- EOM
 EOM
 # Set the frame rate in the JSON file as well
 sed -i '/stream-fps/c\    \"stream-fps\": \"'$DEPTH_CAMERA_FRAME_RATE'\",' local_planner/resource/stereo_calib.json
+
+# Fix the on/of script for realsense auto-exposure
+cat > local_planner/resource/realsense_params.sh <<- EOM
+#!/bin/bash
+# Disable and enable auto-exposure for all cameras as it doesn not work at startup
+EOM
+
+# The CAMERA_CONFIGS string has semi-colon separated camera configurations
+IFS=";"
+for camera in $CAMERA_CONFIGS; do
+  IFS="," #Inside each camera configuration, the parameters are comma-separated
+  set $camera
+  cat >> local_planner/resource/realsense_params.sh <<- EOM
+    rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
+    rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
+  EOM
+done

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -28,6 +28,12 @@ cat > local_planner/launch/avoidance.launch <<- EOM
     <!-- Launch cameras -->
 EOM
 
+# Fix the on/of script for realsense auto-exposure
+cat > local_planner/resource/realsense_params.sh <<- EOM
+#!/bin/bash
+# Disable and enable auto-exposure for all cameras as it does not work at startup
+EOM
+
 # Set the frame rate to 15 if it is undefined
 if [ -z $DEPTH_CAMERA_FRAME_RATE ]; then
   DEPTH_CAMERA_FRAME_RATE=15
@@ -47,7 +53,9 @@ for camera in $CAMERA_CONFIGS; do
 		else
 			camera_topics="$camera_topics,/$1/depth/points"
 		fi
-		cat >> local_planner/launch/avoidance.launch <<- EOM
+
+    # Append to the launch file
+    cat >> local_planner/launch/avoidance.launch <<- EOM
 			<node pkg="tf" type="static_transform_publisher" name="tf_$1"
 			 args="$3 $4 $5 $6 $7 $8 fcu $1_link 10"/>
 			<include file="\$(find local_planner)/launch/rs_depthcloud.launch">
@@ -62,6 +70,12 @@ for camera in $CAMERA_CONFIGS; do
 				<arg name="enable_fisheye"        value="false"/>
 			</include>
 		EOM
+
+    # Append to the realsense auto exposure togglening
+    echo "rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
+rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
+" >> local_planner/resource/realsense_params.sh
+
 	fi
 done
 
@@ -83,22 +97,6 @@ cat >> local_planner/launch/avoidance.launch <<- EOM
 
 </launch>
 EOM
+
 # Set the frame rate in the JSON file as well
 sed -i '/stream-fps/c\    \"stream-fps\": \"'$DEPTH_CAMERA_FRAME_RATE'\",' local_planner/resource/stereo_calib.json
-
-# Fix the on/of script for realsense auto-exposure
-cat > local_planner/resource/realsense_params.sh <<- EOM
-  #!/bin/bash
-  # Disable and enable auto-exposure for all cameras as it doesn not work at startup
-EOM
-
-# The CAMERA_CONFIGS string has semi-colon separated camera configurations
-IFS=";"
-for camera in $CAMERA_CONFIGS; do
-  IFS="," #Inside each camera configuration, the parameters are comma-separated
-  set $camera
-  cat >> local_planner/resource/realsense_params.sh <<- EOM
-    rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
-    rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
-  EOM
-done

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -71,7 +71,7 @@ for camera in $CAMERA_CONFIGS; do
 			</include>
 		EOM
 
-    # Append to the realsense auto exposure togglening
+    # Append to the realsense auto exposure toggling
     echo "rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 0
 rosrun dynamic_reconfigure dynparam set /$1/realsense2_camera_manager rs435_depth_enable_auto_exposure 1
 " >> local_planner/resource/realsense_params.sh

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -88,8 +88,8 @@ sed -i '/stream-fps/c\    \"stream-fps\": \"'$DEPTH_CAMERA_FRAME_RATE'\",' local
 
 # Fix the on/of script for realsense auto-exposure
 cat > local_planner/resource/realsense_params.sh <<- EOM
-#!/bin/bash
-# Disable and enable auto-exposure for all cameras as it doesn not work at startup
+  #!/bin/bash
+  # Disable and enable auto-exposure for all cameras as it doesn not work at startup
 EOM
 
 # The CAMERA_CONFIGS string has semi-colon separated camera configurations


### PR DESCRIPTION
This adds additional logic to the generate_launchfile.sh in order to properly toggle the auto-exposure in the script `realsense_params.sh`