### PR TITLE
Trajectory simulation

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -149,6 +149,7 @@ set(LOCAL_PLANNER_CPP_FILES   "src/nodes/local_planner.cpp"
                               "src/nodes/common.cpp"
                               "src/nodes/local_planner_node.cpp"
                               "src/nodes/local_planner_visualization.cpp"
+                              "src/utils/trajectory_simulator.cpp"
 )
 if(NOT DISABLE_SIMULATION)
   set(LOCAL_PLANNER_CPP_FILES "${LOCAL_PLANNER_CPP_FILES}"
@@ -220,29 +221,30 @@ target_link_libraries(local_planner_node
 #############
 
 if(CATKIN_ENABLE_TESTING)
-	# Add gtest based cpp test target and link libraries
-	catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
-	                                      test/test_example.cpp
-	                                      test/test_common.cpp
-	                                      test/test_local_planner.cpp
-	                                      test/test_planner_functions.cpp
-                                             test/test_star_planner.cpp
-                                             test/test_waypoint_generator.cpp)
+    # Add gtest based cpp test target and link libraries
+    catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
+                                          test/test_example.cpp
+                                          test/test_common.cpp
+                                          test/test_local_planner.cpp
+                                          test/test_planner_functions.cpp
+                                          test/test_star_planner.cpp
+                                          test/test_trajectory_simulator.cpp
+                                          test/test_waypoint_generator.cpp)
 
   catkin_add_gtest(${PROJECT_NAME}-test-roscore test/main.cpp
                                         test/test_local_planner_node.cpp)
-	if(TARGET ${PROJECT_NAME}-test)
-	  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
-	                                             ${catkin_LIBRARIES}
-	                                             ${YAML_CPP_LIBRARIES})
-	endif()
+    if(TARGET ${PROJECT_NAME}-test)
+      target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
+                                                 ${catkin_LIBRARIES}
+                                                 ${YAML_CPP_LIBRARIES})
+    endif()
 
   if(TARGET ${PROJECT_NAME}-test-roscore)
-	  target_link_libraries(${PROJECT_NAME}-test-roscore ${PROJECT_NAME}
-	                                             ${catkin_LIBRARIES}
-	                                             ${YAML_CPP_LIBRARIES})
-	endif()
+      target_link_libraries(${PROJECT_NAME}-test-roscore ${PROJECT_NAME}
+                                                 ${catkin_LIBRARIES}
+                                                 ${YAML_CPP_LIBRARIES})
+    endif()
 
-	## Add folders to be run by python nosetests
-	# catkin_add_nosetests(test)
+    ## Add folders to be run by python nosetests
+    # catkin_add_nosetests(test)
 endif()

--- a/local_planner/include/local_planner/trajectory_simulator.h
+++ b/local_planner/include/local_planner/trajectory_simulator.h
@@ -19,10 +19,17 @@ struct simulation_limits {
   float max_jerk_norm = NAN;
 };
 
