### PR TITLE
disable yaml cpp build when gazebo simulation is not required

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -3,6 +3,7 @@ project(local_planner)
 
 add_definitions(-std=c++11)
 
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -18,8 +19,21 @@ find_package(catkin REQUIRED COMPONENTS
   mavlink
 )
 find_package(PCL 1.7 REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
+
+
+
+################################################
+## Gazebo Simulation
+################################################
+# Disable yaml-cpp when no simulation is required
+if(DISABLE_SIMULATION)
+  message(STATUS "Building local planner without Gazebo Simulation")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_SIMULATION")
+else()
+  message(STATUS "Building local planner with Gazebo Simulation")
+  find_package(yaml-cpp REQUIRED)
+endif(DISABLE_SIMULATION)
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
@@ -125,17 +139,32 @@ include_directories(
 # add_library(avoidance
 #   src/${PROJECT_NAME}/avoidance.cpp
 # )
-add_library(local_planner
-  src/nodes/local_planner.cpp
-  src/nodes/waypoint_generator.cpp
-  src/nodes/histogram.cpp
-  src/nodes/tree_node.cpp
-  src/nodes/box.cpp
-  src/nodes/star_planner.cpp
-  src/nodes/planner_functions.cpp
-  src/nodes/common.cpp
-  src/nodes/rviz_world_loader.cpp
-)
+
+if(DISABLE_SIMULATION)
+  add_library(local_planner
+    src/nodes/local_planner.cpp
+    src/nodes/waypoint_generator.cpp
+    src/nodes/histogram.cpp
+    src/nodes/tree_node.cpp
+    src/nodes/box.cpp
+    src/nodes/star_planner.cpp
+    src/nodes/planner_functions.cpp
+    src/nodes/common.cpp
+  )
+else()
+  message(STATUS "Building local planner with Gazebo Simulation")
+  add_library(local_planner
+    src/nodes/local_planner.cpp
+    src/nodes/waypoint_generator.cpp
+    src/nodes/histogram.cpp
+    src/nodes/tree_node.cpp
+    src/nodes/box.cpp
+    src/nodes/star_planner.cpp
+    src/nodes/planner_functions.cpp
+    src/nodes/common.cpp
+    src/nodes/rviz_world_loader.cpp
+  )
+endif(DISABLE_SIMULATION)
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -30,9 +30,11 @@ find_package(PCL 1.7 REQUIRED)
 if(DISABLE_SIMULATION)
   message(STATUS "Building local planner without Gazebo Simulation")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_SIMULATION")
+  set(RVIZ_WORLD_LOADER "")
 else()
   message(STATUS "Building local planner with Gazebo Simulation")
   find_package(yaml-cpp REQUIRED)
+  set(RVIZ_WORLD_LOADER "src/nodes/rviz_world_loader.cpp")
 endif(DISABLE_SIMULATION)
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -139,32 +141,18 @@ include_directories(
 # add_library(avoidance
 #   src/${PROJECT_NAME}/avoidance.cpp
 # )
+add_library(local_planner
+  src/nodes/local_planner.cpp
+  src/nodes/waypoint_generator.cpp
+  src/nodes/histogram.cpp
+  src/nodes/tree_node.cpp
+  src/nodes/box.cpp
+  src/nodes/star_planner.cpp
+  src/nodes/planner_functions.cpp
+  src/nodes/common.cpp
+  ${RVIZ_WORLD_LOADER}
+)
 
-if(DISABLE_SIMULATION)
-  add_library(local_planner
-    src/nodes/local_planner.cpp
-    src/nodes/waypoint_generator.cpp
-    src/nodes/histogram.cpp
-    src/nodes/tree_node.cpp
-    src/nodes/box.cpp
-    src/nodes/star_planner.cpp
-    src/nodes/planner_functions.cpp
-    src/nodes/common.cpp
-  )
-else()
-  message(STATUS "Building local planner with Gazebo Simulation")
-  add_library(local_planner
-    src/nodes/local_planner.cpp
-    src/nodes/waypoint_generator.cpp
-    src/nodes/histogram.cpp
-    src/nodes/tree_node.cpp
-    src/nodes/box.cpp
-    src/nodes/star_planner.cpp
-    src/nodes/planner_functions.cpp
-    src/nodes/common.cpp
-    src/nodes/rviz_world_loader.cpp
-  )
-endif(DISABLE_SIMULATION)
 
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
@@ -236,8 +224,8 @@ if(CATKIN_ENABLE_TESTING)
 	                                      test/test_common.cpp
 	                                      test/test_local_planner.cpp
 	                                      test/test_planner_functions.cpp
-                                              test/test_star_planner.cpp
-                                              test/test_waypoint_generator.cpp)
+                                        test/test_star_planner.cpp
+                                        test/test_waypoint_generator.cpp)
 	if(TARGET ${PROJECT_NAME}-test)
 	  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
 	                                             ${catkin_LIBRARIES}

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -30,11 +30,9 @@ find_package(PCL 1.7 REQUIRED)
 if(DISABLE_SIMULATION)
   message(STATUS "Building local planner without Gazebo Simulation")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_SIMULATION")
-  set(RVIZ_WORLD_LOADER "")
 else()
   message(STATUS "Building local planner with Gazebo Simulation")
   find_package(yaml-cpp REQUIRED)
-  set(RVIZ_WORLD_LOADER "src/nodes/rviz_world_loader.cpp")
 endif(DISABLE_SIMULATION)
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -141,17 +139,20 @@ include_directories(
 # add_library(avoidance
 #   src/${PROJECT_NAME}/avoidance.cpp
 # )
-add_library(local_planner
-  src/nodes/local_planner.cpp
-  src/nodes/waypoint_generator.cpp
-  src/nodes/histogram.cpp
-  src/nodes/tree_node.cpp
-  src/nodes/box.cpp
-  src/nodes/star_planner.cpp
-  src/nodes/planner_functions.cpp
-  src/nodes/common.cpp
-  ${RVIZ_WORLD_LOADER}
+set(LOCAL_PLANNER_CPP_FILES   "src/nodes/local_planner.cpp"
+                              "src/nodes/waypoint_generator.cpp"
+                              "src/nodes/histogram.cpp"
+                              "src/nodes/tree_node.cpp"
+                              "src/nodes/box.cpp"
+                              "src/nodes/star_planner.cpp"
+                              "src/nodes/planner_functions.cpp"
+                              "src/nodes/common.cpp"
 )
+if(NOT DISABLE_SIMULATION)
+  set(LOCAL_PLANNER_CPP_FILES "${LOCAL_PLANNER_CPP_FILES}"
+                              "src/nodes/rviz_world_loader.cpp")
+endif()
+add_library(local_planner     "${LOCAL_PLANNER_CPP_FILES}")
 
 
 ## Add cmake target dependencies of the library

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -2,7 +2,11 @@
 #define LOCAL_PLANNER_LOCAL_PLANNER_NODE_H
 
 #include "local_planner/avoidance_output.h"
+
+#ifndef DISABLE_SIMULATION
+// include simulation
 #include "local_planner/rviz_world_loader.h"
+#endif
 
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseArray.h>

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -248,6 +248,7 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
   newest_pose_ = msg;
   position_received_ = true;
 
+#ifndef DISABLE_SIMULATION
   // visualize drone in RVIZ
   visualization_msgs::Marker marker;
   if (!world_path_.empty()) {
@@ -255,6 +256,7 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
       drone_pub_.publish(marker);
     }
   }
+#endif
 }
 
 void LocalPlannerNode::velocityCallback(

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -25,6 +25,9 @@ int main(int argc, char** argv) {
   while (ros::ok()) {
     hover = false;
 
+#ifdef DISABLE_SIMULATION
+    startup = false;
+#else
     // visualize world in RVIZ
     if (!Node.world_path_.empty() && startup) {
       visualization_msgs::MarkerArray marker_array;
@@ -33,6 +36,8 @@ int main(int argc, char** argv) {
       }
       startup = false;
     }
+
+#endif
 
     // Process callbacks & wait for a position update
     while (!Node.position_received_ && ros::ok()) {


### PR DESCRIPTION
add cmake argument -DDISABLE_SIMULATION to disable yaml-cpp build. 

To test the PR
`catkin clean`
`catkin build local_planner -DDISABLE_SIMULATION=ON`
eg. when running the local_planner_sitl_3cam.launch the trees and the drone won't be visible in RViz.

By default, `catkin build local_planner` behaves as before the PR.

