### PR TITLE
Yaw smoothing and protect against inf/nan desired setpoints

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -125,8 +125,6 @@ class LocalPlannerNode {
   void publishSetpoint(const geometry_msgs::Twist& wp,
                        waypoint_choice& waypoint_type);
   void threadFunction();
-  void getInterimWaypoint(geometry_msgs::PoseStamped& wp,
-                          geometry_msgs::Twist& wp_vel);
   bool canUpdatePlannerInfo();
   void updatePlannerInfo();
   size_t numReceivedClouds();

--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -59,7 +59,8 @@ class WaypointGenerator {
   bool waypoint_outside_FOV_;
   double last_yaw_;
   double yaw_reached_goal_;
-  double new_yaw_;
+  double new_yaw_ = 0.0;
+  double new_yaw_velocity_ = 0.0;
   double speed_ = 1.0;
   int e_FOV_max_, e_FOV_min_;
   float h_FOV_ = 59.0f;
@@ -104,6 +105,11 @@ class WaypointGenerator {
   * @param[in] dt, time elapsed between two cycles
   **/
   void smoothWaypoint(double dt);
+  /**
+  * @brief     set next yaw, smoothed with a critically damped PD controller
+  * @param[in] dt, time elapsed between two cycles
+  **/
+  void nextSmoothYaw(double dt);
   /**
   * @brief     change speed depending on the presence of obstacles, proximity to
   *            the goal, and waypoint lying with the FOV

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -118,21 +118,11 @@ double velocityLinear(double max_vel, double slope, double v_old,
 }
 
 void wrapAngleToPlusMinusPI(double& angle) {
-  while (angle > M_PI) {
-    angle -= 2 * M_PI;
-  }
-  while (angle < -M_PI) {
-    angle += 2 * M_PI;
-  }
+  angle = angle - 2 * M_PI * floor(angle / (2 * M_PI) + 0.5);
 }
 
 void wrapAngleToPlusMinus180(float& angle) {
-  while (angle >= 180.0) {
-    angle -= 360.0;
-  }
-  while (angle < -180.0) {
-    angle += 360.0;
-  }
+  angle = angle - 360.f * floor(angle / 360.f + 0.5f);
 }
 
 double getAngularVelocity(double desired_yaw, double curr_yaw) {

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -634,16 +634,10 @@ void LocalPlannerNode::updateGoalCallback(
 void LocalPlannerNode::fcuInputGoalCallback(
     const mavros_msgs::Trajectory& msg) {
   if ((msg.point_valid[1] == true) &&
-      ((std::fabs(goal_msg_.pose.position.x - msg.point_2.position.x) >
-        0.001) ||
-       (std::fabs(goal_msg_.pose.position.y - msg.point_2.position.y) >
-        0.001) ||
-       (std::fabs(goal_msg_.pose.position.z - msg.point_2.position.z) >
-        0.001))) {
+      (toEigen(goal_msg_.pose.position) - toEigen(msg.point_2.position))
+              .norm() > 0.01) {
     new_goal_ = true;
-    goal_msg_.pose.position.x = msg.point_2.position.x;
-    goal_msg_.pose.position.y = msg.point_2.position.y;
-    goal_msg_.pose.position.z = msg.point_2.position.z;
+    goal_msg_.pose.position = msg.point_2.position;
   }
 }
 

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -195,7 +195,8 @@ void WaypointGenerator::reachGoalAltitudeFirst() {
 
   // if goal lies directly overhead, do not yaw
   float goal_acceptance_radius = 1.0f;
-  if ((goal_ - toEigen(pose_.pose.position)).norm() < goal_acceptance_radius) {
+  if ((goal_ - toEigen(pose_.pose.position)).norm() < goal_acceptance_radius &&
+      std::isfinite(curr_yaw_)) {
     new_yaw_ = curr_yaw_;
   }
 
@@ -390,7 +391,7 @@ void WaypointGenerator::getPathMsg() {
     output_.smoothed_goto_position = toPoint(goal_);
   }
 
-  if (reached_goal_) {
+  if (reached_goal_ && std::isfinite(yaw_reached_goal_)) {
     new_yaw_ = yaw_reached_goal_;
   }
 

--- a/local_planner/test/test_common.cpp
+++ b/local_planner/test/test_common.cpp
@@ -341,6 +341,7 @@ TEST(Common, wrapAngle) {
   double angle3 = 270.d * M_PI / 180.d;
   double angle4 = -90.d * M_PI / 180.d;
   double angle5 = -225.d * M_PI / 180.d;
+  double angle6 = std::numeric_limits<double>::infinity();
 
   // WHEN: it is wrapped to the space (-PI; PI] space
   wrapAngleToPlusMinusPI(angle1);
@@ -348,12 +349,15 @@ TEST(Common, wrapAngle) {
   wrapAngleToPlusMinusPI(angle3);
   wrapAngleToPlusMinusPI(angle4);
   wrapAngleToPlusMinusPI(angle5);
+  wrapAngleToPlusMinusPI(angle6);
+
   // THEN: the output angles shoudl be ..
   EXPECT_FLOAT_EQ(0.f, angle1);
   EXPECT_FLOAT_EQ(0.523599f, angle2);
   EXPECT_FLOAT_EQ(-1.570796f, angle3);
   EXPECT_FLOAT_EQ(-1.570796f, angle4);
   EXPECT_FLOAT_EQ(2.356194f, angle5);
+  EXPECT_TRUE(std::isnan(angle6));
 }
 
 TEST(Common, getAngularVel) {
@@ -372,7 +376,7 @@ TEST(Common, getAngularVel) {
   // THEN: the distance should be...
 
   EXPECT_FLOAT_EQ(0.f, angular_vel1);
-  EXPECT_FLOAT_EQ(1.570796f, angular_vel2);
+  EXPECT_FLOAT_EQ(-1.570796f, angular_vel2);
   EXPECT_FLOAT_EQ(0.392699f, angular_vel3);
   EXPECT_FLOAT_EQ(-1.178097f, angular_vel4);
 }

--- a/local_planner/test/test_waypoint_generator.cpp
+++ b/local_planner/test/test_waypoint_generator.cpp
@@ -287,18 +287,18 @@ TEST_F(WaypointGeneratorTests, hoverTest) {
   EXPECT_NEAR(0.0003, result.position_waypoint.pose.position.y, 0.001);
   EXPECT_NEAR(2.999, result.position_waypoint.pose.position.z, 0.001);
 
-  EXPECT_NEAR(0.0, result.position_waypoint.pose.orientation.x, 0.001);
-  EXPECT_NEAR(0.0, result.position_waypoint.pose.orientation.y, 0.001);
-  EXPECT_NEAR(0.0, result.position_waypoint.pose.orientation.z, 0.001);
-  EXPECT_NEAR(1.0, result.position_waypoint.pose.orientation.w, 0.001);
+  EXPECT_NEAR(0.0, result.position_waypoint.pose.orientation.x, 0.1);
+  EXPECT_NEAR(0.0, result.position_waypoint.pose.orientation.y, 0.1);
+  EXPECT_NEAR(0.15, result.position_waypoint.pose.orientation.z, 0.1);
+  EXPECT_NEAR(0.9, result.position_waypoint.pose.orientation.w, 0.1);
 
   EXPECT_NEAR(0.0002, result.velocity_waypoint.linear.x, 0.001);
   EXPECT_NEAR(0.0003, result.velocity_waypoint.linear.y, 0.001);
   EXPECT_NEAR(0.999, result.velocity_waypoint.linear.z, 0.001);
 
-  EXPECT_NEAR(0.0, result.velocity_waypoint.angular.x, 0.001);
-  EXPECT_NEAR(0.0, result.velocity_waypoint.angular.y, 0.001);
-  EXPECT_NEAR(0.0, result.velocity_waypoint.angular.z, 0.001);
+  EXPECT_NEAR(0.0, result.velocity_waypoint.angular.x, 0.1);
+  EXPECT_NEAR(0.0, result.velocity_waypoint.angular.y, 0.1);
+  EXPECT_NEAR(0.2, result.velocity_waypoint.angular.z, 0.1);
 }
 
 TEST_F(WaypointGeneratorTests, costmapTest) {


### PR DESCRIPTION
In case the goal gets set to the exact location of the drone, or at an infinite distance, this protects the yaw from becoming +-Inf or Nan.

It also smooths the yaw so instantaneous setpoint changes don't get propagated to the flight controller.