### PR TITLE
Cost matrix image

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,7 +7,7 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 10,  0, 20)
+gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 7,  0, 20)
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 3.0, 0.5, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0.5, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function wight for path smoothness", 1.5, 0.5, 20.0)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -25,6 +25,7 @@ gen.add("reproj_age_", int_t, 0, "maximum age of a reprojected point", 50, 0, 10
 gen.add("velocity_sigmoid_slope_", double_t, 0, "the bigger the bigger the acceleration", 3, 0, 10)
 gen.add("smoothing_speed_xy_", double_t, 0, "response speed of the smoothing system in xy (set to 0 to disable)", 10, 0, 30)
 gen.add("smoothing_speed_z_", double_t, 0, "response speed of the smoothing system in z (set to 0 to disable)", 3, 0, 30)
+gen.add("smoothing_margin_degrees_", double_t, 0, "smoothing radius for obstacle cost in cost histogram", 30, 0, 90)
 
 gen.add("use_vel_setpoints_", bool_t, 0, "Enable velocity setpoints (if false, position setpoints are used)", False)
 gen.add("stop_in_front_", bool_t, 0, "Enable stop in front of the obstacle", False)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,7 +7,7 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("box_radius_",    double_t,    0, "Minimum box extension in x direction", 7,  0, 20)
