### PR TITLE
Quaternion angle cleanup

### DIFF
--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -57,8 +57,9 @@ class LocalPlanner {
   int reproj_age_;
   int counter_close_points_backoff_ = 0;
 
-  float curr_yaw_deg_fcu_frame_, curr_yaw_deg_histogram_frame_;
-  float curr_pitch_deg_;
+  float curr_yaw_fcu_frame_deg_, curr_yaw_histogram_frame_deg_;
+  float curr_pitch_deg_;  // for pitch angles the histogram frame matches the
+                          // fcu frame
   float velocity_around_obstacles_;
   float velocity_far_from_obstacles_;
   float keep_distance_;

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -57,8 +57,8 @@ class LocalPlanner {
   int reproj_age_;
   int counter_close_points_backoff_ = 0;
 
-  float curr_yaw_fcu_frame_;
-  float curr_pitch_fcu_frame_;
+  float curr_yaw_deg_fcu_frame_, curr_yaw_deg_histogram_frame_;
+  float curr_pitch_deg_;
   float velocity_around_obstacles_;
   float velocity_far_from_obstacles_;
   float keep_distance_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -65,7 +65,7 @@ void calculateFOV(float h_FOV, float v_FOV, std::vector<int>& z_FOV_idx,
 * @param[in] reprojected_points, previous iterations occupied histogram bins
 *reprojected in 3D space
 * @param[in] reprojected_points_age, age of each reprojected point
-* @param[]   position, current vehicle positon
+* @param[in]   position, current vehicle positon
 **/
 void propagateHistogram(
     Histogram& polar_histogram_est,
@@ -164,13 +164,14 @@ void getBestCandidatesFromCostMatrix(
 
 /**
 * @brief   computes the cost of each direction in the polar histogram
-* @param[] e_angle, elevation angle [deg]
-* @param[] z_angle, azimuth angle [deg]
-* @param[] goal, current goal position
-* @param[] position, current vehicle position
-* @param[] position, current vehicle heading in histogram angle convention [deg]
-* @param[] last_sent_waypoint, previous position waypoint
-* @param[] cost_params, weights for goal oriented vs smooth behaviour
+* @param[in] e_angle, elevation angle [deg]
+* @param[in] z_angle, azimuth angle [deg]
+* @param[in] goal, current goal position
+* @param[in] position, current vehicle position
+* @param[in] position, current vehicle heading in histogram angle convention
+*[deg]
+* @param[in] last_sent_waypoint, previous position waypoint
+* @param[in] cost_params, weights for goal oriented vs smooth behaviour
 * @param[out] distance_cost, cost component due to proximity to obstacles
 * @param[out] other_costs, cost component due to goal and smoothness
 **/
@@ -184,7 +185,7 @@ void costFunction(float e_angle, float z_angle, float obstacle_distance,
 /**
 * @brief   max-median filtes the cost matrix
 * @param   matrix, cost matrix
-* @param[] smoothing_radius, median filter window size
+* @param[in] smoothing_radius, median filter window size
 **/
 void smoothPolarMatrix(Eigen::MatrixXf& matrix, unsigned int smoothing_radius);
 
@@ -208,7 +209,7 @@ Eigen::ArrayXf getConicKernel(int radius);
 
 /**
 * @brief   helper method to output on the console the histogram
-* @param[] histogram, polar histogram
+* @param[in] histogram, polar histogram
 **/
 void printHistogram(Histogram& histogram);
 

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -117,7 +117,7 @@ void compressHistogramElevation(Histogram& new_hist,
 * @param[in]  histogram, polar histogram representing obstacles
 * @param[in]  goal, current goal position
 * @param[in]  position, current vehicle position
-* @param[in]  current vehicle heading in histogram angle convention
+* @param[in]  current vehicle heading in histogram angle convention [deg]
 * @param[in]  last_sent_waypoint, last position waypoint
 * @param[in]  cost_params, weight for the cost function
 * @param[in]  only_yawed, true if
@@ -127,7 +127,7 @@ void compressHistogramElevation(Histogram& new_hist,
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position,
-                   const float yaw_angle_histogram_frame,
+                   const float yaw_angle_histogram_frame_deg,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
                    const float smoothing_margin_degrees,
@@ -168,7 +168,7 @@ void getBestCandidatesFromCostMatrix(
 * @param[] z_angle, azimuth angle [deg]
 * @param[] goal, current goal position
 * @param[] position, current vehicle position
-* @param[] position, current vehicle heading in histogram angle convention
+* @param[] position, current vehicle heading in histogram angle convention [deg]
 * @param[] last_sent_waypoint, previous position waypoint
 * @param[] cost_params, weights for goal oriented vs smooth behaviour
 * @param[out] distance_cost, cost component due to proximity to obstacles
@@ -176,7 +176,7 @@ void getBestCandidatesFromCostMatrix(
 **/
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  const float yaw_angle_histogram_frame,
+                  const float yaw_angle_histogram_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint,
                   costParameters cost_params, float& distance_cost,
                   float& other_costs);

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -28,7 +28,7 @@ class StarPlanner {
   float tree_node_distance_ = 1.0f;
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
-  float curr_yaw_histogram_frame_deg_;
+  float curr_yaw_histogram_frame_deg_ = 90.f;
   float smoothing_margin_degrees_ = 30.f;
 
   std::vector<int> reprojected_points_age_;

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -28,7 +28,7 @@ class StarPlanner {
   float tree_node_distance_ = 1.0f;
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
-  float curr_yaw_deg_histogram_frame_;
+  float curr_yaw_histogram_frame_deg_;
   float smoothing_margin_degrees_ = 30.f;
 
   std::vector<int> reprojected_points_age_;

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -28,7 +28,7 @@ class StarPlanner {
   float tree_node_distance_ = 1.0f;
   float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
-  float curr_yaw_fcu_frame_;
+  float curr_yaw_deg_histogram_frame_;
   float smoothing_margin_degrees_ = 30.f;
 
   std::vector<int> reprojected_points_age_;

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -115,22 +115,22 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
 }
 
 float getYawFromQuaternion(const Eigen::Quaternionf q) {
-  float siny_cosp = 2.0 * (q.w() * q.z() + q.x() * q.y());
-  float cosy_cosp = 1.0 - 2.0 * (q.y() * q.y() + q.z() * q.z());
+  float siny_cosp = 2.f * (q.w() * q.z() + q.x() * q.y());
+  float cosy_cosp = 1.f - 2.f * (q.y() * q.y() + q.z() * q.z());
   float yaw = atan2(siny_cosp, cosy_cosp);
 
-  return static_cast<float>(yaw * RAD_TO_DEG);
+  return yaw * RAD_TO_DEG;
 }
 
 float getPitchFromQuaternion(const Eigen::Quaternionf q) {
-  float pitch = 0;
-  float sinp = 2.0 * (q.w() * q.y() - q.z() * q.x());
-  if (fabs(sinp) >= 1) {
-    pitch = copysign(M_PI / 2, sinp);  // use PI/2 if out of range
+  float pitch = 0.f;
+  float sinp = 2.f * (q.w() * q.y() - q.z() * q.x());
+  if (fabs(sinp) >= 1.f) {
+    pitch = copysign(M_PI / 2.f, sinp);  // use PI/2 if out of range
   } else {
     pitch = asin(sinp);
   }
-  return static_cast<float>(pitch * RAD_TO_DEG);
+  return pitch * RAD_TO_DEG;
 }
 
 void wrapAngleToPlusMinusPI(float& angle) {

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -6,7 +6,6 @@
 #include <limits>
 #include <vector>
 
-#include <tf/transform_listener.h>
 namespace avoidance {
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
@@ -116,18 +115,21 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
 }
 
 float getYawFromQuaternion(const Eigen::Quaternionf q) {
-  tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
-  tf::Matrix3x3 tf_m(tf_q);
-  double roll, pitch, yaw;
-  tf_m.getRPY(roll, pitch, yaw);
+  float siny_cosp = +2.0 * (q.w() * q.z() + q.x() * q.y());
+  float cosy_cosp = +1.0 - 2.0 * (q.y() * q.y() + q.z() * q.z());
+  float yaw = atan2(siny_cosp, cosy_cosp);
+
   return static_cast<float>(yaw);
 }
 
 float getPitchFromQuaternion(const Eigen::Quaternionf q) {
-  tf::Quaternion tf_q(q.x(), q.y(), q.z(), q.w());
-  tf::Matrix3x3 tf_m(tf_q);
-  double roll, pitch, yaw;
-  tf_m.getRPY(roll, pitch, yaw);
+  float pitch = 0;
+  float sinp = 2.0 * (q.w() * q.y() - q.z() * q.x());
+  if (fabs(sinp) >= 1) {
+    pitch = copysign(M_PI / 2, sinp);  // use 90 degrees if out of range
+  } else {
+    pitch = asin(sinp);
+  }
   return static_cast<float>(pitch);
 }
 

--- a/local_planner/src/nodes/common.cpp
+++ b/local_planner/src/nodes/common.cpp
@@ -115,22 +115,22 @@ void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q,
 }
 
 float getYawFromQuaternion(const Eigen::Quaternionf q) {
-  float siny_cosp = +2.0 * (q.w() * q.z() + q.x() * q.y());
-  float cosy_cosp = +1.0 - 2.0 * (q.y() * q.y() + q.z() * q.z());
+  float siny_cosp = 2.0 * (q.w() * q.z() + q.x() * q.y());
+  float cosy_cosp = 1.0 - 2.0 * (q.y() * q.y() + q.z() * q.z());
   float yaw = atan2(siny_cosp, cosy_cosp);
 
-  return static_cast<float>(yaw);
+  return static_cast<float>(yaw * RAD_TO_DEG);
 }
 
 float getPitchFromQuaternion(const Eigen::Quaternionf q) {
   float pitch = 0;
   float sinp = 2.0 * (q.w() * q.y() - q.z() * q.x());
   if (fabs(sinp) >= 1) {
-    pitch = copysign(M_PI / 2, sinp);  // use 90 degrees if out of range
+    pitch = copysign(M_PI / 2, sinp);  // use PI/2 if out of range
   } else {
     pitch = asin(sinp);
   }
-  return static_cast<float>(pitch);
+  return static_cast<float>(pitch * RAD_TO_DEG);
 }
 
 void wrapAngleToPlusMinusPI(float& angle) {

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -17,11 +17,11 @@ LocalPlanner::~LocalPlanner() {}
 void LocalPlanner::setPose(const Eigen::Vector3f &pos,
                            const Eigen::Quaternionf &q) {
   position_ = pos;
-  curr_yaw_deg_fcu_frame_ = getYawFromQuaternion(q) * RAD_TO_DEG;
-  curr_yaw_deg_histogram_frame_ = -curr_yaw_deg_fcu_frame_ + 90.0f;
+  curr_yaw_fcu_frame_deg_ = getYawFromQuaternion(q);
+  curr_yaw_histogram_frame_deg_ = -curr_yaw_fcu_frame_deg_ + 90.0f;
 
-  curr_pitch_deg_ = getPitchFromQuaternion(q) * RAD_TO_DEG;
-  star_planner_->setPose(position_, curr_yaw_deg_histogram_frame_);
+  curr_pitch_deg_ = getPitchFromQuaternion(q);
+  star_planner_->setPose(position_, curr_yaw_histogram_frame_deg_);
 
   if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
     take_off_pose_ = position_;
@@ -95,7 +95,7 @@ void LocalPlanner::runPlanner() {
   // calculate Field of View
   z_FOV_idx_.clear();
   calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_,
-               curr_yaw_deg_histogram_frame_, curr_pitch_deg_);
+               curr_yaw_histogram_frame_deg_, curr_pitch_deg_);
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
@@ -216,7 +216,7 @@ void LocalPlanner::determineStrategy() {
         obstacle_ = true;
 
         getCostMatrix(
-            polar_histogram_, goal_, position_, curr_yaw_deg_histogram_frame_,
+            polar_histogram_, goal_, position_, curr_yaw_histogram_frame_deg_,
             last_sent_waypoint_, cost_params_, velocity_.norm() < 0.1f,
             smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -222,7 +222,7 @@ void compressHistogramElevation(Histogram& new_hist,
 
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position,
-                   const float yaw_angle_histogram_frame,
+                   const float yaw_angle_histogram_frame_deg,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
                    const float smoothing_margin_degrees,
@@ -250,8 +250,8 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
           histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
 
       costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position,
-                   yaw_angle_histogram_frame, last_sent_waypoint, cost_params,
-                   distance_cost, other_costs);
+                   yaw_angle_histogram_frame_deg, last_sent_waypoint,
+                   cost_params, distance_cost, other_costs);
       cost_matrix(e_index, z_index) = other_costs;
       distance_matrix(e_index, z_index) = distance_cost;
     }
@@ -451,14 +451,14 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 // costfunction for every free histogram cell
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  const float yaw_angle_histogram_frame,
+                  const float yaw_angle_histogram_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint,
                   costParameters cost_params, float& distance_cost,
                   float& other_costs) {
   float goal_dist = (position - goal).norm();
   PolarPoint p_pol(e_angle, z_angle, goal_dist);
   Eigen::Vector3f projected_candidate = polarToCartesian(p_pol, position);
-  PolarPoint heading_pol(e_angle, yaw_angle_histogram_frame, goal_dist);
+  PolarPoint heading_pol(e_angle, yaw_angle_histogram_frame_deg, goal_dist);
   Eigen::Vector3f projected_heading = polarToCartesian(heading_pol, position);
   Eigen::Vector3f projected_goal = goal;
   PolarPoint last_wp_pol = cartesianToPolar(last_sent_waypoint, position);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -36,7 +36,7 @@ void StarPlanner::setFOV(float h_FOV, float v_FOV) {
 
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   position_ = pos;
-  curr_yaw_fcu_frame_ = curr_yaw;
+  curr_yaw_deg_histogram_frame_ = curr_yaw;
 }
 
 void StarPlanner::setCloud(
@@ -123,9 +123,7 @@ void StarPlanner::buildLookAheadTree() {
   // insert first node
   tree_.push_back(TreeNode(0, 0, position_));
   tree_.back().setCosts(treeHeuristicFunction(0), treeHeuristicFunction(0));
-  tree_.back().yaw_ =
-      std::round((-curr_yaw_fcu_frame_ * 180.0f / M_PI_F)) +
-      90.0f;  // from radian to angle and shift reference to y-axis
+  tree_.back().yaw_ = curr_yaw_deg_histogram_frame_;
   tree_.back().last_z_ = tree_.back().yaw_;
 
   int origin = 0;

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -36,7 +36,7 @@ void StarPlanner::setFOV(float h_FOV, float v_FOV) {
 
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   position_ = pos;
-  curr_yaw_deg_histogram_frame_ = curr_yaw;
+  curr_yaw_histogram_frame_deg_ = curr_yaw;
 }
 
 void StarPlanner::setCloud(
@@ -123,7 +123,7 @@ void StarPlanner::buildLookAheadTree() {
   // insert first node
   tree_.push_back(TreeNode(0, 0, position_));
   tree_.back().setCosts(treeHeuristicFunction(0), treeHeuristicFunction(0));
-  tree_.back().yaw_ = curr_yaw_deg_histogram_frame_;
+  tree_.back().yaw_ = curr_yaw_histogram_frame_deg_;
   tree_.back().last_z_ = tree_.back().yaw_;
 
   int origin = 0;

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -86,7 +86,6 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   planner.sendObstacleDistanceDataToFcu(scan);
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    // width determined empirically, TODO investigate why it isn't symmetrical
     if (10 <= i && i <= 19)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
@@ -138,7 +137,6 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   planner.sendObstacleDistanceDataToFcu(scan);
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    // width determined empirically, TODO investigate why it doesnt match angles
     if (12 <= i && i <= 19)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
@@ -185,7 +183,6 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   sensor_msgs::LaserScan scan;
   planner.sendObstacleDistanceDataToFcu(scan);
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    // width determined empirically, TODO investigate why it doesnt match angles
     if (10 <= i && i <= 17)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -87,7 +87,7 @@ TEST_F(LocalPlannerTests, all_obstacles) {
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
     // width determined empirically, TODO investigate why it isn't symmetrical
-    if (10 <= i && i <= 18)
+    if (10 <= i && i <= 19)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);
@@ -136,9 +136,10 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.sendObstacleDistanceDataToFcu(scan);
+
   for (size_t i = 0; i < scan.ranges.size(); i++) {
     // width determined empirically, TODO investigate why it doesnt match angles
-    if (12 <= i && i <= 18)
+    if (12 <= i && i <= 19)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);
@@ -185,7 +186,7 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   planner.sendObstacleDistanceDataToFcu(scan);
   for (size_t i = 0; i < scan.ranges.size(); i++) {
     // width determined empirically, TODO investigate why it doesnt match angles
-    if (9 <= i && i <= 17)
+    if (10 <= i && i <= 17)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -84,11 +84,11 @@ TEST(PlannerFunctions, calculateFOV) {
   float h_fov = 90.0f;
   float v_fov = 45.0f;
   float yaw_z_greater_grid_length =
-      3.14f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min >= GRID_LENGTH_Z
+      270.f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min >= GRID_LENGTH_Z
   float yaw_z_max_greater_grid =
-      -2.3f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min < GRID_LENGTH_Z
-  float yaw_z_min_smaller_zero = 3.9f;  // z_FOV_min < 0 && z_FOV_max >= 0
-  float yaw_z_smaller_zero = 5.6f;      // z_FOV_max < 0 && z_FOV_min < 0
+      210.f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min < GRID_LENGTH_Z
+  float yaw_z_min_smaller_zero = -140.f;  // z_FOV_min < 0 && z_FOV_max >= 0
+  float yaw_z_smaller_zero = -235.f;      // z_FOV_max < 0 && z_FOV_min < 0
   float pitch = 0.0f;
 
   // WHEN: we calculate the Field of View
@@ -110,16 +110,24 @@ TEST(PlannerFunctions, calculateFOV) {
 
   // THEN: we expect polar histogram indexes that are in the Field of View
   std::vector<int> output_z_greater_grid_length = {
-      7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21};
-  std::vector<int> output_z_max_greater_grid = {0, 1, 2,  3,  4,  5,  6, 7,
-                                                8, 9, 10, 11, 12, 58, 59};
-  std::vector<int> output_z_min_smaller_zero = {0, 1, 2,  3,  4,  5,  6, 7,
-                                                8, 9, 10, 11, 12, 13, 59};
+      7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+  std::vector<int> output_z_max_greater_grid = {0, 1, 2,  3,  4,  5,  6,  7,
+                                                8, 9, 10, 11, 12, 57, 58, 59};
+  std::vector<int> output_z_min_smaller_zero = {0, 1, 2,  3,  4,  5,  6,  7,
+                                                8, 9, 10, 11, 12, 13, 14, 59};
   std::vector<int> output_z_smaller_zero = {43, 44, 45, 46, 47, 48, 49, 50,
                                             51, 52, 53, 54, 55, 56, 57, 58};
 
   EXPECT_EQ(18, e_FOV_max);
-  EXPECT_EQ(10, e_FOV_min);
+  EXPECT_EQ(11, e_FOV_min);
+
+  // vector sizes:
+  EXPECT_EQ(output_z_greater_grid_length.size(),
+            z_FOV_idx_z_greater_grid_length.size());
+  EXPECT_EQ(output_z_max_greater_grid.size(), output_z_max_greater_grid.size());
+  EXPECT_EQ(output_z_min_smaller_zero.size(), output_z_min_smaller_zero.size());
+  EXPECT_EQ(output_z_smaller_zero.size(), output_z_smaller_zero.size());
+
   for (size_t i = 0; i < z_FOV_idx_z_greater_grid_length.size(); i++) {
     EXPECT_EQ(output_z_greater_grid_length.at(i),
               z_FOV_idx_z_greater_grid_length.at(i));


### PR DESCRIPTION
There has long been a bit of a chaos with the angle names and frames: The histogram yaw angle is 90 deg shifted from the fcu yaw and measured in the other direction. The variables were not properly named which was dangerous, also the variable names did not reflect whether an angle was radian or degree. I tried to name them properly to avoid future confusion.

In the process I found a major bug in `calculateFOV` sometimes the input angles were given in radian and sometimes in degrees. I fixed this function, also cleaning it up and using the simple logic now provided in common. 