### PR TITLE
Don't send direct mode changes from the planner

### DIFF
--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char** argv) {
   ros::Duration(2).sleep();
   ros::Time start_time = ros::Time::now();
   bool hover = false;
-  bool landing = false;
+  bool planner_is_healthy = true;
   avoidanceOutput planner_output;
   Node.local_planner_->disable_rise_to_goal_altitude_ =
       Node.disable_rise_to_goal_altitude_;
@@ -55,8 +55,8 @@ int main(int argc, char** argv) {
 
     if (since_last_cloud > pointcloud_timeout_land &&
         since_start > pointcloud_timeout_land) {
-      if (!landing) {
-        landing = true;
+      if (planner_is_healthy) {
+    	planner_is_healthy = false;
         Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
         ROS_WARN("\033[1;33m Pointcloud timeout: Aborting \n \033[0m");
       }
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
     }
 
     // send waypoint
-    if (!Node.never_run_ && !landing) {
+    if (!Node.never_run_ && planner_is_healthy) {
       Node.publishWaypoints(hover);
       if (!hover) Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
     } else {

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -56,17 +56,9 @@ int main(int argc, char** argv) {
     if (since_last_cloud > pointcloud_timeout_land &&
         since_start > pointcloud_timeout_land) {
       if (!landing) {
-        mavros_msgs::SetMode mode_msg;
-        mode_msg.request.custom_mode = "AUTO.LOITER";
         landing = true;
         Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
-        if (Node.mavros_set_mode_client_.call(mode_msg) &&
-            mode_msg.response.mode_sent) {
-          ROS_WARN("\033[1;33m Pointcloud timeout: Landing \n \033[0m");
-        } else {
-          ROS_ERROR(
-              "\033[1;33m Pointcloud timeout: Landing failed! \n \033[0m");
-        }
+        ROS_WARN("\033[1;33m Pointcloud timeout: Aborting \n \033[0m");
       }
     } else {
       if (Node.never_run_ || (since_last_cloud > pointcloud_timeout_hover &&

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
     if (since_last_cloud > pointcloud_timeout_land &&
         since_start > pointcloud_timeout_land) {
       if (planner_is_healthy) {
-    	planner_is_healthy = false;
+        planner_is_healthy = false;
         Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
         ROS_WARN("\033[1;33m Pointcloud timeout: Aborting \n \033[0m");
       }


### PR DESCRIPTION
The local planner should not be able to force mode changes. The planner was able to force the drone to hover if it was not getting sensor data. No matter whether the avoidance was even enabled or if the drone was in mission. This produced situations, where the drone constantly switched from position back to hover because to local_planner (running in the background) was struggling.

Sending hover from the planner is not necessary anymore anyway as PR [#11187](https://github.com/PX4/Firmware/pull/11187) handles failsafe actions.