### PR TITLE
Add common avoidance library as a separate package

### DIFF
--- a/avoidance/CMakeLists.txt
+++ b/avoidance/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(avoidance)
+
+add_definitions(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  tf
+  mavros
+  mavros_extras
+  mavros_msgs
+  mavlink
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp rospy std_msgs mavros_msgs geometry_msgs mav_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## CMake Setup
+# Build in Release mode if nothing is specified
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif(NOT CMAKE_BUILD_TYPE)
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(avoidance
+		src/CompanionStatus.cpp
+)
+
+add_dependencies(avoidance ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(avoidance
+  ${catkin_LIBRARIES})

--- a/avoidance/include/avoidance/CompanionStatus.h
+++ b/avoidance/include/avoidance/CompanionStatus.h
@@ -1,0 +1,32 @@
+#ifndef AVOIDANCE_COMPANIONSTATUS_H
+#define AVOIDANCE_COMPANIONSTATUS_H
+
+#define MAV_COMPONENT_ID_AVOIDANCE 196
+
+#include "ros/ros.h"
+#include "mavros_msgs/CompanionProcessStatus.h"
+
+namespace avoidance {
+
+class CompanionStatus {
+ private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ros::Timer publoop_timer_;
+  ros::Publisher companionstatus_pub_;
+
+  double publish_rate_;
+
+  int status_;
+
+ public:
+  CompanionStatus(const ros::NodeHandle& nh,  const ros::NodeHandle& nh_private, double publish_rate);
+  virtual ~CompanionStatus();
+
+  void PubloopCallback(const ros::TimerEvent& event);
+  void setStatus(int status);
+};
+}
+
+#endif  // AVOIDANCE_COMPANIONSTATUS_H

--- a/avoidance/package.xml
+++ b/avoidance/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package>
-  <name>local_planner</name>
+  <name>avoidance</name>
   <version>0.0.0</version>
-  <description>Avoidance module doing local planning.</description>
+  <description>Avoidance Library for PX4</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
@@ -41,8 +41,6 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -50,27 +48,20 @@
   <build_depend>mav_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
-  <build_depend>pcl_ros</build_depend>
   <build_depend>mavros</build_depend>
   <build_depend>mavros_extras</build_depend>
   <build_depend>mavros_msgs</build_depend>
-  <build_depend>avoidance</build_depend>
 
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>mav_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>octomap</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>pcl_ros</run_depend>
   <run_depend>mavros</run_depend>
   <run_depend>mavros_extras</run_depend>
   <run_depend>mavros_msgs</run_depend>
-  <run_depend>avoidance</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/avoidance/src/CompanionStatus.cpp
+++ b/avoidance/src/CompanionStatus.cpp
@@ -1,0 +1,30 @@
+#include "avoidance/CompanionStatus.h"
+
+namespace avoidance {
+
+    CompanionStatus::CompanionStatus(const ros::NodeHandle& nh,
+            const ros::NodeHandle& nh_private, double publish_rate)
+            : nh_(nh), nh_private_(nh_private), publish_rate_(publish_rate) {
+
+        companionstatus_pub_ = nh_.advertise<mavros_msgs::CompanionProcessStatus>("/mavros/companion_process/status", 1);
+        publoop_timer_ = nh_.createTimer(ros::Duration(publish_rate), &CompanionStatus::PubloopCallback, this); // Define timer for constant loop rate
+
+    }
+
+    CompanionStatus::~CompanionStatus() {}
+
+    void CompanionStatus::PubloopCallback(const ros::TimerEvent& event) {
+      mavros_msgs::CompanionProcessStatus status_msg;
+
+      status_msg.header.stamp = ros::Time::now();
+
+      status_msg.component = MAV_COMPONENT_ID_AVOIDANCE;
+      status_msg.state = status_;
+
+      companionstatus_pub_.publish(status_msg);
+    }
+
+    void CompanionStatus::setStatus(int status) {
+      status_ = status;
+    }
+}

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   mavros_extras
   mavros_msgs
   mavlink
+  avoidance
 )
 find_package(PCL 1.7 REQUIRED)
 find_package(yaml-cpp REQUIRED)

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -34,6 +34,7 @@
 
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
+#include <avoidance/CompanionStatus.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -100,8 +101,6 @@ class LocalPlannerNode {
   LocalPlannerNode(const ros::NodeHandle& nh,  const ros::NodeHandle& nh_private);
   ~LocalPlannerNode();
 
-  mavros_msgs::CompanionProcessStatus status_msg_;
-
   std::string world_path_;
   bool never_run_ = true;
   bool position_received_ = false;
@@ -141,7 +140,6 @@ class LocalPlannerNode {
   ros::Publisher waypoint_pub_;
   ros::ServiceClient mavros_set_mode_client_;
   ros::ServiceClient get_px4_param_client_;
-  ros::Publisher mavros_system_status_pub_;
   tf::TransformListener tf_listener_;
 
   std::mutex running_mutex_;  ///< guard against concurrent access to input &
@@ -212,6 +210,7 @@ class LocalPlannerNode {
   * @param     hover, true if the vehicle is loitering
   **/
   void publishWaypoints(bool hover);
+  void setCompanionStatus(int status);
 
   const ros::NodeHandle& nodeHandle() const { return nh_; }
 
@@ -270,6 +269,8 @@ class LocalPlannerNode {
   * @param     config, struct with all the parameters
   * @param     level, bitmsak to group together reconfigurable parameters
   **/
+  CompanionStatus companion_status_;
+
   void dynamicReconfigureCallback(avoidance::LocalPlannerNodeConfig& config,
                                   uint32_t level);
 

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -97,7 +97,7 @@ enum class MAV_STATE {
 
 class LocalPlannerNode {
  public:
-  LocalPlannerNode();
+  LocalPlannerNode(const ros::NodeHandle& nh,  const ros::NodeHandle& nh_private);
   ~LocalPlannerNode();
 
   mavros_msgs::CompanionProcessStatus status_msg_;
@@ -217,6 +217,8 @@ class LocalPlannerNode {
 
  private:
   ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
   avoidance::LocalPlannerNodeConfig rqt_param_config_;
 
   mavros_msgs::Altitude ground_distance_msg_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -18,7 +18,8 @@ namespace avoidance {
 LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
                                    const ros::NodeHandle& nh_private)
         : nh_(nh),
-          nh_private_(nh_private) {
+          nh_private_(nh_private),
+          companion_status_(nh, nh_private, 0.2) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
 
@@ -97,9 +98,6 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
       "/mavros/trajectory/generated", 10);
   mavros_obstacle_distance_pub_ =
       nh_.advertise<sensor_msgs::LaserScan>("/mavros/obstacle/send", 10);
-  mavros_system_status_pub_ =
-      nh_.advertise<mavros_msgs::CompanionProcessStatus>(
-          "/mavros/companion_process/status", 1);
   current_waypoint_pub_ =
       nh_.advertise<visualization_msgs::Marker>("/current_setpoint", 1);
   takeoff_pose_pub_ =
@@ -967,4 +965,9 @@ void LocalPlannerNode::threadFunction() {
     }
   }
 }
+
+void LocalPlannerNode::setCompanionStatus(int status){
+  companion_status_.setStatus(status);
+}
+
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -15,10 +15,13 @@
 
 namespace avoidance {
 
-LocalPlannerNode::LocalPlannerNode() {
+LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
+                                   const ros::NodeHandle& nh_private)
+        : nh_(nh),
+          nh_private_(nh_private) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
-  nh_ = ros::NodeHandle("~");
+
   readParams();
 
   // Set up Dynamic Reconfigure Server

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -7,7 +7,11 @@
 int main(int argc, char** argv) {
   using namespace avoidance;
   ros::init(argc, argv, "local_planner_node");
-  LocalPlannerNode Node;
+
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
+
+  LocalPlannerNode Node(nh, nh_private);
   ros::Duration(2).sleep();
   ros::Time start_time = ros::Time::now();
   bool hover = false;


### PR DESCRIPTION
This PR adds a separate package named `avoidance` which hosts common files that can be shared with the global and local planner.

To start with, I have added a companion status publisher in the avoidance library.

By initializing the `CompanionStatusPublisher` object it will automatically publish companion status message without requiring to handle this in the loop of the planner.
