### PR TITLE
remove nans from received sensor message before doing transforms and …

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -23,6 +23,7 @@
 #include <pcl_conversions/pcl_conversions.h>  // fromROSMsg
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/transforms.h>  // transformPointCloud
+#include <pcl/filters/filter.h>
 #include <ros/ros.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/PointCloud2.h>

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -20,10 +20,10 @@
 #include <mavros_msgs/Trajectory.h>
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
+#include <pcl/filters/filter.h>
 #include <pcl_conversions/pcl_conversions.h>  // fromROSMsg
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/transforms.h>  // transformPointCloud
-#include <pcl/filters/filter.h>
 #include <ros/ros.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/PointCloud2.h>

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -195,19 +195,18 @@ void LocalPlannerNode::updatePlannerInfo() {
   for (size_t i = 0; i < cameras_.size(); ++i) {
     pcl::PointCloud<pcl::PointXYZ> pcl_cloud_world_frame;
     pcl::PointCloud<pcl::PointXYZ> pcl_cloud_cam_frame;
-    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_cam_frame_without_nan;
     try {
       // transform message to pcl type
       pcl::fromROSMsg(cameras_[i].newest_cloud_msg_, pcl_cloud_cam_frame);
 
       // remove nan padding
       std::vector<int> dummy_index;
-      pcl::removeNaNFromPointCloud(
-          pcl_cloud_cam_frame, pcl_cloud_cam_frame_without_nan, dummy_index);
+      dummy_index.reserve(pcl_cloud_cam_frame.points.size());
+      pcl::removeNaNFromPointCloud(pcl_cloud_cam_frame, pcl_cloud_cam_frame,
+                                   dummy_index);
 
       // transform cloud to /local_origin frame
-      pcl_ros::transformPointCloud("/local_origin",
-                                   pcl_cloud_cam_frame_without_nan,
+      pcl_ros::transformPointCloud("/local_origin", pcl_cloud_cam_frame,
                                    pcl_cloud_world_frame, tf_listener_);
 
       local_planner_->complete_cloud_.push_back(

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -193,24 +193,21 @@ void LocalPlannerNode::updatePlannerInfo() {
   // update the point cloud
   local_planner_->complete_cloud_.clear();
   for (size_t i = 0; i < cameras_.size(); ++i) {
-    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_world_frame;
-    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_cam_frame;
+    pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
     try {
       // transform message to pcl type
-      pcl::fromROSMsg(cameras_[i].newest_cloud_msg_, pcl_cloud_cam_frame);
+      pcl::fromROSMsg(cameras_[i].newest_cloud_msg_, pcl_cloud);
 
       // remove nan padding
       std::vector<int> dummy_index;
-      dummy_index.reserve(pcl_cloud_cam_frame.points.size());
-      pcl::removeNaNFromPointCloud(pcl_cloud_cam_frame, pcl_cloud_cam_frame,
-                                   dummy_index);
+      dummy_index.reserve(pcl_cloud.points.size());
+      pcl::removeNaNFromPointCloud(pcl_cloud, pcl_cloud, dummy_index);
 
       // transform cloud to /local_origin frame
-      pcl_ros::transformPointCloud("/local_origin", pcl_cloud_cam_frame,
-                                   pcl_cloud_world_frame, tf_listener_);
+      pcl_ros::transformPointCloud("/local_origin", pcl_cloud, pcl_cloud,
+                                   tf_listener_);
 
-      local_planner_->complete_cloud_.push_back(
-          std::move(pcl_cloud_world_frame));
+      local_planner_->complete_cloud_.push_back(std::move(pcl_cloud));
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s",
                 ex.what());

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -197,18 +197,21 @@ void LocalPlannerNode::updatePlannerInfo() {
     pcl::PointCloud<pcl::PointXYZ> pcl_cloud_cam_frame;
     pcl::PointCloud<pcl::PointXYZ> pcl_cloud_cam_frame_without_nan;
     try {
-
-      //transform message to pcl type
+      // transform message to pcl type
       pcl::fromROSMsg(cameras_[i].newest_cloud_msg_, pcl_cloud_cam_frame);
 
-      //remove nan padding
-      std::vector< int > dummy_index;
-      pcl::removeNaNFromPointCloud(pcl_cloud_cam_frame, pcl_cloud_cam_frame_without_nan, dummy_index);
+      // remove nan padding
+      std::vector<int> dummy_index;
+      pcl::removeNaNFromPointCloud(
+          pcl_cloud_cam_frame, pcl_cloud_cam_frame_without_nan, dummy_index);
 
-      //transform cloud to /local_origin frame
-      pcl_ros::transformPointCloud ("/local_origin", pcl_cloud_cam_frame_without_nan, pcl_cloud_world_frame, tf_listener_);
+      // transform cloud to /local_origin frame
+      pcl_ros::transformPointCloud("/local_origin",
+                                   pcl_cloud_cam_frame_without_nan,
+                                   pcl_cloud_world_frame, tf_listener_);
 
-      local_planner_->complete_cloud_.push_back(std::move(pcl_cloud_world_frame));
+      local_planner_->complete_cloud_.push_back(
+          std::move(pcl_cloud_world_frame));
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s",
                 ex.what());


### PR DESCRIPTION
We found out the data from the sensor is heavily padded with nans. In the case of the realsense, the container has a size of about 4'000'000. from which the biggest pointcloud we saw contained 200'000 points. We put all those nans through the transform and into the planner. The planner update function was by far the slowest function in the whole pipeline.

This PR removes the nans before the frame transformation and the update of the planner pointcloud. We see a significant improvement in the execution time of this function even in SITL. We expect this to be even more prominent with the larger realsense pointclouds.

![analysis](https://user-images.githubusercontent.com/25756842/54020712-b5a28800-418e-11e9-95e0-7a078acb8bc0.png)