-std::vector<simulation_state> run_steps(const simulation_limits& config,
-                                        const simulation_state& start,
-                                        const Eigen::Vector3f& goal_direction,
-                                        float step_time, int num_steps);
+std::vector<simulation_state> velocity_trajectory(
+    const simulation_limits& config, const simulation_state& start,
+    const Eigen::Vector3f& goal_direction, float step_time, int num_steps);
+
+simulation_state simulate_step_constant_jerk(const simulation_state& state,
+                                             const Eigen::Vector3f& jerk,
+                                             float step_time);
+
+Eigen::Vector3f jerk_for_velocity_setpoint(
+    float P_constant, float D_constant, float max_jerk_norm,
+    const Eigen::Vector3f& desired_velocity, const simulation_state& state);
 
 template <int N>
 Eigen::Matrix<float, N, 1> norm_clamp(const Eigen::Matrix<float, N, 1>& val,

--- a/local_planner/include/local_planner/trajectory_simulator.h
+++ b/local_planner/include/local_planner/trajectory_simulator.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <eigen3/Eigen/Core>
+
+namespace avoidance {
+
+struct simulation_state {
+  Eigen::Vector3f position = NAN * Eigen::Vector3f::Ones();
+  Eigen::Vector3f velocity = NAN * Eigen::Vector3f::Ones();
+  Eigen::Vector3f acceleration = NAN * Eigen::Vector3f::Ones();
+};
+
+struct simulation_limits {
+  float max_z_velocity = NAN;
+  float min_z_velocity = NAN;
+  float max_xy_velocity_norm = NAN;
+  float max_acceleration_norm = NAN;
+  float max_jerk_norm = NAN;
+};
+
+std::vector<simulation_state> run_steps(const simulation_limits& config,
+                                        const simulation_state& start,
+                                        const Eigen::Vector3f& goal_direction,
+                                        float step_time, int num_steps);
+
+template <int N>
+Eigen::Matrix<float, N, 1> norm_clamp(const Eigen::Matrix<float, N, 1>& val,
+                                      float max_norm) {
+  float norm_sq = val.squaredNorm();
+  if (norm_sq > max_norm * max_norm)
+    return val * (max_norm / std::sqrt(norm_sq));
+  else
+    return val;
+}
+}

--- a/local_planner/include/local_planner/trajectory_simulator.h
+++ b/local_planner/include/local_planner/trajectory_simulator.h
@@ -19,18 +19,29 @@ struct simulation_limits {
   float max_jerk_norm = NAN;
 };
 
-std::vector<simulation_state> velocity_trajectory(
-    const simulation_limits& config, const simulation_state& start,
-    const Eigen::Vector3f& goal_direction, float step_time, int num_steps);
+class TrajectorySimulator {
+ public:
+  TrajectorySimulator(const simulation_limits& config,
+                      const simulation_state& start, float step_time = 0.1f);
 
-simulation_state simulate_step_constant_jerk(const simulation_state& state,
-                                             const Eigen::Vector3f& jerk,
-                                             float step_time);
+  std::vector<simulation_state> generate_trajectory(
+      const Eigen::Vector3f& goal_direction, float simulation_duration);
 
-Eigen::Vector3f jerk_for_velocity_setpoint(
-    float P_constant, float D_constant, float max_jerk_norm,
-    const Eigen::Vector3f& desired_velocity, const simulation_state& state);
+ protected:
+  const simulation_limits config_;
+  const simulation_state start_;
+  const float step_time_;
 
+  static simulation_state simulate_step_constant_jerk(
+      const simulation_state& state, const Eigen::Vector3f& jerk,
+      float step_time);
+
+  static Eigen::Vector3f jerk_for_velocity_setpoint(
+      float P_constant, float D_constant, float max_jerk_norm,
+      const Eigen::Vector3f& desired_velocity, const simulation_state& state);
+};
+
+// templated helper function
 template <int N>
 Eigen::Matrix<float, N, 1> norm_clamp(const Eigen::Matrix<float, N, 1>& val,
                                       float max_norm) {

--- a/local_planner/include/local_planner/trajectory_simulator.h
+++ b/local_planner/include/local_planner/trajectory_simulator.h
@@ -5,6 +5,7 @@
 namespace avoidance {
 
 struct simulation_state {
+  float time = NAN;
   Eigen::Vector3f position = NAN * Eigen::Vector3f::Ones();
   Eigen::Vector3f velocity = NAN * Eigen::Vector3f::Ones();
   Eigen::Vector3f acceleration = NAN * Eigen::Vector3f::Ones();

--- a/local_planner/src/utils/trajectory_simulator.cpp
+++ b/local_planner/src/utils/trajectory_simulator.cpp
@@ -1,11 +1,45 @@
 #include "local_planner/trajectory_simulator.h"
 
+#include <cfloat>
+
 namespace avoidance {
 
-std::vector<simulation_state> run_steps(const simulation_limits& config,
-                                        const simulation_state& start,
-                                        const Eigen::Vector3f& goal_direction,
-                                        float step_time, int num_steps) {
+simulation_state simulate_step_constant_jerk(const simulation_state& state,
+                                             const Eigen::Vector3f& jerk,
+                                             float step_time) {
+  auto sqr = [](float f) -> float { return f * f; };
+  auto cube = [](float f) -> float { return f * f * f; };
+  simulation_state next_state;
+  next_state.position = state.position + step_time * state.velocity +
+                        0.5f * sqr(step_time) * state.acceleration +
+                        (1.f / 6.f) * cube(step_time) * jerk;
+  next_state.velocity = state.velocity + state.acceleration * step_time +
+                        0.5f * sqr(step_time) * jerk;
+  next_state.acceleration = state.acceleration + step_time * jerk;
+  next_state.time = state.time + step_time;
+  return next_state;
+}
+
+Eigen::Vector3f jerk_for_velocity_setpoint(
+    float P_constant, float D_constant, float max_jerk_norm,
+    const Eigen::Vector3f& desired_velocity, const simulation_state& state) {
+  const Eigen::Vector3f desired_accel = Eigen::Vector3f::Zero();
+  const Eigen::Vector3f accel_diff = desired_accel - state.acceleration;
+  const Eigen::Vector3f velocity_diff = desired_velocity - state.velocity;
+
+  const Eigen::Vector3f p = velocity_diff * P_constant;
+  const Eigen::Vector3f d = accel_diff * D_constant;
+
+  const Eigen::Vector3f damped_jerk = norm_clamp<3>(p + d, max_jerk_norm);
+  return damped_jerk;
+}
+
+std::vector<simulation_state> velocity_trajectory(
+    const simulation_limits& config, const simulation_state& start,
+    const Eigen::Vector3f& goal_direction, float step_time,
+    int num_steps) {
+
+  // some helpers
   auto xy_norm_z_clamp = [](const Eigen::Vector3f& val, float max_xy_norm,
                             float min_z, float max_z) -> Eigen::Vector3f {
     Eigen::Vector3f result;
@@ -13,6 +47,7 @@ std::vector<simulation_state> run_steps(const simulation_limits& config,
     result.z() = std::min(max_z, std::max(min_z, val.z()));
     return result;
   };
+  auto sqr = [](float f) -> float { return f * f; };
 
   simulation_state run_state = start;
   std::vector<simulation_state> timepoints;
@@ -26,44 +61,42 @@ std::vector<simulation_state> run_steps(const simulation_limits& config,
       config.max_xy_velocity_norm, config.min_z_velocity,
       config.max_z_velocity);
 
-  auto sqr = [](float f) -> float { return f * f; };
-  auto cube = [](float f) -> float { return f * f * f; };
   // calculate P and D constants such that they hit the jerk limit when
   // doing accel from 0
-  float P_constant = config.max_jerk_norm;
+  float max_accel_norm = std::min(2 * std::sqrt(config.max_jerk_norm),
+                                  config.max_acceleration_norm);
+  float P_constant =
+      10 * (std::sqrt(sqr(max_accel_norm) +
+                      config.max_jerk_norm * desired_velocity.norm()) -
+            max_accel_norm) /
+      (desired_velocity.norm());
   float D_constant = 2 * std::sqrt(P_constant);
 
   for (int i = 0; i < num_steps; i++) {
-    // determine what our jerk should be to control the velocity
-    const Eigen::Vector3f velocity_diff = desired_velocity - run_state.velocity;
-    const Eigen::Vector3f desired_accel = Eigen::Vector3f::Zero();
-    const Eigen::Vector3f accel_diff = desired_accel - run_state.acceleration;
-
-    const Eigen::Vector3f p = velocity_diff * P_constant;
-    const Eigen::Vector3f d = accel_diff * D_constant;
-
+    float single_step_time = step_time;
     const Eigen::Vector3f damped_jerk =
-        norm_clamp<3>(p + d, config.max_jerk_norm);
+        jerk_for_velocity_setpoint(P_constant, D_constant, config.max_jerk_norm,
+                                   desired_velocity, run_state);
 
-    // clamp the jerk to keep the accel within requested limits
-    const Eigen::Vector3f requested_accel = run_state.acceleration +=
-        step_time * damped_jerk;
-    const Eigen::Vector3f clamped_accel =
-        norm_clamp<3>(requested_accel, config.max_acceleration_norm);
-    const Eigen::Vector3f jerk =
-        (clamped_accel - run_state.acceleration) / step_time;
+    // limit time step to not exceed the maximum acceleration, but clamp
+    // jerk to 0 if at maximum acceleration already
+    const Eigen::Vector3f requested_accel =
+        run_state.acceleration + single_step_time * damped_jerk;
+    Eigen::Vector3f jerk = damped_jerk;
+    if (requested_accel.squaredNorm() > sqr(max_accel_norm)) {
+      single_step_time = (max_accel_norm - run_state.acceleration.norm()) /
+                  damped_jerk.norm();  // Use a dot product here somewhere?
+      if (single_step_time <= FLT_EPSILON || single_step_time > step_time) {
+        jerk = Eigen::Vector3f::Zero();
+        single_step_time = step_time;
+      }
+    }
 
     // update the state based on motion equations with the final jerk
-    run_state.position += step_time * run_state.velocity +
-                          0.5f * sqr(step_time) * run_state.acceleration +
-                          (1.f / 6.f) * cube(step_time) * jerk;
-    run_state.velocity +=
-        run_state.acceleration * step_time + 0.5f * sqr(step_time) * jerk;
-    run_state.acceleration += step_time * jerk;
-    run_state.time += step_time;
-
+    run_state = simulate_step_constant_jerk(run_state, jerk, single_step_time);
     timepoints.push_back(run_state);
   }
   return timepoints;
 }
 }
+

--- a/local_planner/src/utils/trajectory_simulator.cpp
+++ b/local_planner/src/utils/trajectory_simulator.cpp
@@ -2,13 +2,84 @@
 
 #include <cfloat>
 
+namespace {
+Eigen::Vector3f xy_norm_z_clamp(const Eigen::Vector3f& val, float max_xy_norm,
+                                float min_z, float max_z) {
+  Eigen::Vector3f result;
+  result.topRows<2>() = avoidance::norm_clamp<2>(val.topRows<2>(), max_xy_norm);
+  result.z() = std::min(max_z, std::max(min_z, val.z()));
+  return result;
+}
+
+float sqr(float f) { return f * f; }
+float cube(float f) { return f * f * f; }
+}
+
 namespace avoidance {
 
-simulation_state simulate_step_constant_jerk(const simulation_state& state,
+TrajectorySimulator::TrajectorySimulator(
+    const avoidance::simulation_limits& config,
+    const avoidance::simulation_state& start, float step_time)
+    : config_(config), start_(start), step_time_(step_time) {}
+
+std::vector<simulation_state> TrajectorySimulator::generate_trajectory(
+    const Eigen::Vector3f& goal_direction, float simulation_duration) {
+  int num_steps = static_cast<int>(std::ceil(simulation_duration / step_time_));
+  std::vector<simulation_state> timepoints;
+  timepoints.reserve(num_steps);
+
+  const Eigen::Vector3f unit_goal = goal_direction.normalized();
+  const Eigen::Vector3f desired_velocity = xy_norm_z_clamp(
+      unit_goal * std::hypot(config_.max_xy_velocity_norm,
+                             unit_goal.z() > 0 ? config_.max_z_velocity
+                                               : config_.min_z_velocity),
+      config_.max_xy_velocity_norm, config_.min_z_velocity,
+      config_.max_z_velocity);
+
+  // calculate P and D constants such that they hit the jerk limit when
+  // doing accel from 0
+  float max_accel_norm = std::min(2 * std::sqrt(config_.max_jerk_norm),
+                                  config_.max_acceleration_norm);
+  float P_constant =
+      (std::sqrt(sqr(max_accel_norm) +
+                 config_.max_jerk_norm * desired_velocity.norm()) -
+       max_accel_norm) /
+      desired_velocity.norm() * 10;
+  float D_constant = 2 * std::sqrt(P_constant);
+
+  simulation_state run_state = start_;
+  for (int i = 0; i < num_steps; i++) {
+    float single_step_time = step_time_;
+    const Eigen::Vector3f damped_jerk = jerk_for_velocity_setpoint(
+        P_constant, D_constant, config_.max_jerk_norm, desired_velocity,
+        run_state);
+
+    // limit time step to not exceed the maximum acceleration, but clamp
+    // jerk to 0 if at maximum acceleration already
+    const Eigen::Vector3f requested_accel =
+        run_state.acceleration + single_step_time * damped_jerk;
+    Eigen::Vector3f jerk = damped_jerk;
+    if (requested_accel.squaredNorm() > sqr(max_accel_norm)) {
+      single_step_time =
+          (max_accel_norm - run_state.acceleration.norm()) /
+          damped_jerk.norm();  // Use a dot product here somewhere?
+      if (single_step_time <= FLT_EPSILON || single_step_time > step_time_) {
+        jerk = Eigen::Vector3f::Zero();
+        single_step_time = step_time_;
+      }
+    }
+
+    // update the state based on motion equations with the final jerk
+    run_state = simulate_step_constant_jerk(run_state, jerk, single_step_time);
+    timepoints.push_back(run_state);
+  }
+
+  return timepoints;
+}
+
+simulation_state TrajectorySimulator::simulate_step_constant_jerk(const simulation_state& state,
                                              const Eigen::Vector3f& jerk,
                                              float step_time) {
-  auto sqr = [](float f) -> float { return f * f; };
-  auto cube = [](float f) -> float { return f * f * f; };
   simulation_state next_state;
   next_state.position = state.position + step_time * state.velocity +
                         0.5f * sqr(step_time) * state.acceleration +
@@ -20,7 +91,7 @@ simulation_state simulate_step_constant_jerk(const simulation_state& state,
   return next_state;
 }
 
-Eigen::Vector3f jerk_for_velocity_setpoint(
+Eigen::Vector3f TrajectorySimulator::jerk_for_velocity_setpoint(
     float P_constant, float D_constant, float max_jerk_norm,
     const Eigen::Vector3f& desired_velocity, const simulation_state& state) {
   const Eigen::Vector3f desired_accel = Eigen::Vector3f::Zero();
@@ -33,70 +104,4 @@ Eigen::Vector3f jerk_for_velocity_setpoint(
   const Eigen::Vector3f damped_jerk = norm_clamp<3>(p + d, max_jerk_norm);
   return damped_jerk;
 }
-
-std::vector<simulation_state> velocity_trajectory(
-    const simulation_limits& config, const simulation_state& start,
-    const Eigen::Vector3f& goal_direction, float step_time,
-    int num_steps) {
-
-  // some helpers
-  auto xy_norm_z_clamp = [](const Eigen::Vector3f& val, float max_xy_norm,
-                            float min_z, float max_z) -> Eigen::Vector3f {
-    Eigen::Vector3f result;
-    result.topRows<2>() = norm_clamp<2>(val.topRows<2>(), max_xy_norm);
-    result.z() = std::min(max_z, std::max(min_z, val.z()));
-    return result;
-  };
-  auto sqr = [](float f) -> float { return f * f; };
-
-  simulation_state run_state = start;
-  std::vector<simulation_state> timepoints;
-  timepoints.reserve(num_steps);
-
-  const Eigen::Vector3f unit_goal = goal_direction.normalized();
-  const Eigen::Vector3f desired_velocity = xy_norm_z_clamp(
-      unit_goal * std::hypot(config.max_xy_velocity_norm,
-                             unit_goal.z() > 0 ? config.max_z_velocity
-                                               : config.min_z_velocity),
-      config.max_xy_velocity_norm, config.min_z_velocity,
-      config.max_z_velocity);
-
-  // calculate P and D constants such that they hit the jerk limit when
-  // doing accel from 0
-  float max_accel_norm = std::min(2 * std::sqrt(config.max_jerk_norm),
-                                  config.max_acceleration_norm);
-  float P_constant =
-      10 * (std::sqrt(sqr(max_accel_norm) +
-                      config.max_jerk_norm * desired_velocity.norm()) -
-            max_accel_norm) /
-      (desired_velocity.norm());
-  float D_constant = 2 * std::sqrt(P_constant);
-
-  for (int i = 0; i < num_steps; i++) {
-    float single_step_time = step_time;
-    const Eigen::Vector3f damped_jerk =
-        jerk_for_velocity_setpoint(P_constant, D_constant, config.max_jerk_norm,
-                                   desired_velocity, run_state);
-
-    // limit time step to not exceed the maximum acceleration, but clamp
-    // jerk to 0 if at maximum acceleration already
-    const Eigen::Vector3f requested_accel =
-        run_state.acceleration + single_step_time * damped_jerk;
-    Eigen::Vector3f jerk = damped_jerk;
-    if (requested_accel.squaredNorm() > sqr(max_accel_norm)) {
-      single_step_time = (max_accel_norm - run_state.acceleration.norm()) /
-                  damped_jerk.norm();  // Use a dot product here somewhere?
-      if (single_step_time <= FLT_EPSILON || single_step_time > step_time) {
-        jerk = Eigen::Vector3f::Zero();
-        single_step_time = step_time;
-      }
-    }
-
-    // update the state based on motion equations with the final jerk
-    run_state = simulate_step_constant_jerk(run_state, jerk, single_step_time);
-    timepoints.push_back(run_state);
-  }
-  return timepoints;
 }
-}
-

--- a/local_planner/src/utils/trajectory_simulator.cpp
+++ b/local_planner/src/utils/trajectory_simulator.cpp
@@ -77,9 +77,9 @@ std::vector<simulation_state> TrajectorySimulator::generate_trajectory(
   return timepoints;
 }
 
-simulation_state TrajectorySimulator::simulate_step_constant_jerk(const simulation_state& state,
-                                             const Eigen::Vector3f& jerk,
-                                             float step_time) {
+simulation_state TrajectorySimulator::simulate_step_constant_jerk(
+    const simulation_state& state, const Eigen::Vector3f& jerk,
+    float step_time) {
   simulation_state next_state;
   next_state.position = state.position + step_time * state.velocity +
                         0.5f * sqr(step_time) * state.acceleration +

--- a/local_planner/src/utils/trajectory_simulator.cpp
+++ b/local_planner/src/utils/trajectory_simulator.cpp
@@ -1,0 +1,77 @@
+#include "local_planner/trajectory_simulator.h"
+
+namespace avoidance {
+
+std::vector<simulation_state> run_steps(const simulation_limits& config,
+                                        const simulation_state& start,
+                                        const Eigen::Vector3f& goal_direction,
+                                        float step_time, int num_steps) {
+  auto xy_norm_z_clamp = [](const Eigen::Vector3f& val, float max_xy_norm,
+                            float min_z, float max_z) -> Eigen::Vector3f {
+    Eigen::Vector3f result;
+    result.topRows<2>() = norm_clamp<2>(val.topRows<2>(), max_xy_norm);
+    result.z() = std::min(max_z, std::max(min_z, val.z()));
+    return result;
+  };
+
+  simulation_state run_state = start;
+  std::vector<simulation_state> timepoints;
+  timepoints.reserve(num_steps);
+
+  const Eigen::Vector3f unit_goal = goal_direction.normalized();
+  const Eigen::Vector3f desired_velocity = xy_norm_z_clamp(
+      unit_goal * std::hypot(config.max_xy_velocity_norm,
+                             unit_goal.z() > 0 ? config.max_z_velocity
+                                               : config.min_z_velocity),
+      config.max_xy_velocity_norm, config.min_z_velocity,
+      config.max_z_velocity);
+
+  // calculate P and D constants such that they hit the jerk limit when
+  // doing a full-speed reverse. but not when doing accel from 0
+  // TODO: is this what actually happens when the firmware controls a drone?
+  /** Math: in maximum case, vel*p + 2*sqrt(p)*accel = max_jerk
+   * let k = sqrt(p), then solve quadratically
+   * k = (-2*accel + sqrt(4*accel*accel - 4*vel*(-max_jerk)))/(2*vel)
+   * thus p = ((sqrt(accel*accel + vel*max_jerk) - accel)/vel)^2
+   */
+  auto sqr = [](float f) -> float { return f * f; };
+  auto cube = [](float f) -> float { return f * f * f; };
+  float vel = desired_velocity.norm();
+  float accel = config.max_acceleration_norm;
+  float P_constant =
+      sqr((std::sqrt(sqr(accel) + vel * config.max_jerk_norm) - accel) / vel);
+  float D_constant = 2 * std::sqrt(P_constant);
+
+  for (int i = 0; i < num_steps; i++) {
+    // determine what our jerk should be to control the velocity
+    const Eigen::Vector3f velocity_diff = desired_velocity - run_state.velocity;
+    const Eigen::Vector3f desired_accel = Eigen::Vector3f::Zero();
+    const Eigen::Vector3f accel_diff = desired_accel - run_state.acceleration;
+
+    const Eigen::Vector3f p = velocity_diff * P_constant;
+    const Eigen::Vector3f d = accel_diff * D_constant;
+
+    const Eigen::Vector3f damped_jerk =
+        norm_clamp<3>(p + d, config.max_jerk_norm);
+
+    // clamp the jerk to keep the accel within requested limits
+    const Eigen::Vector3f requested_accel = run_state.acceleration +=
+        step_time * damped_jerk;
+    const Eigen::Vector3f clamped_accel =
+        norm_clamp<3>(requested_accel, config.max_acceleration_norm);
+    const Eigen::Vector3f jerk =
+        (clamped_accel - run_state.acceleration) / step_time;
+
+    // update the state based on motion equations with the final jerk
+    run_state.position += step_time * run_state.velocity +
+                          0.5f * sqr(step_time) * run_state.acceleration +
+                          (1.f / 6.f) * cube(step_time) * jerk;
+    run_state.velocity +=
+        run_state.acceleration * step_time + 0.5f * sqr(step_time) * jerk;
+    run_state.acceleration += step_time * jerk;
+
+    timepoints.push_back(run_state);
+  }
+  return timepoints;
+}
+}

--- a/local_planner/test/test_trajectory_simulator.cpp
+++ b/local_planner/test/test_trajectory_simulator.cpp
@@ -102,6 +102,7 @@ TEST(TrajectorySimulator, givesConstantVelWhenVelCorrect) {
   state.position = Eigen::Vector3f::Zero();
   state.velocity << 3.f, 0.f, 0.f;
   state.acceleration = Eigen::Vector3f::Zero();
+  state.time = 0.f;
 
   simulation_limits config;
   config.max_z_velocity = 1.f;
@@ -134,6 +135,7 @@ TEST(TrajectorySimulator, acceleratesToConstantVel) {
   state.position = Eigen::Vector3f::Zero();
   state.velocity << -3.f, 0.f, 0.f;
   state.acceleration = Eigen::Vector3f::Zero();
+  state.time = 0.f;
 
   simulation_limits config;
   config.max_z_velocity = 1.f;

--- a/local_planner/test/test_trajectory_simulator.cpp
+++ b/local_planner/test/test_trajectory_simulator.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+#include <limits>
+#include "../include/local_planner/trajectory_simulator.h"
+
+using namespace avoidance;
+
+void expect_respects_limits(simulation_limits config, simulation_state start,
+                            float step_time, int num_steps,
+                            const std::vector<simulation_state>& steps) {
+  const simulation_state* last_step = &start;
+  EXPECT_EQ(num_steps, steps.size());
+  for (const auto& step : steps) {
+    Eigen::Vector3f jerk =
+        (step.acceleration - last_step->acceleration) / step_time;
+    last_step = &step;
+
+    EXPECT_LE(jerk.norm(), config.max_jerk_norm);
+    EXPECT_LE(step.acceleration.norm(), config.max_acceleration_norm);
+    EXPECT_LE(step.velocity.topRows<2>().norm(), config.max_xy_velocity_norm);
+  }
+}
+
+void expect_goes_in_goal_direction(Eigen::Vector3f goal_dir,
+                                   simulation_state start, float step_time,
+                                   const std::vector<simulation_state>& steps) {
+  const simulation_state* last_step = &start;
+  for (const auto& step : steps) {
+    Eigen::Vector3f jerk =
+        (step.acceleration - last_step->acceleration) / step_time;
+    last_step = &step;
+
+    // things to check:
+    // 1) acceleration should be to correct norm(vel) != goal_vel
+    // 2) if it isn't, then jerk should be trying to correct accel in goal
+    // direction
+
+    Eigen::Vector3f vel_dir_error =
+        step.velocity.normalized() - goal_dir.normalized();
+
+    if (vel_dir_error.dot(step.acceleration.normalized()) < 0) {
+      EXPECT_GE(jerk.dot(goal_dir), 0);
+    }
+  }
+}
+
+TEST(TrajectorySimulator, normClampWorksWithZeros) {
+  // GIVEN: a vector shorter than the clamp
+  Eigen::Vector3f short_vec(0, 0, 0);
+
+  // WHEN we try to clamp it
+  auto clamped = norm_clamp(short_vec, 0);
+
+  // THEN: it should be zero, not NaN
+  EXPECT_TRUE(clamped.norm() == 0.f);
+  EXPECT_FALSE(clamped.array().isNaN().any());
+}
+
+TEST(TrajectorySimulator, normClampPassesShortVectors) {
+  // GIVEN: a vector shorter than the clamp
+  Eigen::Vector3f short_vec(0.5f, 0.6f, 0.7f);
+
+  // WHEN we try to clamp it
+  auto clamped = norm_clamp(short_vec, 5.f);
+
+  // THEN: it should match exactly the input
+  EXPECT_TRUE((short_vec - clamped).norm() == 0.f);
+}
+
+TEST(TrajectorySimulator, normClampClampsLongVectors) {
+  // GIVEN: a vector longer than the clamp
+  Eigen::Vector3f long_vec(5.f, 6.f, 7.f);
+
+  // WHEN we try to clamp it
+  auto clamped = norm_clamp(long_vec, 5.f);
+
+  // THEN: it should have length clamped to
+  EXPECT_FLOAT_EQ(5.f, clamped.norm());
+
+  // AND: should be in the same direction as the original
+  EXPECT_FLOAT_EQ(1.f, clamped.normalized().dot(long_vec.normalized()));
+}
+
+TEST(TrajectorySimulator, givesEmptyListWithNoSteps) {
+  // GIVEN: a starting point, and not set up simulation limits
+  simulation_state state;
+  simulation_limits config;
+  Eigen::Vector3f goal_dir;
+  float step_time = 0.01;
+
+  // WHEN: we get the list of trajectories with 0 steps
+  int num_steps = 0;
+  std::vector<simulation_state> steps =
+      run_steps(config, state, goal_dir, step_time, num_steps);
+
+  // THEN: we should get an empty list
+  EXPECT_EQ(0, steps.size());
+}
+
+TEST(TrajectorySimulator, givesConstantVelWhenVelCorrect) {
+  // GIVEN: a starting point
+  simulation_state state;
+  state.position = Eigen::Vector3f::Zero();
+  state.velocity << 3.f, 0.f, 0.f;
+  state.acceleration = Eigen::Vector3f::Zero();
+
+  simulation_limits config;
+  config.max_z_velocity = 1.f;
+  config.min_z_velocity = -0.5f;
+  config.max_xy_velocity_norm = 3.f;
+  config.max_acceleration_norm = 3.f;
+  config.max_jerk_norm = 20.f;
+
+  Eigen::Vector3f goal_dir(1.f, 0.f, 0.f);
+  float step_time = 0.01;
+
+  // WHEN: we get the list of trajectories with 0 steps
+  int num_steps = 10;
+  std::vector<simulation_state> steps =
+      run_steps(config, state, goal_dir, step_time, num_steps);
+
+  // THEN: we should get a list with all the same velocity, zero accel
+  EXPECT_EQ(num_steps, steps.size());
+  for (const auto& step : steps) {
+    EXPECT_TRUE((state.velocity - step.velocity).norm() < 1e-5);
+    EXPECT_TRUE(step.acceleration.norm() < 1e-5);
+  }
+  EXPECT_NO_FATAL_FAILURE(
+      expect_respects_limits(config, state, step_time, num_steps, steps));
+}
+
+TEST(TrajectorySimulator, acceleratesToConstantVel) {
+  // GIVEN: a starting point
+  simulation_state state;
+  state.position = Eigen::Vector3f::Zero();
+  state.velocity << -3.f, 0.f, 0.f;
+  state.acceleration = Eigen::Vector3f::Zero();
+
+  simulation_limits config;
+  config.max_z_velocity = 1.f;
+  config.min_z_velocity = -0.5f;
+  config.max_xy_velocity_norm = 3.f;
+  config.max_acceleration_norm = 3.f;
+  config.max_jerk_norm = 20.f;
+
+  Eigen::Vector3f goal_dir(1.f, 0.f, 0.f);
+  float step_time = 0.1;
+
+  // WHEN: we get the list of trajectories with 0 steps
+  int num_steps = 300;
+  std::vector<simulation_state> steps =
+      run_steps(config, state, goal_dir, step_time, num_steps);
+
+  // THEN: we should get a list where it moves in the goal direction
+  EXPECT_NO_FATAL_FAILURE(
+      expect_respects_limits(config, state, step_time, num_steps, steps));
+  EXPECT_NO_FATAL_FAILURE(
+      expect_goes_in_goal_direction(goal_dir, state, step_time, steps));
+}


### PR DESCRIPTION
This adds a simple trajectory simulator, which tries to mimic what the drone would do if given a direction setpoint. It only simulates position/velocity/acceleration, no orientation, uses jerk limiting and keeps within pre-defined thresholds which should be fairly compatible with the firmware parameters.

The idea is that it gives a list of all of the intermediate states, so that they can be tested for collisions with obstacles.

Not used anywhere yet, just the code and some tests added so far.