### PR TITLE
Don't check for mission mode when setting trajectory triple points

### DIFF
--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -707,7 +707,7 @@ void LocalPlannerNode::updateGoalCallback(
 
 void LocalPlannerNode::fcuInputGoalCallback(
     const mavros_msgs::Trajectory& msg) {
-  if (mission_ && (msg.point_valid[1] == true) &&
+  if ((msg.point_valid[1] == true) &&
       ((std::fabs(goal_msg_.pose.position.x - msg.point_2.position.x) >
         0.001) ||
        (std::fabs(goal_msg_.pose.position.y - msg.point_2.position.y) >


### PR DESCRIPTION
When the serial communication between FCU and companion is congested, it can result in the first waypoint arriving before the avoidance has switched to mission mode, causing the waypoint to be discarded.

Not checking for mission mode shouldn't have any side effects, since trajectory triples aren't sent unless we want the avoidance running anyway.