### PR TITLE
save last waypoint for temporal smoothing in agular representation

### DIFF
--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -5,6 +5,7 @@
 #include "avoidance_output.h"
 #include "box.h"
 #include "candidate_direction.h"
+#include "common.h"
 #include "cost_parameters.h"
 #include "histogram.h"
 
@@ -162,9 +163,8 @@ class LocalPlanner {
   float ground_distance_ = 2.0;
 
   Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
-  ;
   sensor_msgs::LaserScan distance_data_ = {};
-  Eigen::Vector3f last_sent_waypoint_ = Eigen::Vector3f::Zero();
+  PolarPoint last_sent_waypoint_direction_;
 
   // complete_cloud_ contains n complete clouds from the cameras
   std::vector<pcl::PointCloud<pcl::PointXYZ>> complete_cloud_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -126,7 +126,7 @@ void compressHistogramElevation(Histogram& new_hist,
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position, const float heading,
-                   const Eigen::Vector3f& last_sent_waypoint,
+                   const PolarPoint& last_sent_waypoint_direction,
                    costParameters cost_params, bool only_yawed,
                    Eigen::MatrixXf& cost_matrix);
 /**
@@ -155,7 +155,7 @@ void getBestCandidatesFromCostMatrix(
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                   const float heading,
-                  const Eigen::Vector3f& last_sent_waypoint,
+                  const PolarPoint& last_sent_waypoint_direction,
                   costParameters cost_params, float& distance_cost,
                   float& other_costs);
 

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -2,6 +2,7 @@
 #define STAR_PLANNER_H
 
 #include "box.h"
+#include "common.h"
 #include "cost_parameters.h"
 #include "histogram.h"
 
@@ -37,7 +38,7 @@ class StarPlanner {
   pcl::PointCloud<pcl::PointXYZ> reprojected_points_;
 
   Eigen::Vector3f goal_ = Eigen::Vector3f(NAN, NAN, NAN);
-  Eigen::Vector3f projected_last_wp_ = Eigen::Vector3f::Zero();
+  PolarPoint last_wp_direction_;
   Eigen::Vector3f position_ = Eigen::Vector3f(NAN, NAN, NAN);
   costParameters cost_params_;
 
@@ -73,9 +74,9 @@ class StarPlanner {
 
   /**
   * @brief     setter method for last sent waypoint
-  * @param[in] projected_last_wp, last waypoint projected out to goal distance
+  * @param[in] polar point of last waypoint, last sent direction
   **/
-  void setLastDirection(const Eigen::Vector3f& projected_last_wp);
+  void setLastDirection(const PolarPoint& last_wp_direction);
 
   /**
   * @brief     setter method for Fielf of View

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -260,12 +260,7 @@ void LocalPlanner::determineStrategy() {
           star_planner_->setCloud(final_cloud_);
 
           // set last chosen direction for smoothing
-          PolarPoint last_wp_pol =
-              cartesianToPolar(last_sent_waypoint_, position_);
-          last_wp_pol.r = (position_ - goal_).norm();
-          Eigen::Vector3f projected_last_wp =
-              polarToCartesian(last_wp_pol, position_);
-          star_planner_->setLastDirection(projected_last_wp);
+          star_planner_->setLastDirection(last_sent_waypoint_direction_);
 
           // build search tree
           star_planner_->buildLookAheadTree();
@@ -275,7 +270,7 @@ void LocalPlanner::determineStrategy() {
         } else {
           float yaw_angle = std::round((-curr_yaw_ * 180.0f / M_PI_F)) + 90.0f;
           getCostMatrix(polar_histogram_, goal_, position_, yaw_angle,
-                        last_sent_waypoint_, cost_params_,
+                        last_sent_waypoint_direction_, cost_params_,
                         velocity_.norm() < 0.1f, cost_matrix_);
           getBestCandidatesFromCostMatrix(cost_matrix_, 1, candidate_vector_);
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -248,7 +248,9 @@ void LocalPlannerNode::updatePlannerInfo() {
   }
 
   // update last sent waypoint
-  local_planner_->last_sent_waypoint_ = toEigen(newest_waypoint_position_);
+  PolarPoint last_wp_pol = cartesianToPolar(
+      toEigen(newest_waypoint_position_), toEigen(newest_pose_.pose.position));
+  local_planner_->last_sent_waypoint_direction_ = last_wp_pol;
 }
 
 void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -23,8 +23,8 @@ void StarPlanner::setParams(costParameters cost_params) {
   cost_params_ = cost_params;
 }
 
-void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) {
-  projected_last_wp_ = projected_last_wp;
+void StarPlanner::setLastDirection(const PolarPoint& last_wp_direction) {
+  last_wp_direction_ = last_wp_direction;
 }
 
 void StarPlanner::setFOV(float h_FOV, float v_FOV) {
@@ -154,7 +154,7 @@ void StarPlanner::buildLookAheadTree() {
     Eigen::MatrixXf cost_matrix;
     std::vector<candidateDirection> candidate_vector;
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_,
-                  projected_last_wp_, cost_params_, false, cost_matrix);
+                  last_wp_direction_, cost_params_, false, cost_matrix);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_,
                                     candidate_vector);
 

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -430,7 +430,7 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   // GIVEN: a position, goal and an empty histogram
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
+  PolarPoint last_wp_direction(0.f, 0.f, 1.f);
   float heading = 0.f;
   costParameters cost_params;
   cost_params.goal_cost_param = 2.f;
@@ -441,7 +441,7 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   Histogram histogram = Histogram(ALPHA_RES);
 
   // WHEN: we calculate the cost matrix from the input data
-  getCostMatrix(histogram, goal, position, heading, last_sent_waypoint,
+  getCostMatrix(histogram, goal, position, heading, last_wp_direction,
                 cost_params, false, cost_matrix);
 
   // THEN: The minimum cost should be in the direction of the goal
@@ -511,7 +511,7 @@ TEST(PlannerFunctions, CostfunctionGoalCost) {
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal_1(0.f, 5.f, 0.f);
   Eigen::Vector3f goal_2(3.f, 3.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
+  PolarPoint last_wp_direction(0.f, 0.f, 1.f);
   float heading = 0.f;
   costParameters cost_params;
   cost_params.goal_cost_param = 3.f;
@@ -527,10 +527,10 @@ TEST(PlannerFunctions, CostfunctionGoalCost) {
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different goals
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal_1,
-               position, heading, last_sent_waypoint, cost_params,
+               position, heading, last_wp_direction, cost_params,
                distance_cost_1, other_costs_1);
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal_2,
-               position, heading, last_sent_waypoint, cost_params,
+               position, heading, last_wp_direction, cost_params,
                distance_cost_2, other_costs_2);
 
   // THEN: The cost in the case where the goal is in the cell direction should
@@ -542,7 +542,7 @@ TEST(PlannerFunctions, CostfunctionDistanceCost) {
   // GIVEN: a scenario with two different obstacle distances
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
+  PolarPoint last_wp_direction(0.f, 0.f, 1.f);
   float heading = 0.f;
   costParameters cost_params;
   cost_params.goal_cost_param = 3.f;
@@ -560,13 +560,13 @@ TEST(PlannerFunctions, CostfunctionDistanceCost) {
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different obstacle distance
   costFunction(candidate_1.y(), candidate_1.x(), distance_1, goal, position,
-               heading, last_sent_waypoint, cost_params, distance_cost_1,
+               heading, last_wp_direction, cost_params, distance_cost_1,
                other_costs);
   costFunction(candidate_1.y(), candidate_1.x(), distance_2, goal, position,
-               heading, last_sent_waypoint, cost_params, distance_cost_2,
+               heading, last_wp_direction, cost_params, distance_cost_2,
                other_costs);
   costFunction(candidate_1.y(), candidate_1.x(), distance_3, goal, position,
-               heading, last_sent_waypoint, cost_params, distance_cost_3,
+               heading, last_wp_direction, cost_params, distance_cost_3,
                other_costs);
 
   // THEN: The distance cost for no obstacle should be zero and the distance
@@ -580,7 +580,7 @@ TEST(PlannerFunctions, CostfunctionHeadingCost) {
   // GIVEN: a scenario with two different initial headings
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
+  PolarPoint last_wp_direction(0.f, 0.f, 1.f);
   float heading_1 = 10.f;
   float heading_2 = 30.f;
   costParameters cost_params;
@@ -597,10 +597,10 @@ TEST(PlannerFunctions, CostfunctionHeadingCost) {
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different initial headings
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal,
-               position, heading_1, last_sent_waypoint, cost_params,
+               position, heading_1, last_wp_direction, cost_params,
                distance_cost, other_costs_1);
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal,
-               position, heading_2, last_sent_waypoint, cost_params,
+               position, heading_2, last_wp_direction, cost_params,
                distance_cost, other_costs_2);
 
   // THEN: The cost in the case where the initial heading is closer to the
@@ -612,8 +612,8 @@ TEST(PlannerFunctions, CostfunctionSmoothingCost) {
   // GIVEN: a scenario with two different initial headings
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint_1(1.f, 2.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint_2(1.5f, 1.5f, 0.f);
+  PolarPoint last_wp_direction_1(30.f, 0.f, 1.f);
+  PolarPoint last_wp_direction_2(45.f, 0.f, 1.f);
   float heading = 0.f;
   costParameters cost_params;
   cost_params.goal_cost_param = 3.f;
@@ -629,10 +629,10 @@ TEST(PlannerFunctions, CostfunctionSmoothingCost) {
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different last waypoints
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal,
-               position, heading, last_sent_waypoint_1, cost_params,
+               position, heading, last_wp_direction_1, cost_params,
                distance_cost, other_costs_1);
   costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal,
-               position, heading, last_sent_waypoint_2, cost_params,
+               position, heading, last_wp_direction_2, cost_params,
                distance_cost, other_costs_2);
 
   // THEN: The cost in the case where the last waypoint is closer to the


### PR DESCRIPTION
The last waypoint was so far saved as a cartesion point. That meant the smoothing encouraged going towards this point absolute in space.

I would suggest a better solution would be to safe the direction we were commanding the vehicle to go in the last timestep. Smoothing would then encourage going into the same direction. This visualization shows the difference. The colored points goal, proj_wp, proj_heading are used to determine the cost of the proj_candidate in the cost function.

This PR would need some SITL testing and flight testing.
![final](https://user-images.githubusercontent.com/25756842/54424313-ea748900-4712-11e9-830c-7475f8040339.png)