+gen.add("box_radius_",    double_t,    0, "Minimum box extension in x direction", 15,  0, 20)
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 3.0, 0.5, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0.5, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function wight for path smoothness", 1.5, 0.5, 20.0)
@@ -22,8 +22,6 @@ gen.add("min_dist_backoff_", double_t, 0, "min dist before backing off", 1.5, 0,
 gen.add("timeout_critical_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 0.5, 0, 10)
 gen.add("timeout_termination_", double_t, 0, "After this timeout the companion status is MAV_STATE_FLIGHT_TERMINATION", 15, 0, 1000)
 gen.add("reproj_age_", int_t, 0, "maximum age of a reprojected point", 50, 0, 1000)
-gen.add("relevance_margin_e_degree_", double_t, 0, "obstacles at more than this angle from goal direction are ignored", 25, 0, 90)
-gen.add("relevance_margin_z_degree_", double_t, 0, "obstacles at more than this angle from goal direction are ignored", 40, 0, 180)
 gen.add("velocity_sigmoid_slope_", double_t, 0, "the bigger the bigger the acceleration", 3, 0, 10)
 gen.add("smoothing_speed_xy_", double_t, 0, "response speed of the smoothing system in xy (set to 0 to disable)", 10, 0, 30)
 gen.add("smoothing_speed_z_", double_t, 0, "response speed of the smoothing system in z (set to 0 to disable)", 3, 0, 30)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,7 +7,7 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("box_radius_",    double_t,    0, "Minimum box extension in x direction", 15,  0, 20)
+gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 10,  0, 20)
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 3.0, 0.5, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0.5, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function wight for path smoothness", 1.5, 0.5, 20.0)

--- a/local_planner/include/local_planner/common.h
+++ b/local_planner/include/local_planner/common.h
@@ -95,6 +95,18 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
                    const Eigen::Vector3f& in_waypt, float yaw);
 
 /**
+* @brief     Compute the yaw angle from a quaternion
+* @returns   yaw angle in degrees
+**/
+float getYawFromQuaternion(const Eigen::Quaternionf q);
+
+/**
+* @brief     Compute the pitch angle from a quaternion
+* @returns   pitch angle in degrees
+**/
+float getPitchFromQuaternion(const Eigen::Quaternionf q);
+
+/**
 * @brief     wrappes the input angle in to plus minus PI space
 * @param[in, out] angle to be wrapped  [rad]
 **/

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -58,8 +58,8 @@ class LocalPlanner {
   int reproj_age_;
   int counter_close_points_backoff_ = 0;
 
-  float curr_yaw_;
-  float curr_pitch_;
+  float curr_yaw_fcu_frame_;
+  float curr_pitch_fcu_frame_;
   float velocity_around_obstacles_;
   float velocity_far_from_obstacles_;
   float keep_distance_;

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -73,6 +73,7 @@ class LocalPlanner {
   float min_realsense_dist_ = 0.2f;
   float costmap_direction_e_;
   float costmap_direction_z_;
+  float smoothing_margin_degrees_ = 30.f;
 
   waypoint_choice waypoint_type_;
   ros::Time last_path_time_;

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -18,7 +18,6 @@
 
 #include <tf/transform_listener.h>
 
-#include <sensor_msgs/Image.h>
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/PointCloud2.h>
 
@@ -138,14 +137,14 @@ class LocalPlanner {
   * @param     histogram, polar histogram representing obstacles
   * @returns   histogram image
   **/
-  sensor_msgs::Image generateHistogramImage(Histogram &histogram);
+  void generateHistogramImage(Histogram &histogram);
 
  public:
   float h_FOV_ = 59.0f;
   float v_FOV_ = 46.0f;
   Box histogram_box_;
-  sensor_msgs::Image histogram_image_;
-  sensor_msgs::Image cost_image_;
+  std::vector<uint8_t> histogram_image_data_;
+  std::vector<uint8_t> cost_image_data_;
   bool use_vel_setpoints_;
   bool currently_armed_ = false;
   bool offboard_ = false;
@@ -162,7 +161,6 @@ class LocalPlanner {
   float ground_distance_ = 2.0;
 
   Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
-  ;
   sensor_msgs::LaserScan distance_data_ = {};
   Eigen::Vector3f last_sent_waypoint_ = Eigen::Vector3f::Zero();
 

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -69,8 +69,6 @@ class LocalPlanner {
   float distance_to_closest_point_;
   int min_cloud_size_ = 160;
   float min_dist_backoff_;
-  float relevance_margin_z_degree_ = 40.0f;
-  float relevance_margin_e_degree_ = 25.0f;
   float velocity_sigmoid_slope_ = 1.0;
   float min_realsense_dist_ = 0.2f;
   float costmap_direction_e_;
@@ -146,6 +144,7 @@ class LocalPlanner {
   float v_FOV_ = 46.0f;
   Box histogram_box_;
   sensor_msgs::Image histogram_image_;
+  sensor_msgs::Image cost_image_;
   bool use_vel_setpoints_;
   bool currently_armed_ = false;
   bool offboard_ = false;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -273,6 +273,7 @@ class LocalPlannerNode {
   ros::Publisher adapted_wp_pub_;
   ros::Publisher smoothed_wp_pub_;
   ros::Publisher histogram_image_pub_;
+  ros::Publisher cost_image_pub_;
 
   std::vector<float> algo_time;
 
@@ -396,7 +397,7 @@ class LocalPlannerNode {
   /**
   * @brief     publishes polar histogram image for Rviz visualization
   **/
-  void publishHistogramImage();
+  void publishDataImages();
   /**
   * @brief     publishes ground plane visualization for Rviz
   **/

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -14,6 +14,8 @@
 
 #include <nav_msgs/GridCells.h>
 #include <nav_msgs/Path.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
 
 #include <queue>
 #include <vector>
@@ -128,12 +130,30 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position, const float heading,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
-                   Eigen::MatrixXf& cost_matrix);
+                   Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image);
+
+/**
+* @brief      get the index in the data vector of a color image
+*             from the histogram index
+* @param[in] histogram index e,z and color (0=red, 1=green, 2=blue)
+* @param[out] index in image data vector
+**/
+int colorImageIndex(int e_ind, int z_ind, int color);
+
+/**
+* @brief      transform cost_matrix into an image
+* @param[in]  cost matrices
+* @param[out] image
+**/
+void generateCostImage(const Eigen::MatrixXf& cost_matrix,
+                       const Eigen::MatrixXf& distance_matrix,
+                       sensor_msgs::Image& image);
+
 /**
 * @brief      classifies the candidate directions in increasing cost order
 * @param[in]  matrix, cost matrix
-* @param[in]  number_of_candidates, number of candiate direction to consider
-* @param[out] candidate_vector, array of candidate polar direction arraged from
+* @param[in]  number_of_candidates, number of candidate direction to consider
+* @param[out] candidate_vector, array of candidate polar direction arranged from
 *the least to the most expensive
 **/
 void getBestCandidatesFromCostMatrix(

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -125,12 +125,15 @@ void compressHistogramElevation(Histogram& new_hist,
 * @param[in]  last_sent_waypoint, last position waypoint
 * @param[in]  cost_params, weight for the cost function
 * @param[in]  only_yawed, true if
-* @param[out] cost_matrix,
+* @param[in]  parameter how far an obstacle is spread in the cost matrix
+* @param[out] cost_matrix
+* @param[out] image of the cost matrix for visualization
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position, const float yaw_angle_histogram_frame,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
+				   const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image);
 
 /**

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -12,11 +12,6 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <nav_msgs/GridCells.h>
-#include <nav_msgs/Path.h>
-#include <sensor_msgs/Image.h>
-#include <sensor_msgs/image_encodings.h>
-
 #include <queue>
 #include <vector>
 
@@ -136,7 +131,8 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
                    const float smoothing_margin_degrees,
-                   Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image);
+                   Eigen::MatrixXf& cost_matrix,
+                   std::vector<uint8_t>& image_data);
 
 /**
 * @brief      get the index in the data vector of a color image
@@ -153,7 +149,7 @@ int colorImageIndex(int e_ind, int z_ind, int color);
 **/
 void generateCostImage(const Eigen::MatrixXf& cost_matrix,
                        const Eigen::MatrixXf& distance_matrix,
-                       sensor_msgs::Image& image);
+                       std::vector<uint8_t>& image_data);
 
 /**
 * @brief      classifies the candidate directions in increasing cost order

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -60,7 +60,7 @@ void filterPointCloud(
 * @note azimuth angle is wrapped, elevation is not
 **/
 void calculateFOV(float h_FOV, float v_FOV, std::vector<int>& z_FOV_idx,
-                  int& e_FOV_min, int& e_FOV_max, float yaw, float pitch);
+                  int& e_FOV_min, int& e_FOV_max, float yaw_fcu_frame, float pitch_fcu_frame);
 
 /**
 * @brief     calculates a histogram from older pointcloud data around the
@@ -121,13 +121,14 @@ void compressHistogramElevation(Histogram& new_hist,
 * @param[in]  histogram, polar histogram representing obstacles
 * @param[in]  goal, current goal position
 * @param[in]  position, current vehicle position
+* @param[in]  current vehicle heading in histogram angle convention
 * @param[in]  last_sent_waypoint, last position waypoint
 * @param[in]  cost_params, weight for the cost function
 * @param[in]  only_yawed, true if
 * @param[out] cost_matrix,
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position, const float heading,
+                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
                    Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image);
@@ -166,7 +167,7 @@ void getBestCandidatesFromCostMatrix(
 * @param[] z_angle, azimuth angle [deg]
 * @param[] goal, current goal position
 * @param[] position, current vehicle position
-* @param[] position, current vehicle heading
+* @param[] position, current vehicle heading in histogram angle convention
 * @param[] last_sent_waypoint, previous position waypoint
 * @param[] cost_params, weights for goal oriented vs smooth behaviour
 * @param[out] distance_cost, cost component due to proximity to obstacles
@@ -174,7 +175,7 @@ void getBestCandidatesFromCostMatrix(
 **/
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  const float heading,
+                  const float yaw_angle_histogram_frame,
                   const Eigen::Vector3f& last_sent_waypoint,
                   costParameters cost_params, float& distance_cost,
                   float& other_costs);

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -60,7 +60,8 @@ void filterPointCloud(
 * @note azimuth angle is wrapped, elevation is not
 **/
 void calculateFOV(float h_FOV, float v_FOV, std::vector<int>& z_FOV_idx,
-                  int& e_FOV_min, int& e_FOV_max, float yaw_fcu_frame, float pitch_fcu_frame);
+                  int& e_FOV_min, int& e_FOV_max, float yaw_fcu_frame,
+                  float pitch_fcu_frame);
 
 /**
 * @brief     calculates a histogram from older pointcloud data around the
@@ -130,10 +131,11 @@ void compressHistogramElevation(Histogram& new_hist,
 * @param[out] image of the cost matrix for visualization
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame,
+                   const Eigen::Vector3f& position,
+                   const float yaw_angle_histogram_frame,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
-				   const float smoothing_margin_degrees,
+                   const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image);
 
 /**

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -29,7 +29,7 @@ class StarPlanner {
   float tree_node_distance_ = 1.0f;
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
-  float curr_yaw_;
+  float curr_yaw_fcu_frame_;
 
   std::vector<int> reprojected_points_age_;
   std::vector<int> path_node_origins_;

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -14,6 +14,7 @@
 
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
+#include <sensor_msgs/Image.h>
 
 #include <vector>
 

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -14,7 +14,6 @@
 
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
-#include <sensor_msgs/Image.h>
 
 #include <vector>
 

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -30,6 +30,7 @@ class StarPlanner {
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
   float curr_yaw_fcu_frame_;
+  float smoothing_margin_degrees_ = 30.f;
 
   std::vector<int> reprojected_points_age_;
   std::vector<int> path_node_origins_;

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -115,20 +115,20 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
           Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ());
 }
 
-float getYawFromQuaternion(const Eigen::Quaternionf q){
-	tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
-	tf::Matrix3x3 tf_m(tf_q);
-	double roll, pitch, yaw;
-	tf_m.getRPY(roll, pitch, yaw);
-	return static_cast<float>(yaw);
+float getYawFromQuaternion(const Eigen::Quaternionf q) {
+  tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
+  tf::Matrix3x3 tf_m(tf_q);
+  double roll, pitch, yaw;
+  tf_m.getRPY(roll, pitch, yaw);
+  return static_cast<float>(yaw);
 }
 
-float getPitchFromQuaternion(const Eigen::Quaternionf q){
-	tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
-	tf::Matrix3x3 tf_m(tf_q);
-	double roll, pitch, yaw;
-	tf_m.getRPY(roll, pitch, yaw);
-	return static_cast<float>(pitch);
+float getPitchFromQuaternion(const Eigen::Quaternionf q) {
+  tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
+  tf::Matrix3x3 tf_m(tf_q);
+  double roll, pitch, yaw;
+  tf_m.getRPY(roll, pitch, yaw);
+  return static_cast<float>(pitch);
 }
 
 void wrapAngleToPlusMinusPI(float& angle) {

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -115,6 +115,22 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
           Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ());
 }
 
+float getYawFromQuaternion(const Eigen::Quaternionf q){
+	tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
+	tf::Matrix3x3 tf_m(tf_q);
+	double roll, pitch, yaw;
+	tf_m.getRPY(roll, pitch, yaw);
+	return static_cast<float>(yaw);
+}
+
+float getPitchFromQuaternion(const Eigen::Quaternionf q){
+	tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
+	tf::Matrix3x3 tf_m(tf_q);
+	double roll, pitch, yaw;
+	tf_m.getRPY(roll, pitch, yaw);
+	return static_cast<float>(pitch);
+}
+
 void wrapAngleToPlusMinusPI(float& angle) {
   angle = angle - 2.0f * M_PI_F * std::floor(angle / (2.0f * M_PI_F) + 0.5f);
 }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -131,12 +131,12 @@ void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
 void LocalPlanner::generateHistogramImage(Histogram &histogram) {
   histogram_image_data_.clear();
   histogram_image_data_.reserve(GRID_LENGTH_E * GRID_LENGTH_Z);
-  float sensor_max_dist = 10.f;
 
   // fill image data
   for (int e = GRID_LENGTH_E - 1; e >= 0; e--) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
-      float depth_val = 255.f * histogram.get_dist(e, z) / sensor_max_dist;
+      float depth_val =
+          255.f * histogram.get_dist(e, z) / histogram_box_.radius_;
       histogram_image_data_.push_back(
           (int)std::max(0.0f, std::min(255.f, depth_val)));
     }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -41,7 +41,6 @@ void LocalPlanner::dynamicReconfigureSetParams(
   keep_distance_ = config.keep_distance_;
   reproj_age_ = static_cast<float>(config.reproj_age_);
   velocity_sigmoid_slope_ = static_cast<float>(config.velocity_sigmoid_slope_);
-
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
   min_cloud_size_ = config.min_cloud_size_;
   min_realsense_dist_ = static_cast<float>(config.min_realsense_dist_);
@@ -50,6 +49,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
   timeout_termination_ = config.timeout_termination_;
   children_per_node_ = config.children_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
+  smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
 
   if (getGoal().z() != config.goal_z_param) {
     auto goal = getGoal();
@@ -224,7 +224,8 @@ void LocalPlanner::determineStrategy() {
         float yaw_angle_histogram_frame = std::round((-curr_yaw_fcu_frame_ * 180.0f / M_PI_F)) + 90.0f;
         getCostMatrix(polar_histogram_, goal_, position_, yaw_angle_histogram_frame,
                       last_sent_waypoint_, cost_params_,
-                      velocity_.norm() < 0.1f, cost_matrix_, cost_image_);
+                      velocity_.norm() < 0.1f, smoothing_margin_degrees_,
+					  cost_matrix_, cost_image_);
 
         if (use_VFH_star_) {
           star_planner_->setParams(cost_params_);

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -49,7 +49,8 @@ void LocalPlanner::dynamicReconfigureSetParams(
   timeout_termination_ = config.timeout_termination_;
   children_per_node_ = config.children_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
-  smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
+  smoothing_margin_degrees_ =
+      static_cast<float>(config.smoothing_margin_degrees_);
 
   if (getGoal().z() != config.goal_z_param) {
     auto goal = getGoal();
@@ -91,8 +92,8 @@ void LocalPlanner::runPlanner() {
 
   // calculate Field of View
   z_FOV_idx_.clear();
-  calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_, curr_yaw_fcu_frame_,
-               curr_pitch_fcu_frame_);
+  calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_,
+               curr_yaw_fcu_frame_, curr_pitch_fcu_frame_);
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
@@ -155,7 +156,6 @@ void LocalPlanner::determineStrategy() {
   star_planner_->tree_age_++;
 
   // clear cost image
-  cost_image_.data.reserve(3 * GRID_LENGTH_E * GRID_LENGTH_Z);
   std::fill(cost_image_.data.begin(), cost_image_.data.end(), 0);
 
   if (disable_rise_to_goal_altitude_) {
@@ -221,11 +221,12 @@ void LocalPlanner::determineStrategy() {
       if (!hist_is_empty_ && reach_altitude_) {
         obstacle_ = true;
 
-        float yaw_angle_histogram_frame = std::round((-curr_yaw_fcu_frame_ * 180.0f / M_PI_F)) + 90.0f;
-        getCostMatrix(polar_histogram_, goal_, position_, yaw_angle_histogram_frame,
-                      last_sent_waypoint_, cost_params_,
-                      velocity_.norm() < 0.1f, smoothing_margin_degrees_,
-					  cost_matrix_, cost_image_);
+        float yaw_angle_histogram_frame =
+            std::round((-curr_yaw_fcu_frame_ * 180.0f / M_PI_F)) + 90.0f;
+        getCostMatrix(polar_histogram_, goal_, position_,
+                      yaw_angle_histogram_frame, last_sent_waypoint_,
+                      cost_params_, velocity_.norm() < 0.1f,
+                      smoothing_margin_degrees_, cost_matrix_, cost_image_);
 
         if (use_VFH_star_) {
           star_planner_->setParams(cost_params_);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -565,8 +565,14 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
 }
 
 void LocalPlannerNode::publishDataImages() {
-  sensor_msgs::Image cost_img = local_planner_->cost_image_;
+  sensor_msgs::Image cost_img;
   cost_img.header.stamp = ros::Time::now();
+  cost_img.height = GRID_LENGTH_E;
+  cost_img.width = GRID_LENGTH_Z;
+  cost_img.encoding = "rgb8";
+  cost_img.is_bigendian = 0;
+  cost_img.step = 3 * cost_img.width;
+  cost_img.data = local_planner_->cost_image_data_;
 
   // current orientation
   float curr_yaw_fcu_frame =
@@ -609,7 +615,17 @@ void LocalPlannerNode::publishDataImages() {
                                   adapted_waypoint_index.x(), 2)] = 255.f;
   }
 
-  histogram_image_pub_.publish(local_planner_->histogram_image_);
+  // histogram image
+  sensor_msgs::Image hist_img;
+  hist_img.header.stamp = ros::Time::now();
+  hist_img.height = GRID_LENGTH_E;
+  hist_img.width = GRID_LENGTH_Z;
+  hist_img.encoding = sensor_msgs::image_encodings::MONO8;
+  hist_img.is_bigendian = 0;
+  hist_img.step = 255;
+  hist_img.data = local_planner_->histogram_image_data_;
+
+  histogram_image_pub_.publish(hist_img);
   cost_image_pub_.publish(cost_img);
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -569,9 +569,11 @@ void LocalPlannerNode::publishDataImages() {
   cost_img.header.stamp = ros::Time::now();
 
   // current orientation
-  float curr_yaw_fcu_frame = getYawFromQuaternion(toEigen(newest_pose_.pose.orientation));
+  float curr_yaw_fcu_frame =
+      getYawFromQuaternion(toEigen(newest_pose_.pose.orientation));
   float yaw_angle_histogram_frame =
-      std::round((-static_cast<float>(curr_yaw_fcu_frame) * 180.0f / M_PI_F)) + 90.0f;
+      std::round((-static_cast<float>(curr_yaw_fcu_frame) * 180.0f / M_PI_F)) +
+      90.0f;
   PolarPoint heading_pol(0, yaw_angle_histogram_frame, 1.0);
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -566,6 +566,7 @@ void LocalPlannerNode::publishWaypoints(bool hover) {
 
 void LocalPlannerNode::publishDataImages() {
   sensor_msgs::Image cost_img = local_planner_->cost_image_;
+  cost_img.header.stamp = ros::Time::now();
 
   // current orientation
   Eigen::Quaternionf q = toEigen(newest_pose_.pose.orientation);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -569,14 +569,10 @@ void LocalPlannerNode::publishDataImages() {
   cost_img.header.stamp = ros::Time::now();
 
   // current orientation
-  Eigen::Quaternionf q = toEigen(newest_pose_.pose.orientation);
-  tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
-  tf::Matrix3x3 tf_m(tf_q);
-  double roll, pitch, yaw;
-  tf_m.getRPY(roll, pitch, yaw);
-  float yaw_angle =
-      std::round((-static_cast<float>(yaw) * 180.0f / M_PI_F)) + 90.0f;
-  PolarPoint heading_pol(0, yaw_angle, 1.0);
+  float curr_yaw_fcu_frame = getYawFromQuaternion(toEigen(newest_pose_.pose.orientation));
+  float yaw_angle_histogram_frame =
+      std::round((-static_cast<float>(curr_yaw_fcu_frame) * 180.0f / M_PI_F)) + 90.0f;
+  PolarPoint heading_pol(0, yaw_angle_histogram_frame, 1.0);
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 
   // current setpoint

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -57,21 +57,21 @@ void filterPointCloud(
 
 // Calculate FOV. Azimuth angle is wrapped, elevation is not!
 void calculateFOV(float h_fov, float v_fov, std::vector<int>& z_FOV_idx,
-                  int& e_FOV_min, int& e_FOV_max, float yaw, float pitch) {
+                  int& e_FOV_min, int& e_FOV_max, float yaw_fcu_frame, float pitch_fcu_frame) {
   int z_FOV_max =
-      static_cast<int>(std::round((-yaw * RAD_TO_DEG + h_fov / 2.0f + 270.0f) /
+      static_cast<int>(std::round((-yaw_fcu_frame * RAD_TO_DEG + h_fov / 2.0f + 270.0f) /
                                   static_cast<float>(ALPHA_RES))) -
       1;
   int z_FOV_min =
-      static_cast<int>(std::round((-yaw * RAD_TO_DEG - h_fov / 2.0f + 270.0f) /
+      static_cast<int>(std::round((-yaw_fcu_frame * RAD_TO_DEG - h_fov / 2.0f + 270.0f) /
                                   static_cast<float>(ALPHA_RES))) -
       1;
   e_FOV_max =
-      static_cast<int>(std::round((-pitch * RAD_TO_DEG + v_fov / 2.0f + 90.0f) /
+      static_cast<int>(std::round((-pitch_fcu_frame * RAD_TO_DEG + v_fov / 2.0f + 90.0f) /
                                   static_cast<float>(ALPHA_RES))) -
       1;
   e_FOV_min =
-      static_cast<int>(std::round((-pitch * RAD_TO_DEG - v_fov / 2.0f + 90.0f) /
+      static_cast<int>(std::round((-pitch_fcu_frame * RAD_TO_DEG - v_fov / 2.0f + 90.0f) /
                                   static_cast<float>(ALPHA_RES))) -
       1;
 
@@ -240,7 +240,7 @@ void compressHistogramElevation(Histogram& new_hist,
 }
 
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position, const float heading,
+                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
                    Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image) {
@@ -265,7 +265,7 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
       PolarPoint p_pol =
           histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
 
-      costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position, heading,
+      costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position, yaw_angle_histogram_frame,
                    last_sent_waypoint, cost_params, distance_cost, other_costs);
       cost_matrix(e_index, z_index) = other_costs;
       distance_matrix(e_index, z_index) = distance_cost;
@@ -484,14 +484,14 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 // costfunction for every free histogram cell
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  const float heading,
+                  const float yaw_angle_histogram_frame,
                   const Eigen::Vector3f& last_sent_waypoint,
                   costParameters cost_params, float& distance_cost,
                   float& other_costs) {
   float goal_dist = (position - goal).norm();
   PolarPoint p_pol(e_angle, z_angle, goal_dist);
   Eigen::Vector3f projected_candidate = polarToCartesian(p_pol, position);
-  PolarPoint heading_pol(e_angle, heading, goal_dist);
+  PolarPoint heading_pol(e_angle, yaw_angle_histogram_frame, goal_dist);
   Eigen::Vector3f projected_heading = polarToCartesian(heading_pol, position);
   Eigen::Vector3f projected_goal = goal;
   PolarPoint last_wp_pol = cartesianToPolar(last_sent_waypoint, position);

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -243,6 +243,7 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position, const float yaw_angle_histogram_frame,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
+				   const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, sensor_msgs::Image& image) {
   Eigen::MatrixXf distance_matrix(GRID_LENGTH_E, GRID_LENGTH_Z);
   distance_matrix.fill(NAN);
@@ -308,7 +309,6 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
     }
   }
 
-  float smoothing_margin_degrees = 30;
   unsigned int smooth_radius = ceil(smoothing_margin_degrees / ALPHA_RES);
   smoothPolarMatrix(distance_matrix, smooth_radius);
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -320,8 +320,6 @@ void generateCostImage(const Eigen::MatrixXf& cost_matrix,
                        const Eigen::MatrixXf& distance_matrix,
                        sensor_msgs::Image& image) {
   float max_val = std::max(cost_matrix.maxCoeff(), distance_matrix.maxCoeff());
-  // float max_val = cost_matrix.maxCoeff();
-  image.header.stamp = ros::Time::now();
   image.height = GRID_LENGTH_E;
   image.width = GRID_LENGTH_Z;
   image.encoding = "rgb8";

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -397,37 +397,26 @@ void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius) {
   Eigen::ArrayXf kernel1d = getConicKernel(smoothing_radius);
 
   Eigen::ArrayXf temp_col(matrix_padded.rows());
-
   for (int col_index = 0; col_index < matrix_padded.cols(); col_index++) {
-    temp_col.fill(NAN);
+    temp_col = matrix_padded.col(col_index);
     for (int row_index = 0; row_index < matrix.rows(); row_index++) {
-      float smooth_val = (matrix_padded.col(col_index)
-                              .segment(row_index, 2 * smoothing_radius + 1)
-                              .array() *
-                          kernel1d)
-                             .sum();
-      temp_col(row_index + smoothing_radius) = smooth_val;
+      float smooth_val =
+          (temp_col.segment(row_index, 2 * smoothing_radius + 1) * kernel1d)
+              .sum();
+      matrix_padded(row_index + smoothing_radius, col_index) = smooth_val;
     }
-    matrix_padded.col(col_index) = temp_col;
   }
 
   Eigen::ArrayXf temp_row(matrix_padded.cols());
-  for (int row_index = 0; row_index < matrix_padded.rows(); row_index++) {
-    temp_row.fill(NAN);
+  for (int row_index = 0; row_index < matrix.rows(); row_index++) {
+    temp_row = matrix_padded.row(row_index + smoothing_radius);
     for (int col_index = 0; col_index < matrix.cols(); col_index++) {
-      float smooth_val = (matrix_padded.row(row_index)
-                              .segment(col_index, 2 * smoothing_radius + 1)
-                              .transpose()
-                              .array() *
-                          kernel1d)
-                             .sum();
-
-      temp_row(col_index + smoothing_radius) = smooth_val;
+      float smooth_val =
+          (temp_row.segment(col_index, 2 * smoothing_radius + 1) * kernel1d)
+              .sum();
+      matrix(row_index, col_index) = smooth_val;
     }
-    matrix_padded.row(row_index) = temp_row.transpose();
   }
-  matrix = matrix_padded.block(smoothing_radius, smoothing_radius,
-                               matrix.rows(), matrix.cols());
 }
 
 Eigen::ArrayXf getConicKernel(int radius) {

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -17,6 +17,7 @@ void StarPlanner::dynamicReconfigureSetStarParams(
   tree_node_distance_ = static_cast<float>(config.tree_node_distance_);
   tree_discount_factor_ = static_cast<float>(config.tree_discount_factor_);
   max_path_length_ = static_cast<float>(config.max_path_length_);
+  smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
 }
 
 void StarPlanner::setParams(costParameters cost_params) {
@@ -155,8 +156,8 @@ void StarPlanner::buildLookAheadTree() {
     sensor_msgs::Image cost_image;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_,
-                  projected_last_wp_, cost_params_, false, cost_matrix,
-                  cost_image);
+                  projected_last_wp_, cost_params_, false, smoothing_margin_degrees_,
+				  cost_matrix, cost_image);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -152,9 +152,11 @@ void StarPlanner::buildLookAheadTree() {
 
     // calculate candidates
     Eigen::MatrixXf cost_matrix;
+    sensor_msgs::Image cost_image;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_,
-                  projected_last_wp_, cost_params_, false, cost_matrix);
+                  projected_last_wp_, cost_params_, false, cost_matrix,
+                  cost_image);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -154,11 +154,11 @@ void StarPlanner::buildLookAheadTree() {
 
     // calculate candidates
     Eigen::MatrixXf cost_matrix;
-    sensor_msgs::Image cost_image;
+    std::vector<uint8_t> cost_image_data;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_,
                   projected_last_wp_, cost_params_, false,
-                  smoothing_margin_degrees_, cost_matrix, cost_image);
+                  smoothing_margin_degrees_, cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -34,7 +34,7 @@ void StarPlanner::setFOV(float h_FOV, float v_FOV) {
 
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   position_ = pos;
-  curr_yaw_ = curr_yaw;
+  curr_yaw_fcu_frame_ = curr_yaw;
 }
 
 void StarPlanner::setCloud(
@@ -122,7 +122,7 @@ void StarPlanner::buildLookAheadTree() {
   tree_.push_back(TreeNode(0, 0, position_));
   tree_.back().setCosts(treeHeuristicFunction(0), treeHeuristicFunction(0));
   tree_.back().yaw_ =
-      std::round((-curr_yaw_ * 180.0f / M_PI_F)) +
+      std::round((-curr_yaw_fcu_frame_ * 180.0f / M_PI_F)) +
       90.0f;  // from radian to angle and shift reference to y-axis
   tree_.back().last_z_ = tree_.back().yaw_;
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -17,7 +17,8 @@ void StarPlanner::dynamicReconfigureSetStarParams(
   tree_node_distance_ = static_cast<float>(config.tree_node_distance_);
   tree_discount_factor_ = static_cast<float>(config.tree_discount_factor_);
   max_path_length_ = static_cast<float>(config.max_path_length_);
-  smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
+  smoothing_margin_degrees_ =
+      static_cast<float>(config.smoothing_margin_degrees_);
 }
 
 void StarPlanner::setParams(costParameters cost_params) {
@@ -156,8 +157,8 @@ void StarPlanner::buildLookAheadTree() {
     sensor_msgs::Image cost_image;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_,
-                  projected_last_wp_, cost_params_, false, smoothing_margin_degrees_,
-				  cost_matrix, cost_image);
+                  projected_last_wp_, cost_params_, false,
+                  smoothing_margin_degrees_, cost_matrix, cost_image);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -441,8 +441,9 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   Histogram histogram = Histogram(ALPHA_RES);
 
   // WHEN: we calculate the cost matrix from the input data
+  sensor_msgs::Image image;
   getCostMatrix(histogram, goal, position, heading, last_sent_waypoint,
-                cost_params, false, cost_matrix);
+                cost_params, false, cost_matrix, image);
 
   // THEN: The minimum cost should be in the direction of the goal
   PolarPoint best_pol = cartesianToPolar(goal, position);

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -471,11 +471,12 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   cost_params.height_change_cost_param_adapted = 4.f;
   Eigen::MatrixXf cost_matrix;
   Histogram histogram = Histogram(ALPHA_RES);
+  float smoothing_radius = 30.f;
 
   // WHEN: we calculate the cost matrix from the input data
   sensor_msgs::Image image;
   getCostMatrix(histogram, goal, position, heading, last_sent_waypoint,
-                cost_params, false, cost_matrix, image);
+                cost_params, false, smoothing_radius, cost_matrix, image);
 
   // THEN: The minimum cost should be in the direction of the goal
   PolarPoint best_pol = cartesianToPolar(goal, position);

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -7,26 +7,6 @@
 
 using namespace avoidance;
 
-void check_indexes(nav_msgs::GridCells &test,
-                   std::vector<Eigen::Vector2i> &truth, int resolution) {
-  for (int i = 0, j = 0; i < test.cells.size(), j < truth.size(); i++, j++) {
-    PolarPoint p_pol(test.cells[i].x, test.cells[i].y, 0.0f);
-    Eigen::Vector2i cell_idx = polarToHistogramIndex(p_pol, resolution);
-
-    EXPECT_EQ(truth[j], cell_idx);
-  }
-}
-
-void check_indexes(nav_msgs::GridCells &test, int truth_idx_e, int truth_idx_z,
-                   int resolution) {
-  for (int i = 0; i < test.cells.size(); i++) {
-    PolarPoint p_pol(test.cells[i].x, test.cells[i].y, 0.0f);
-    Eigen::Vector2i cell_idx = polarToHistogramIndex(p_pol, resolution);
-    EXPECT_EQ(truth_idx_e, cell_idx.y());
-    EXPECT_EQ(truth_idx_z, cell_idx.x());
-  }
-}
-
 TEST(PlannerFunctions, generateNewHistogramEmpty) {
   // GIVEN: an empty pointcloud
   pcl::PointCloud<pcl::PointXYZ> empty_cloud;
@@ -474,9 +454,10 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   float smoothing_radius = 30.f;
 
   // WHEN: we calculate the cost matrix from the input data
-  sensor_msgs::Image image;
+  std::vector<uint8_t> cost_image_data;
   getCostMatrix(histogram, goal, position, heading, last_sent_waypoint,
-                cost_params, false, smoothing_radius, cost_matrix, image);
+                cost_params, false, smoothing_radius, cost_matrix,
+                cost_image_data);
 
   // THEN: The minimum cost should be in the direction of the goal
   PolarPoint best_pol = cartesianToPolar(goal, position);

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -426,6 +426,38 @@ TEST(PlannerFunctions, smoothPolarMatrix) {
   EXPECT_TRUE(greater_equal);
 }
 
+TEST(PlannerFunctions, smoothMatrix) {
+  // GIVEN: a matrix with a single cell set
+  unsigned int smooth_radius = 4;
+  Eigen::MatrixXf matrix;
+  matrix.resize(10, 20);
+  matrix.fill(0);
+  matrix(3, 16) = 100;
+  matrix(6, 6) = -100;
+
+  // WHEN: we smooth it
+  Eigen::MatrixXf matrix_old = matrix;
+  smoothPolarMatrix(matrix, smooth_radius);
+
+  // THEN: it should match the matrix we expect
+  Eigen::MatrixXf expected_matrix(matrix.rows(), matrix.cols());
+  // clang-format off
+  expected_matrix <<
+   8, 0,   4,   8,  12,  16,  20,  16,  12,   8,   4, 0,  8, 16,  24,  32,  40,  32,  24, 16,
+  12, 0,   0,   0,   0,   0,   0,   0,   0,   0,   0, 0, 12, 24,  36,  48,  60,  48,  36, 24,
+  16, 0,  -4,  -8, -12, -16, -20, -16, -12,  -8,  -4, 0, 16, 32,  48,  64,  80,  64,  48, 32,
+  20, 0,  -8, -16, -24, -32, -40, -32, -24, -16,  -8, 0, 20, 40,  60,  80, 100,  80,  60, 40,
+  16, 0, -12, -24, -36, -48, -60, -48, -36, -24, -12, 0, 16, 32,  48,  64,  80,  64,  48, 32,
+  12, 0, -16, -32, -48, -64, -80, -64, -48, -32, -16, 0, 12, 24,  36,  48,  60,  48,  36, 24,
+   8, 0, -20, -40, -60, -80,-100, -80, -60, -40, -20, 0,  8, 16,  24,  32,  40,  32,  24, 16,
+   4, 0, -16, -32, -48, -64, -80, -64, -48, -32, -16, 0,  4,  8,  12,  16,  20,  16,  12,  8,
+   0, 0, -12, -24, -36, -48, -60, -48, -36, -24, -12, 0,  0,  0,   0,   0,   0,   0,   0,  0,
+  -4, 0,  -8, -16, -24, -32, -40, -32, -24, -16,  -8, 0, -4, -8, -12, -16, -20, -16, -12, -8;
+  // clang-format on
+
+  EXPECT_LT((expected_matrix - matrix).cwiseAbs().maxCoeff(), 1e-5);
+}
+
 TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   // GIVEN: a position, goal and an empty histogram
   Eigen::Vector3f position(0.f, 0.f, 0.f);


### PR DESCRIPTION
![cost_image](https://user-images.githubusercontent.com/25756842/54343780-d6ac2280-463f-11e9-917c-5664534b93c8.jpg)
Visualization of the costmatrix, where current heading, chosen waypoint and smoothed waypoint are marked. This 2D visualization is very helpful for debugging

The greener the matrix the more costly from a goal or smoothing perspective the cell is. The reder a cell the more expensive it is due to obstacle distance. The darkest cell is the least expensive one. The dark blue cell (here pink because it is in the red area) is current heading, the light blue one currently chosen best cell, the white one the smoothed setpoint which is actually sent to the pixhawk

Different fixes:
- fix bug in smoothing function
- change smoothing kernel to be non energy conservant
- increase box size
- take out histogram relevance check (get rid of unnecessary moving parts which could cause troubles which are hard to find)