### PR TITLE
do not consider histogram cells full if the contain very little points

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -17,6 +17,7 @@ gen.add("keep_distance_", double_t, 0, "Distance at which the UAV stops in front
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_cloud_size_", int_t, 0, "Discard pointclouds smaller than this value", 200, 0, 5000)
+gen.add("n_points_occupied_", int_t, 0, "Histogram cells with less points are empty", 10, 0, 500)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
 gen.add("min_dist_backoff_", double_t, 0, "min dist before backing off", 1.5, 0, 10)
 gen.add("pointcloud_timeout_hover_", double_t, 0, "after this timeout the controller sends hover commands", 0.5, 0, 10)

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -61,6 +61,7 @@ class LocalPlanner {
   int n_expanded_nodes_;
   int reproj_age_;
   int counter_close_points_backoff_ = 0;
+  int n_points_occupied_ = 10;
 
   float velocity_mod_;
   float curr_yaw_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -87,7 +87,8 @@ void propagateHistogram(
 **/
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
-                          const Eigen::Vector3f& position);
+                          const Eigen::Vector3f& position,
+                          const Eigen::Vector3f& n_points_occupied);
 
 /**
 * @brief      merges together the histogram calculated with the current frame

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -84,11 +84,12 @@ void propagateHistogram(
 * @param[out] polar_histogram, represents cropped_cloud
 * @param[in]  cropped_cloud, current frame filtered pointcloud
 * @param[in]  position, current vehicle position
+* @param[in]  minimum number of data points to react to the object
 **/
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
                           const Eigen::Vector3f& position,
-                          const Eigen::Vector3f& n_points_occupied);
+                          int n_points_occupied);
 
 /**
 * @brief      merges together the histogram calculated with the current frame

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -28,6 +28,7 @@ class StarPlanner {
   float v_FOV_ = 46.0f;
   int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
+  int n_points_occupied_ = 10;
   float tree_node_distance_ = 1.0f;
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -58,6 +58,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
 
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
   min_cloud_size_ = config.min_cloud_size_;
+  n_points_occupied_ = config.n_points_occupied_;
   min_realsense_dist_ = static_cast<float>(config.min_realsense_dist_);
   min_dist_backoff_ = static_cast<float>(config.min_dist_backoff_);
   pointcloud_timeout_hover_ =
@@ -141,7 +142,7 @@ void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
   propagateHistogram(propagated_histogram, reprojected_points_,
                      reprojected_points_age_, toEigen(pose_.pose.position));
   generateNewHistogram(new_histogram, final_cloud_,
-                       toEigen(pose_.pose.position));
+                       toEigen(pose_.pose.position), n_points_occupied_);
   combinedHistogram(hist_is_empty_, new_histogram, propagated_histogram,
                     waypoint_outside_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_);
   if (send_to_fcu) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -154,7 +154,7 @@ void propagateHistogram(
 // Generate new histogram from pointcloud
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
-                          const Eigen::Vector3f& position) {
+                          const Eigen::Vector3f& position, int n_points_occupied) {
   Eigen::MatrixXi counter(GRID_LENGTH_E, GRID_LENGTH_Z);
   counter.fill(0);
   for (auto xyz : cropped_cloud) {
@@ -172,7 +172,7 @@ void generateNewHistogram(Histogram& polar_histogram,
   // Normalize and get mean in distance bins
   for (int e = 0; e < GRID_LENGTH_E; e++) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
-      if (counter(e, z) > 0) {
+      if (counter(e, z) > n_points_occupied) {
         polar_histogram.set_dist(
             e, z, polar_histogram.get_dist(e, z) / counter(e, z));
       } else {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -154,7 +154,8 @@ void propagateHistogram(
 // Generate new histogram from pointcloud
 void generateNewHistogram(Histogram& polar_histogram,
                           const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud,
-                          const Eigen::Vector3f& position, int n_points_occupied) {
+                          const Eigen::Vector3f& position,
+                          int n_points_occupied) {
   Eigen::MatrixXi counter(GRID_LENGTH_E, GRID_LENGTH_Z);
   counter.fill(0);
   for (auto xyz : cropped_cloud) {

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -17,6 +17,7 @@ void StarPlanner::dynamicReconfigureSetStarParams(
   tree_node_distance_ = static_cast<float>(config.tree_node_distance_);
   tree_discount_factor_ = static_cast<float>(config.tree_discount_factor_);
   max_path_length_ = static_cast<float>(config.max_path_length_);
+  n_points_occupied_ = config.n_points_occupied_;
 }
 
 void StarPlanner::setParams(costParameters cost_params) {
@@ -147,7 +148,8 @@ void StarPlanner::buildLookAheadTree() {
 
     propagateHistogram(propagated_histogram, reprojected_points_,
                        reprojected_points_age_, origin_position);
-    generateNewHistogram(histogram, pointcloud_, origin_position);
+    generateNewHistogram(histogram, pointcloud_, origin_position,
+                         n_points_occupied_);
     combinedHistogram(hist_is_empty, histogram, propagated_histogram, false,
                       z_FOV_idx, e_FOV_min, e_FOV_max);
 

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -35,10 +35,11 @@ TEST(PlannerFunctions, generateNewHistogramEmpty) {
   location.pose.position.x = 0;
   location.pose.position.y = 0;
   location.pose.position.z = 0;
+  int min_n_points = 1;
 
   // WHEN: we build a histogram
   generateNewHistogram(histogram_output, empty_cloud,
-                       toEigen(location.pose.position));
+                       toEigen(location.pose.position), min_n_points);
 
   // THEN: the histogram should be all zeros
   for (int e = 0; e < GRID_LENGTH_E; e++) {
@@ -56,6 +57,7 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   location.pose.position.y = 0;
   location.pose.position.z = 0;
   float distance = 1.0f;
+  int min_n_points = 1;
 
   std::vector<float> e_angle_filled = {-89.9f, -30.0f, 0.0f,
                                        20.0f,  40.0f,  89.9f};
@@ -82,8 +84,8 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   }
 
   // WHEN: we build a histogram
-  generateNewHistogram(histogram_output, cloud,
-                       toEigen(location.pose.position));
+  generateNewHistogram(histogram_output, cloud, toEigen(location.pose.position),
+                       min_n_points);
 
   // THEN: the filled cells in the histogram should be one and the others be
   // zeros


### PR DESCRIPTION
This got dropped somewhere in all the changes. Originally the was a minimum of points which make up a blocked histogram cell. As it was now, the cell would be blocked even if it contains just one point, which makes the algorithm very sensitive to noise.

Should be flight tested, as I'm not sure, when we lost this and if the chosen default value of 10 points is compatible with the Realsense.