### PR TITLE
Improve path following behavior. Visualize non-smoothed wp path

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -123,6 +123,8 @@ class LocalPlannerNode {
   geometry_msgs::PoseStamped last_pose_;
   geometry_msgs::Point newest_waypoint_position_;
   geometry_msgs::Point last_waypoint_position_;
+  geometry_msgs::Point newest_adapted_waypoint_position_;
+  geometry_msgs::Point last_adapted_waypoint_position_;
   geometry_msgs::PoseStamped goal_msg_;
 
   ros::Time last_wp_time_;
@@ -244,6 +246,7 @@ class LocalPlannerNode {
   ros::Publisher marker_pub_;
   ros::Publisher path_actual_pub_;
   ros::Publisher path_waypoint_pub_;
+  ros::Publisher path_adapted_waypoint_pub_;
   ros::Publisher marker_goal_pub_;
   ros::Publisher takeoff_pose_pub_;
   ros::Publisher offboard_pose_pub_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -191,6 +191,7 @@ void printHistogram(Histogram& histogram);
 bool getDirectionFromTree(
     PolarPoint& p_pol,
     const std::vector<geometry_msgs::Point>& path_node_positions,
-    const Eigen::Vector3f& position);
+    const Eigen::Vector3f& position,
+	const Eigen::Vector3f& goal);
 }
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -191,7 +191,6 @@ void printHistogram(Histogram& histogram);
 bool getDirectionFromTree(
     PolarPoint& p_pol,
     const std::vector<geometry_msgs::Point>& path_node_positions,
-    const Eigen::Vector3f& position,
-	const Eigen::Vector3f& goal);
+    const Eigen::Vector3f& position, const Eigen::Vector3f& goal);
 }
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -346,8 +346,10 @@ void LocalPlannerNode::publishPaths() {
   path_adapted_waypoint_marker.color.g = 0.0;
   path_adapted_waypoint_marker.color.b = 1.0;
 
-  path_adapted_waypoint_marker.points.push_back(last_adapted_waypoint_position_);
-  path_adapted_waypoint_marker.points.push_back(newest_adapted_waypoint_position_);
+  path_adapted_waypoint_marker.points.push_back(
+      last_adapted_waypoint_position_);
+  path_adapted_waypoint_marker.points.push_back(
+      newest_adapted_waypoint_position_);
   path_adapted_waypoint_pub_.publish(path_adapted_waypoint_marker);
 
   path_length_++;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -86,6 +86,8 @@ LocalPlannerNode::LocalPlannerNode() {
       nh_.advertise<visualization_msgs::Marker>("/path_actual", 1);
   path_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/path_waypoint", 1);
+  path_adapted_waypoint_pub_ =
+      nh_.advertise<visualization_msgs::Marker>("/path_adapted_waypoint", 1);
   mavros_vel_setpoint_pub_ = nh_.advertise<geometry_msgs::Twist>(
       "/mavros/setpoint_velocity/cmd_vel_unstamped", 10);
   mavros_pos_setpoint_pub_ = nh_.advertise<geometry_msgs::PoseStamped>(
@@ -330,6 +332,24 @@ void LocalPlannerNode::publishPaths() {
   path_waypoint_marker.points.push_back(newest_waypoint_position_);
   path_waypoint_pub_.publish(path_waypoint_marker);
 
+  // publish path set by calculated waypoints
+  visualization_msgs::Marker path_adapted_waypoint_marker;
+  path_adapted_waypoint_marker.header.frame_id = "local_origin";
+  path_adapted_waypoint_marker.header.stamp = ros::Time::now();
+  path_adapted_waypoint_marker.id = path_length_;
+  path_adapted_waypoint_marker.type = visualization_msgs::Marker::LINE_STRIP;
+  path_adapted_waypoint_marker.action = visualization_msgs::Marker::ADD;
+  path_adapted_waypoint_marker.pose.orientation.w = 1.0;
+  path_adapted_waypoint_marker.scale.x = 0.02;
+  path_adapted_waypoint_marker.color.a = 1.0;
+  path_adapted_waypoint_marker.color.r = 0.0;
+  path_adapted_waypoint_marker.color.g = 0.0;
+  path_adapted_waypoint_marker.color.b = 1.0;
+
+  path_adapted_waypoint_marker.points.push_back(last_adapted_waypoint_position_);
+  path_adapted_waypoint_marker.points.push_back(newest_adapted_waypoint_position_);
+  path_adapted_waypoint_pub_.publish(path_adapted_waypoint_marker);
+
   path_length_++;
 }
 
@@ -545,6 +565,8 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
 
   last_waypoint_position_ = newest_waypoint_position_;
   newest_waypoint_position_ = result.smoothed_goto_position;
+  last_adapted_waypoint_position_ = newest_adapted_waypoint_position_;
+  newest_adapted_waypoint_position_ = result.adapted_goto_position;
   publishPaths();
   publishSetpoint(result.velocity_waypoint, result.waypoint_type);
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -463,7 +463,10 @@ bool getDirectionFromTree(
                                         path_node_positions.end());
     int size_extended = path_node_positions_extended.size();
 
-    // find path nodes between which the drone is currently located
+    // find path nodes between which the drone is currently located:
+    // a vector with the distances of each node to the drone is generated
+    // the indices of the nodes with smallest and next smallest distance are
+    // found
     int min_dist_idx = 0;
     int second_min_dist_idx = 0;
     float min_dist = HUGE_VAL;
@@ -484,11 +487,15 @@ bool getDirectionFromTree(
         second_min_dist_idx = i;
       }
     }
+
+    // the drone is located between the two nodes(min_dist_idx,
+    // second_min_dist_idx),
+    // wp_idx describes the node further ahead in the path
     int wp_idx = std::min(min_dist_idx, second_min_dist_idx);
 
-    if (min_dist > 3.0 ||
-        wp_idx ==
-            0) {  // too far away from tree or drone already passed the tree
+    // if drone is too far away from tree or already at last node -> don't use
+    // tree
+    if (min_dist > 3.0f || wp_idx == 0) {
       tree_available = false;
     } else {
       float cos_alpha = (node_distance * node_distance +

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -439,23 +439,32 @@ float costFunction(float e_angle, float z_angle, float obstacle_distance,
 bool getDirectionFromTree(
     PolarPoint& p_pol,
     const std::vector<geometry_msgs::Point>& path_node_positions,
-    const Eigen::Vector3f& position) {
+    const Eigen::Vector3f& position, const Eigen::Vector3f& goal) {
   int size = path_node_positions.size();
   bool tree_available = true;
 
-  if (size > 0) {
+  if (size > 1) { //path contains at least 2 points (current position and one wp)
+
+	//extend path with a node at the end in goal direction (for smoother transition to direct flight)
+	float node_distance =
+	          (toEigen(path_node_positions[0]) - toEigen(path_node_positions[1])).norm();
+	Eigen::Vector3f dir_last_node_to_goal = (goal - toEigen(path_node_positions[0])).normalized();
+	geometry_msgs::Point goal_node = toPoint(toEigen(path_node_positions[0]) + node_distance * dir_last_node_to_goal);
+	std::vector<geometry_msgs::Point> path_node_positions_extended;
+	path_node_positions_extended.push_back(goal_node);
+	path_node_positions_extended.insert(path_node_positions_extended.end(), path_node_positions.begin(), path_node_positions.end());
+	int size_extended = path_node_positions_extended.size();
+
+	//find path nodes between which the drone is currently located
     int min_dist_idx = 0;
     int second_min_dist_idx = 0;
     float min_dist = HUGE_VAL;
     float second_min_dist = HUGE_VAL;
-    float node_distance =
-        (toEigen(path_node_positions[0]) - toEigen(path_node_positions[1]))
-            .norm();
-
     std::vector<float> distances;
-    distances.reserve(size);
-    for (int i = 0; i < size; i++) {
-      distances.push_back((position - toEigen(path_node_positions[i])).norm());
+    distances.reserve(size_extended);
+
+    for (int i = 0; i < size_extended; i++) {
+      distances.push_back((position - toEigen(path_node_positions_extended[i])).norm());
       if (distances[i] < min_dist) {
         second_min_dist_idx = min_dist_idx;
         second_min_dist = min_dist;
@@ -467,15 +476,9 @@ bool getDirectionFromTree(
       }
     }
     int wp_idx = std::min(min_dist_idx, second_min_dist_idx);
-    if (min_dist > 3.0f) {
+
+    if (min_dist > 3.0 || wp_idx == 0 ) {  //too far away from tree or drone already passed the tree
       tree_available = false;
-    } else if (wp_idx == 0) {
-      if (size == 2) {
-        p_pol = cartesianToPolar(toEigen(path_node_positions[0]), position);
-        p_pol.r = 0.0;
-      } else {
-        tree_available = false;
-      }
     } else {
       float cos_alpha = (node_distance * node_distance +
                          distances[wp_idx] * distances[wp_idx] -
@@ -485,8 +488,8 @@ bool getDirectionFromTree(
       float l_frac = l_front / node_distance;
 
       Eigen::Vector3f mean_point =
-          (1.f - l_frac) * toEigen(path_node_positions[wp_idx - 1]) +
-          l_frac * toEigen(path_node_positions[wp_idx]);
+          (1.f - l_frac) * toEigen(path_node_positions_extended[wp_idx - 1]) +
+          l_frac * toEigen(path_node_positions_extended[wp_idx]);
 
       p_pol = cartesianToPolar(mean_point, position);
       p_pol.r = 0.0f;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -443,19 +443,27 @@ bool getDirectionFromTree(
   int size = path_node_positions.size();
   bool tree_available = true;
 
-  if (size > 1) { //path contains at least 2 points (current position and one wp)
+  if (size >
+      1) {  // path contains at least 2 points (current position and one wp)
 
-	//extend path with a node at the end in goal direction (for smoother transition to direct flight)
-	float node_distance =
-	          (toEigen(path_node_positions[0]) - toEigen(path_node_positions[1])).norm();
-	Eigen::Vector3f dir_last_node_to_goal = (goal - toEigen(path_node_positions[0])).normalized();
-	geometry_msgs::Point goal_node = toPoint(toEigen(path_node_positions[0]) + node_distance * dir_last_node_to_goal);
-	std::vector<geometry_msgs::Point> path_node_positions_extended;
-	path_node_positions_extended.push_back(goal_node);
-	path_node_positions_extended.insert(path_node_positions_extended.end(), path_node_positions.begin(), path_node_positions.end());
-	int size_extended = path_node_positions_extended.size();
+    // extend path with a node at the end in goal direction (for smoother
+    // transition to direct flight)
+    float node_distance =
+        (toEigen(path_node_positions[0]) - toEigen(path_node_positions[1]))
+            .norm();
+    Eigen::Vector3f dir_last_node_to_goal =
+        (goal - toEigen(path_node_positions[0])).normalized();
+    geometry_msgs::Point goal_node =
+        toPoint(toEigen(path_node_positions[0]) +
+                node_distance * dir_last_node_to_goal);
+    std::vector<geometry_msgs::Point> path_node_positions_extended;
+    path_node_positions_extended.push_back(goal_node);
+    path_node_positions_extended.insert(path_node_positions_extended.end(),
+                                        path_node_positions.begin(),
+                                        path_node_positions.end());
+    int size_extended = path_node_positions_extended.size();
 
-	//find path nodes between which the drone is currently located
+    // find path nodes between which the drone is currently located
     int min_dist_idx = 0;
     int second_min_dist_idx = 0;
     float min_dist = HUGE_VAL;
@@ -464,7 +472,8 @@ bool getDirectionFromTree(
     distances.reserve(size_extended);
 
     for (int i = 0; i < size_extended; i++) {
-      distances.push_back((position - toEigen(path_node_positions_extended[i])).norm());
+      distances.push_back(
+          (position - toEigen(path_node_positions_extended[i])).norm());
       if (distances[i] < min_dist) {
         second_min_dist_idx = min_dist_idx;
         second_min_dist = min_dist;
@@ -477,7 +486,9 @@ bool getDirectionFromTree(
     }
     int wp_idx = std::min(min_dist_idx, second_min_dist_idx);
 
-    if (min_dist > 3.0 || wp_idx == 0 ) {  //too far away from tree or drone already passed the tree
+    if (min_dist > 3.0 ||
+        wp_idx ==
+            0) {  // too far away from tree or drone already passed the tree
       tree_available = false;
     } else {
       float cos_alpha = (node_distance * node_distance +

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -46,7 +46,7 @@ void WaypointGenerator::calculateWaypoint() {
       PolarPoint p_pol(0.0f, 0.0f, 0.0f);
       bool tree_available =
           getDirectionFromTree(p_pol, planner_info_.path_node_positions,
-                               toEigen(pose_.pose.position));
+                               toEigen(pose_.pose.position), goal_);
 
       float dist_goal = (goal_ - toEigen(pose_.pose.position)).norm();
       ros::Duration since_last_path =

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -57,8 +57,10 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   location.pose.position.z = 0;
   float distance = 1.0f;
 
-  std::vector<float> e_angle_filled = {-89.9, -30, 0, 20, 40, 89.9};
-  std::vector<float> z_angle_filled = {-180, -50, 0, 59, 100, 175};
+  std::vector<float> e_angle_filled = {-89.9f, -30.0f, 0.0f,
+                                       20.0f,  40.0f,  89.9f};
+  std::vector<float> z_angle_filled = {-180.0f, -50.0f, 0.0f,
+                                       59.0f,   100.0f, 175.0f};
   std::vector<Eigen::Vector3f> middle_of_cell;
   std::vector<int> e_index, z_index;
 
@@ -249,10 +251,10 @@ TEST(PlannerFunctions, testDirectionTree) {
                                                                  n0};
 
   PolarPoint p, p1, p2;
-  Eigen::Vector3f postion(0.2, 0.3, 1.5);
-  Eigen::Vector3f postion1(1.1, 2.3, 2.5);
-  Eigen::Vector3f postion2(5.4, 2.0, 2.5);
-  Eigen::Vector3f goal(10, 5, 2.5);
+  Eigen::Vector3f postion(0.2f, 0.3f, 1.5f);
+  Eigen::Vector3f postion1(1.1f, 2.3f, 2.5f);
+  Eigen::Vector3f postion2(5.4f, 2.0f, 2.5f);
+  Eigen::Vector3f goal(10.f, 5.f, 2.5f);
 
   // WHEN: we look for the best direction to fly towards
   bool res = getDirectionFromTree(p, path_node_positions, postion, goal);
@@ -442,9 +444,9 @@ TEST(PlannerFunctions, smoothPolarMatrix) {
 
 TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   // GIVEN: a position, goal and an empty histogram
-  Eigen::Vector3f position(0, 0, 0);
-  Eigen::Vector3f goal(0, 5, 0);
-  Eigen::Vector3f last_sent_waypoint(0, 1, 0);
+  Eigen::Vector3f position(0.f, 0.f, 0.f);
+  Eigen::Vector3f goal(0.f, 5.f, 0.f);
+  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
   costParameters cost_params;
   cost_params.goal_cost_param = 2.f;
   cost_params.smooth_cost_param = 1.5f;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -252,11 +252,12 @@ TEST(PlannerFunctions, testDirectionTree) {
   Eigen::Vector3f postion(0.2, 0.3, 1.5);
   Eigen::Vector3f postion1(1.1, 2.3, 2.5);
   Eigen::Vector3f postion2(5.4, 2.0, 2.5);
+  Eigen::Vector3f goal(10, 5, 2.5);
 
   // WHEN: we look for the best direction to fly towards
-  bool res = getDirectionFromTree(p, path_node_positions, postion);
-  bool res1 = getDirectionFromTree(p1, path_node_positions, postion1);
-  bool res2 = getDirectionFromTree(p2, path_node_positions, postion2);
+  bool res = getDirectionFromTree(p, path_node_positions, postion, goal);
+  bool res1 = getDirectionFromTree(p1, path_node_positions, postion1, goal);
+  bool res2 = getDirectionFromTree(p2, path_node_positions, postion2, goal);
 
   // THEN: we expect a direction in between node n1 and n2 for position, between
   // node n3 and n4 for position1, and not to get an available tree for the


### PR DESCRIPTION
In previous flights we sometimes had the issue that at the transition from path following to direct flight weird stuff happened. Sometimes, the waypoint just stayed at the end of the path which made the drone fly a loop.

This is a fix for that. At the end of the path another node is added (same edge length as all others) which points from the last node in the goal direction. This allows for a smoother transition from the path following to direct flight.

The non smoothed waypoint is published as an rviz topic for future debugging