### PR TITLE
Publish size of cropped point cloud

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -31,6 +31,7 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/String.h>
+#include <std_msgs/UInt32.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
@@ -276,6 +277,7 @@ class LocalPlannerNode {
   ros::Publisher smoothed_wp_pub_;
   ros::Publisher histogram_image_pub_;
   ros::Publisher cost_image_pub_;
+  ros::Publisher pointcloud_size_pub_;
 
   std::vector<float> algo_time;
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -111,6 +111,7 @@ LocalPlannerNode::LocalPlannerNode(const bool tf_spin_thread) {
   histogram_image_pub_ =
       nh_.advertise<sensor_msgs::Image>("/histogram_image", 1);
   cost_image_pub_ = nh_.advertise<sensor_msgs::Image>("/cost_image", 1);
+  pointcloud_size_pub_ = nh_.advertise<std_msgs::UInt32>("/pointcloud_size", 1);
   mavros_set_mode_client_ =
       nh_.serviceClient<mavros_msgs::SetMode>("/mavros/set_mode");
   get_px4_param_client_ =
@@ -1006,6 +1007,7 @@ void LocalPlannerNode::publishPlannerData() {
   local_planner_->getCloudsForVisualization(final_cloud, reprojected_points);
   local_pointcloud_pub_.publish(final_cloud);
   reprojected_points_pub_.publish(reprojected_points);
+  pointcloud_size_pub_.publish(static_cast<uint32_t>(final_cloud.size()));
 
   publishTree();
 


### PR DESCRIPTION
This commit adds a new topic on which the planner publishes the
number of points in the cropped point cloud. This can be very
helpful when debugging on real hardware and logging capabilities are limited.