### PR TITLE
Move main processes into subclass functions

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -155,7 +155,6 @@ class LocalPlannerNode {
                               /// output data (point cloud, position, ...)
 
   std::mutex data_ready_mutex_;
-  bool data_ready_ = false;
   std::condition_variable data_ready_cv_;
 
   /**
@@ -170,6 +169,8 @@ class LocalPlannerNode {
   * @brief     handles threads for data publication and subscription
   **/
   void threadFunction();
+
+  void updatePlanner();
 
   /**
   * @brief     checks if the transformation from the camera frame to
@@ -279,6 +280,7 @@ class LocalPlannerNode {
 
   geometry_msgs::TwistStamped vel_msg_;
   bool armed_, offboard_, mission_, new_goal_;
+  bool data_ready_ = false;
 
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;
   boost::recursive_mutex config_mutex_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -220,6 +220,7 @@ class LocalPlannerNode {
   * @param     hover, true if the vehicle is loitering
   **/
   void publishWaypoints(bool hover);
+  void publishSystemStatus();
 
   /**
   * @brief     check healthiness of the avoidance system to trigger failsafe in

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -181,6 +181,29 @@ size_t LocalPlannerNode::numReceivedClouds() {
   return num_received_clouds;
 }
 
+void LocalPlannerNode::updatePlanner() {
+  if (cameras_.size() == numReceivedClouds() && cameras_.size() != 0) {
+    if (canUpdatePlannerInfo()) {
+      if (running_mutex_.try_lock()) {
+        updatePlannerInfo();
+        // reset all clouds to not yet received
+        for (size_t i = 0; i < cameras_.size(); i++) {
+          cameras_[i].received_ = false;
+        }
+        wp_generator_->setPlannerInfo(local_planner_->getAvoidanceOutput());
+        if (local_planner_->stop_in_front_active_) {
+          goal_msg_.pose.position = toPoint(local_planner_->getGoal());
+        }
+        running_mutex_.unlock();
+        // Wake up the planner
+        std::unique_lock<std::mutex> lck(data_ready_mutex_);
+        data_ready_ = true;
+        data_ready_cv_.notify_one();
+      }
+    }
+  }
+}
+
 bool LocalPlannerNode::canUpdatePlannerInfo() {
   // Check if we have a transformation available at the time of the current
   // point cloud

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -704,7 +704,7 @@ void LocalPlannerNode::publishTree() {
   tree_path_pub_.publish(path_marker);
 }
 
-void LocalPlannerNode::publishSystemStatus(){
+void LocalPlannerNode::publishSystemStatus() {
   status_msg_.header.stamp = ros::Time::now();
   status_msg_.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
   mavros_system_status_pub_.publish(status_msg_);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -704,6 +704,13 @@ void LocalPlannerNode::publishTree() {
   tree_path_pub_.publish(path_marker);
 }
 
+void LocalPlannerNode::publishSystemStatus(){
+  status_msg_.header.stamp = ros::Time::now();
+  status_msg_.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
+  mavros_system_status_pub_.publish(status_msg_);
+  t_status_sent_ = ros::Time::now();
+}
+
 void LocalPlannerNode::clickedPointCallback(
     const geometry_msgs::PointStamped& msg) {
   printPointInfo(msg.point.x, msg.point.y, msg.point.z);

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -60,7 +60,8 @@ int main(int argc, char** argv) {
     if (!Node.never_run_ && planner_is_healthy) {
       Node.publishWaypoints(hover);
       if (!hover) Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
-    } else {
+    }
+    else {
       for (size_t i = 0; i < Node.cameras_.size(); ++i) {
         // once the camera info have been set once, unsubscribe from topic
         Node.cameras_[i].camera_info_sub_.shutdown();
@@ -70,12 +71,8 @@ int main(int argc, char** argv) {
     Node.position_received_ = false;
 
     // publish system status
-    if (now - Node.t_status_sent_ > ros::Duration(0.2)) {
-      Node.status_msg_.header.stamp = ros::Time::now();
-      Node.status_msg_.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
-      Node.mavros_system_status_pub_.publish(Node.status_msg_);
-      Node.t_status_sent_ = now;
-    }
+    if (now - Node.t_status_sent_ > ros::Duration(0.2)) Node.publishSystemStatus();
+
   }
 
   Node.should_exit_ = true;

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -60,8 +60,7 @@ int main(int argc, char** argv) {
     if (!Node.never_run_ && planner_is_healthy) {
       Node.publishWaypoints(hover);
       if (!hover) Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
-    }
-    else {
+    } else {
       for (size_t i = 0; i < Node.cameras_.size(); ++i) {
         // once the camera info have been set once, unsubscribe from topic
         Node.cameras_[i].camera_info_sub_.shutdown();
@@ -71,8 +70,8 @@ int main(int argc, char** argv) {
     Node.position_received_ = false;
 
     // publish system status
-    if (now - Node.t_status_sent_ > ros::Duration(0.2)) Node.publishSystemStatus();
-
+    if (now - Node.t_status_sent_ > ros::Duration(0.2))
+      Node.publishSystemStatus();
   }
 
   Node.should_exit_ = true;

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -54,29 +54,7 @@ int main(int argc, char** argv) {
                        hover);
 
     // If planner is not running, update planner info and get last results
-    if (Node.cameras_.size() == Node.numReceivedClouds() &&
-        Node.cameras_.size() != 0) {
-      if (Node.canUpdatePlannerInfo()) {
-        if (Node.running_mutex_.try_lock()) {
-          Node.updatePlannerInfo();
-          // reset all clouds to not yet received
-          for (size_t i = 0; i < Node.cameras_.size(); i++) {
-            Node.cameras_[i].received_ = false;
-          }
-          Node.wp_generator_->setPlannerInfo(
-              Node.local_planner_->getAvoidanceOutput());
-          if (Node.local_planner_->stop_in_front_active_) {
-            Node.goal_msg_.pose.position =
-                toPoint(Node.local_planner_->getGoal());
-          }
-          Node.running_mutex_.unlock();
-          // Wake up the planner
-          std::unique_lock<std::mutex> lck(Node.data_ready_mutex_);
-          Node.data_ready_ = true;
-          Node.data_ready_cv_.notify_one();
-        }
-      }
-    }
+    Node.updatePlanner();
 
     // send waypoint
     if (!Node.never_run_ && planner_is_healthy) {


### PR DESCRIPTION
This PR is a simple refactor on parts of the `main` function where variables / members are from the subclass `LocalPlannerNode` but are calculated in `main`. These processes are moved into a function of the subclass.

I have tested this in SITL and as far as I can tell looks like it has no change in behaviors.