### PR TITLE
remove take_off_pose

### DIFF
--- a/local_planner/include/local_planner/avoidance_output.h
+++ b/local_planner/include/local_planner/avoidance_output.h
@@ -14,10 +14,7 @@ struct avoidanceOutput {
   bool obstacle_ahead;    // true is there is an obstacle ahead of the vehicle
   float cruise_velocity;  // mission cruise velocity
   ros::Time last_path_time;  // finish built time for the VFH+* tree
-
-  Eigen::Vector3f take_off_pose;  // last vehicle position when not armed
   float starting_height;  // height at which the system starts planning a path
-
   std::vector<Eigen::Vector3f> path_node_positions;  // array of tree nodes
                                                      // position, each node
                                                      // is the minimum cost

--- a/local_planner/include/local_planner/avoidance_output.h
+++ b/local_planner/include/local_planner/avoidance_output.h
@@ -16,6 +16,7 @@ struct avoidanceOutput {
   ros::Time last_path_time;  // finish built time for the VFH+* tree
 
   Eigen::Vector3f take_off_pose;  // last vehicle position when not armed
+  float starting_height;  // height at which the system starts planning a path
 
   std::vector<Eigen::Vector3f> path_node_positions;  // array of tree nodes
                                                      // position, each node

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -59,6 +59,8 @@ struct ModelParameters {
   float param_mpc_tko_speed = NAN; // Takeoff climb rate
   float param_mpc_land_speed = NAN;   // Landing descend rate
 
+  float param_mis_takeoff_alt = NAN; // Minimum takeoff altitude
+
   // TODO: add estimator limitations for max speed and height
 
   float param_mpc_col_prev_d = NAN; // Collision Prevention distance to keep from obstacle. -1 for disabled
@@ -167,6 +169,8 @@ class LocalPlanner {
 
   // original_cloud_vector_ contains n complete clouds from the cameras
   std::vector<pcl::PointCloud<pcl::PointXYZ>> original_cloud_vector_;
+
+  ModelParameters model_params_; // PX4 Firmware paramters
 
   LocalPlanner();
   ~LocalPlanner();

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -169,7 +169,7 @@ class LocalPlanner {
   // original_cloud_vector_ contains n complete clouds from the cameras
   std::vector<pcl::PointCloud<pcl::PointXYZ>> original_cloud_vector_;
 
-  ModelParameters model_params_; // PX4 Firmware paramters
+  ModelParameters model_params_;  // PX4 Firmware paramters
 
   LocalPlanner();
   ~LocalPlanner();

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -163,7 +163,6 @@ class LocalPlanner {
 
   ModelParameters px4_;  // PX4 Firmware paramters
 
-  Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
   sensor_msgs::LaserScan distance_data_ = {};
   Eigen::Vector3f last_sent_waypoint_ = Eigen::Vector3f::Zero();
 

--- a/local_planner/include/local_planner/local_planner_visualization.h
+++ b/local_planner/include/local_planner/local_planner_visualization.h
@@ -63,11 +63,11 @@ class LocalPlannerVisualization {
 
   /**
   * @brief       Visualization of the data used during takeoff
-  * @params[in]  take_off_pose, pose at which the vehicle was armed
+  * @params[in]  drone_pos, vehicle current position
   * @params[in]  starting_height, height at which the planner starts planning
   *forward
   **/
-  void publishReachHeight(const Eigen::Vector3f& take_off_pose,
+  void publishReachHeight(const Eigen::Vector3f& drone_pos,
                           float starting_height) const;
 
   /**
@@ -154,7 +154,6 @@ class LocalPlannerVisualization {
   ros::Publisher path_waypoint_pub_;
   ros::Publisher path_adapted_waypoint_pub_;
   ros::Publisher current_waypoint_pub_;
-  ros::Publisher takeoff_pose_pub_;
   ros::Publisher initial_height_pub_;
   ros::Publisher histogram_image_pub_;
   ros::Publisher cost_image_pub_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -24,7 +24,6 @@ void LocalPlanner::setPose(const Eigen::Vector3f& pos,
   star_planner_->setPose(position_, curr_yaw_histogram_frame_deg_);
 
   if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
-    take_off_pose_ = position_;
     reach_altitude_ = false;
   }
 }
@@ -143,7 +142,7 @@ void LocalPlanner::determineStrategy() {
   if (!reach_altitude_) {
     // use half of the goal altitude as an acceptance altitude as done in
     // the Firmware
-    starting_height_ = std::max(goal_.z() / 2.0f, take_off_pose_.z() + 1.0f);
+    starting_height_ = std::max(goal_.z() / 2.0f, px4_.param_mis_takeoff_alt);
     ROS_INFO("\033[1;35m[OA] Reach height (%f) first: Go fast\n \033[0m",
              starting_height_);
     waypoint_type_ = reachHeight;
@@ -340,7 +339,6 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
   out.cruise_velocity = px4_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 
-  out.take_off_pose = take_off_pose_;
   out.starting_height = starting_height_;
 
   out.path_node_positions = star_planner_->path_node_positions_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -141,7 +141,9 @@ void LocalPlanner::determineStrategy() {
   }
 
   if (!reach_altitude_) {
-    starting_height_ = std::max(goal_.z() - 0.5f, take_off_pose_.z() + 1.0f);
+    // use half of the goal altitude as an acceptance altitude as done in
+    // the Firmware
+    starting_height_ = std::max(goal_.z() / 2.0f, take_off_pose_.z() + 1.0f);
     ROS_INFO("\033[1;35m[OA] Reach height (%f) first: Go fast\n \033[0m",
              starting_height_);
     waypoint_type_ = reachHeight;
@@ -339,6 +341,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;
+  out.starting_height = starting_height_;
 
   out.path_node_positions = star_planner_->path_node_positions_;
   return out;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -427,9 +427,11 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
              local_planner_->px4_.param_mpc_col_prev_d, msg.value.real);
     local_planner_->px4_.param_mpc_col_prev_d = msg.value.real;
   } else if (msg.param_id == "MIS_TAKEOFF_ALT") {
-    ROS_INFO("model parameter minimum mission takeoff altitude is set from  %f to %f \n",
-           local_planner_->px4_.param_mis_takeoff_alt, msg.value.real);
-   }
+    ROS_INFO(
+        "model parameter minimum mission takeoff altitude is set from  %f to "
+        "%f \n",
+        local_planner_->px4_.param_mis_takeoff_alt, msg.value.real);
+  }
 }
 
 void LocalPlannerNode::checkPx4Parameters() {

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -426,7 +426,10 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
     ROS_INFO("parameter collision prevention distance is set from  %f to %f \n",
              local_planner_->px4_.param_mpc_col_prev_d, msg.value.real);
     local_planner_->px4_.param_mpc_col_prev_d = msg.value.real;
-  }
+  } else if (msg.param_id == "MIS_TAKEOFF_ALT") {
+    ROS_INFO("model parameter minimum mission takeoff altitude is set from  %f to %f \n",
+           local_planner_->px4_.param_mis_takeoff_alt, msg.value.real);
+   }
 }
 
 void LocalPlannerNode::checkPx4Parameters() {
@@ -445,6 +448,12 @@ void LocalPlannerNode::checkPx4Parameters() {
     req.request.param_id = "MPC_COL_PREV_D";
     if (get_px4_param_client_.call(req) && req.response.success) {
       local_planner_->px4_.param_mpc_col_prev_d = req.response.value.real;
+    }
+
+    req.response.success = false;
+    req.request.param_id = "MIS_TAKEOFF_ALT";
+    if (get_px4_param_client_.call(req) && req.response.success) {
+      local_planner_->px4_.param_mis_takeoff_alt = req.response.value.real;
     }
     std::this_thread::sleep_for(std::chrono::seconds(30));
   }

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -37,8 +37,6 @@ void LocalPlannerVisualization::initializePublishers(ros::NodeHandle& nh) {
       nh.advertise<visualization_msgs::Marker>("/path_adapted_waypoint", 1);
   current_waypoint_pub_ =
       nh.advertise<visualization_msgs::Marker>("/current_setpoint", 1);
-  takeoff_pose_pub_ =
-      nh.advertise<visualization_msgs::Marker>("/take_off_pose", 1);
   initial_height_pub_ =
       nh.advertise<visualization_msgs::Marker>("/initial_height", 1);
   histogram_image_pub_ =
@@ -71,7 +69,7 @@ void LocalPlannerVisualization::visualizePlannerData(
              planner.histogram_box_.zmin_);
 
   // publish data related to takeoff maneuver
-  publishReachHeight(planner.take_off_pose_, planner.starting_height_);
+  publishReachHeight(planner.getPosition(), planner.starting_height_);
 
   // publish histogram image
   publishDataImages(planner.histogram_image_data_, planner.cost_image_data_,
@@ -201,13 +199,13 @@ void LocalPlannerVisualization::publishBox(const Eigen::Vector3f& drone_pos,
 }
 
 void LocalPlannerVisualization::publishReachHeight(
-    const Eigen::Vector3f& take_off_pose, float starting_height) const {
+    const Eigen::Vector3f& drone_pos, float starting_height) const {
   visualization_msgs::Marker m;
   m.header.frame_id = "local_origin";
   m.header.stamp = ros::Time::now();
   m.type = visualization_msgs::Marker::CUBE;
-  m.pose.position.x = take_off_pose.x();
-  m.pose.position.y = take_off_pose.y();
+  m.pose.position.x = drone_pos.x();
+  m.pose.position.y = drone_pos.y();
   m.pose.position.z = starting_height;
   m.pose.orientation.x = 0.0;
   m.pose.orientation.y = 0.0;
@@ -224,23 +222,6 @@ void LocalPlannerVisualization::publishReachHeight(
   m.id = 0;
 
   initial_height_pub_.publish(m);
-
-  visualization_msgs::Marker t;
-  t.header.frame_id = "local_origin";
-  t.header.stamp = ros::Time::now();
-  t.type = visualization_msgs::Marker::SPHERE;
-  t.action = visualization_msgs::Marker::ADD;
-  t.scale.x = 0.2;
-  t.scale.y = 0.2;
-  t.scale.z = 0.2;
-  t.color.a = 1.0;
-  t.color.r = 1.0;
-  t.color.g = 0.0;
-  t.color.b = 0.0;
-  t.lifetime = ros::Duration();
-  t.id = 0;
-  t.pose.position = toPoint(take_off_pose);
-  takeoff_pose_pub_.publish(t);
 }
 
 void LocalPlannerVisualization::publishDataImages(

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -131,13 +131,11 @@ void WaypointGenerator::reachGoalAltitudeFirst() {
   // goto_position is a unit vector pointing straight up/down from current
   // location
   output_.goto_position = position_;
-  goal_.x() = position_.x();  // Needed so adaptSpeed can clamp to goal
-  goal_.y() = position_.y();
 
   // Only move the setpoint if drone is in the air
   if (is_airborne_) {
     // Ascend/Descend to goal altitude
-    if (position_.z() <= goal_.z()) {
+    if (position_.z() <= planner_info_.starting_height) {
       output_.goto_position.z() += 1.0f;
     } else {
       output_.goto_position.z() -= 1.0f;

--- a/local_planner/test/test_waypoint_generator.cpp
+++ b/local_planner/test/test_waypoint_generator.cpp
@@ -60,6 +60,7 @@ TEST_F(WaypointGeneratorTests, reachAltitudeTest) {
   // goal altiude
   avoidance_output.waypoint_type = reachHeight;
   goal.z() = 5.f;
+  avoidance_output.starting_height = goal.z() / 2.f;
   setPlannerInfo(avoidance_output);
   double time_sec = 0.0;
   float goto_to_goal_prev = 1000.0f;


### PR DESCRIPTION
On master if the planner is killed and then restarted the vehicle cannot advance in the mission because the takeoff position is set in air when the planner is restarted. So `goal.z - 0.5 < take_off_position  + 1 ` . The `starting_height_` can never be reached if `position.z > goal.z` because the waypoint generator will generated setpoints to lower the vehicle altitude. 