### PR TITLE
Fail travis if tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,5 @@ script:
   - cd src/avoidance
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - ./check_code_format.sh
-  - catkin build local_planner --no-deps -v -i --catkin-make-args run_tests
+  - catkin build local_planner global_planner --no-deps -v -i --catkin-make-args tests
+  - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do $f || status=1; done && exit $status


### PR DESCRIPTION
Right now catkin returns 0 (pass) even if the tests fail. We need to run the test binaries manually after catkin builds them to get the result correctly.

This new test running is show to work on this example commit with a broken test: https://travis-ci.org/PX4/avoidance/builds/489970548?utm_source=github_status&utm_medium=notification

