### PR TITLE
Disable gazebo client by default

### DIFF
--- a/local_planner/launch/local_planner_sitl_mavros.launch
+++ b/local_planner/launch/local_planner_sitl_mavros.launch
@@ -3,7 +3,7 @@
 
     <arg name="world_path" default="$(find local_planner)/../sim/worlds/outdoor_village_3.world" />
     <arg name="headless" default="false"/>
-    <arg name="gui" default="true"/>
+    <arg name="gui" default="false"/>
     <arg name="ns" default="/"/>
     <arg name="model" default="iris_depth_camera"/>
     <arg name="build" default="px4_sitl_default"/>


### PR DESCRIPTION
Since we have the RVIZ visualization anyway, I disabled the gazebo GUI
by default. This makes SITL run significantly better. Open to discuss
whether we want to merge this or not