### PR TITLE
Make global_planner depend on mavros_extras

### DIFF
--- a/global_planner/package.xml
+++ b/global_planner/package.xml
@@ -53,6 +53,8 @@
   <build_depend>tf</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>mavros</build_depend>
+  <build_depend>mavros_extras</build_depend>
+
 
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>message_runtime</run_depend>
@@ -66,6 +68,7 @@
   <run_depend>tf</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>mavros</run_depend>
+  <run_depend>mavros_extras</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Build error occurs from missing dependency of global planner:
```
Errors     << global_planner:cmake /home/jalim/catkin_ws/logs/global_planner/build.cmake.000.log
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "mavros_extras"
  with any of the following names:

    mavros_extrasConfig.cmake
    mavros_extras-config.cmake

  Add the installation prefix of "mavros_extras" to CMAKE_PREFIX_PATH or set
  "mavros_extras_DIR" to a directory containing one of the above files.  If
  "mavros_extras" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:9 (find_package)

```

This can be fixed by adding `mavros_extras` as a build dependency of `global_planner`