### PR TITLE
Add script to install commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,5 +459,7 @@ ROS topic | ROS Msgs. | MAVROS Plugin | MAVLink | PX4 Topic
 Fork the project and then clone your repository. Create a new branch off of master for your new feature or bug fix.
 
 Please, take into consideration our [coding style](https://github.com/PX4/avoidance/blob/master/tools/fix_style.sh).
+For convenience, you can install the commit hooks which will run this formatting on every commit. To do so, run
+`./tools/set_up_commit_hooks` from the main directory.
 
 Commit your changes with informative commit messages, push your branch and open a new pull request. Please provide ROS bags and the Autopilot flight logs relevant to the changes you have made.

--- a/tools/set_up_commit_hooks
+++ b/tools/set_up_commit_hooks
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# If run from the tools directory, fail
+if [ ! -d .git ] ; then
+  echo "Commit hooks not installed, run from main directory! (./tools/set_up_commit_hooks)"
+  exit 1
+fi
+
+#If there are already commit hooks installed
+if [ -f .git/hooks/pre-commit ] ; then
+  echo "You already have commit hooks, manually delete them and run again!"
+  exit 1
+fi
+
+cat >> .git/hooks/pre-commit <<- EOM
+#!/bin/bash
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#!/bin/bash
+
+STYLE="google"
+if [ -n "${STYLE}" ] ; then
+  STYLEARG="-style=${STYLE}"
+else
+  STYLEARG=""
+fi
+
+format_file() {
+  file="${1}"
+  clang-format-3.8 -i ${STYLEARG} ${1}
+  git add ${1}
+}
+
+case "${1}" in
+  --about )
+    echo "Runs clang-format on source files"
+    ;;
+  * )
+    for file in `git diff-index --cached --name-only HEAD` ; do
+      if [[ ${file} == *".cpp" ]] || [[ ${file} == *".h" ]] || [[ ${file} == *".hpp" ]]; then
+        echo
+        format_file "${file}"
+      fi
+    done
+    ;;
+esac
+EOM
+echo "Commit hooks successfully installed!"
+exit 0

--- a/tools/set_up_commit_hooks.sh
+++ b/tools/set_up_commit_hooks.sh
@@ -22,15 +22,10 @@ cat >> .git/hooks/pre-commit <<- EOM
 #!/bin/bash
 
 STYLE="google"
-if [ -n "${STYLE}" ] ; then
-  STYLEARG="-style=${STYLE}"
-else
-  STYLEARG=""
-fi
 
 format_file() {
   file="${1}"
-  clang-format-3.8 -i ${STYLEARG} ${1}
+  clang-format-3.8 -i -style=${STYLE} ${1}
   git add ${1}
 }
 


### PR DESCRIPTION
This commit adds a script that can be run and will install a pre-commit hook
which runs clang-format on all committed files.

To install the hooks, run (from the main directory)
`./tools/set_up_commit_hooks`

And you'll be set.

Along with it, an addition to the README that explains this.
