### PR TITLE
Initialize node handle in main function

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -102,7 +102,7 @@ enum class MAV_STATE {
 
 class LocalPlannerNode {
  public:
-  LocalPlannerNode(const bool tf_spin_thread = true);
+  LocalPlannerNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const bool tf_spin_thread = true);
   ~LocalPlannerNode();
 
   mavros_msgs::CompanionProcessStatus status_msg_;
@@ -232,10 +232,10 @@ class LocalPlannerNode {
   void checkFailsafe(ros::Duration since_last_cloud, ros::Duration since_start,
                      bool& planner_is_healthy, bool& hover);
 
-  const ros::NodeHandle& nodeHandle() const { return nh_; }
-
  private:
   ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
   avoidance::LocalPlannerNodeConfig rqt_param_config_;
 
   mavros_msgs::Altitude ground_distance_msg_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -102,7 +102,8 @@ enum class MAV_STATE {
 
 class LocalPlannerNode {
  public:
-  LocalPlannerNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const bool tf_spin_thread = true);
+  LocalPlannerNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private,
+                   const bool tf_spin_thread = true);
   ~LocalPlannerNode();
 
   mavros_msgs::CompanionProcessStatus status_msg_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -15,10 +15,13 @@
 
 namespace avoidance {
 
-LocalPlannerNode::LocalPlannerNode(const bool tf_spin_thread) {
+LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
+                                   const ros::NodeHandle& nh_private,
+                                   const bool tf_spin_thread)
+    : nh_(nh), nh_private_(nh_private) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
-  nh_ = ros::NodeHandle("~");
+
   readParams();
 
   tf_listener_ = new tf::TransformListener(

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -8,7 +8,10 @@
 int main(int argc, char** argv) {
   using namespace avoidance;
   ros::init(argc, argv, "local_planner_node");
-  LocalPlannerNode Node(true);
+  ros::NodeHandle nh("~");
+  ros::NodeHandle nh_private("");
+
+  LocalPlannerNode Node(nh, nh_private, true);
   ros::Duration(2).sleep();
   ros::Time start_time = ros::Time::now();
   bool hover = false;

--- a/local_planner/test/test_local_planner_node.cpp
+++ b/local_planner/test/test_local_planner_node.cpp
@@ -6,7 +6,9 @@ using namespace avoidance;
 
 TEST(LocalPlannerNodeTests, failsafe) {
   ros::Time::init();
-  LocalPlannerNode Node(false);
+  ros::NodeHandle nh("~");
+  ros::NodeHandle nh_private("");
+  LocalPlannerNode Node(nh, nh_private, false);
   bool planner_is_healthy = true;
   bool hover = false;
 

--- a/local_planner/test/valgrind_suppressions.sup
+++ b/local_planner/test/valgrind_suppressions.sup
@@ -13,9 +13,8 @@
    fun:_ZN3ros5startEv
    fun:_ZN3ros10NodeHandle9constructERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb
    fun:_ZN3ros10NodeHandleC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKSt3mapIS6_S6_St4lessIS6_ESaISt4pairIS7_S6_EEE
-   fun:_ZN9avoidance16LocalPlannerNodeC1Eb
    fun:_ZN35LocalPlannerNodeTests_failsafe_Test8TestBodyEv
-   fun:HandleSehExceptionsInMethodIfSupported<testing::Test, void>
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
    fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
    fun:_ZN7testing4Test3RunEv
 }


### PR DESCRIPTION
This PR initializes the node handle in the main function.

This enables multiple objects to consume node handle within the local planner object in the constructor.