### PR TITLE
Add link time optimization for the library and node

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.9)
 project(local_planner)
 
 add_definitions(-std=c++11)
@@ -164,6 +164,18 @@ add_dependencies(local_planner ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPO
 ## Declare a C++ executable
 # add_executable(avoidance_node src/avoidance_node.cpp)
 add_executable(local_planner_node src/nodes/local_planner_node_main.cpp)
+
+## Check for Link Time Optimization support
+## and enable it on the library and node if we are doing a release build
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported OUTPUT error)
+if( ipo_supported AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    message(STATUS "IPO / LTO enabled")
+    set_property(TARGET local_planner PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set_property(TARGET local_planner_node PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+    message(STATUS "IPO / LTO not enabled: <${error}>")
+endif()
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -153,7 +153,8 @@ if(NOT DISABLE_SIMULATION)
   set(LOCAL_PLANNER_CPP_FILES "${LOCAL_PLANNER_CPP_FILES}"
                               "src/nodes/rviz_world_loader.cpp")
 endif()
-add_library(local_planner     "${LOCAL_PLANNER_CPP_FILES}")
+add_library(local_planner STATIC
+                          "${LOCAL_PLANNER_CPP_FILES}")
 
 
 ## Add cmake target dependencies of the library


### PR DESCRIPTION
This adds Link Time Optimization when compiling in Release mode. It should improve speed in the helper functions for things like polarToCartesian which are called ~500k times per iteration, and reduce binary size considerably. Note that it does slow down linking.

Release build sizes before:
devel/lib/local_planner/local_planner_node 103K
devel/lib/liblocal_planner.so 1.1M 

After:
devel/lib/local_planner/local_planner_node 78K
devel/lib/liblocal_planner.so 878K

Then adding static linking:
devel/lib/local_planner/local_planner_node 762K
