### PR TITLE
Run Local Planner Node at a fixed rate

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -119,6 +119,8 @@ class LocalPlannerNode {
   std::mutex data_ready_mutex_;
   std::mutex px4_params_mutex_;
   std::condition_variable data_ready_cv_;
+  bool never_run_ = true;
+  bool position_received_ = false;
 
   /**
   * @brief     handles threads for data publication and subscription
@@ -268,8 +270,6 @@ class LocalPlannerNode {
   bool planner_is_healthy_;
   bool startup_;
   bool callPx4Params_;
-  bool never_run_ = true;
-  bool position_received_ = false;
   bool disable_rise_to_goal_altitude_;
   bool accept_goal_input_topic_;
   double spin_dt_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -107,6 +107,8 @@ class LocalPlannerNode {
 
   std::unique_ptr<LocalPlanner> local_planner_;
   std::unique_ptr<WaypointGenerator> wp_generator_;
+  std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
+
   LocalPlannerVisualization visualizer_;
 
 #ifndef DISABLE_SIMULATION
@@ -225,7 +227,6 @@ class LocalPlannerNode {
 
   ros::Timer cmdloop_timer_;
   ros::CallbackQueue cmdloop_queue_;
-  ros::AsyncSpinner cmdloop_spinner_;
 
   // Publishers
   ros::Publisher mavros_pos_setpoint_pub_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -113,7 +113,6 @@ class LocalPlannerNode {
   WorldVisualizer world_visualizer_;
 #endif
 
-
   std::mutex running_mutex_;  ///< guard against concurrent access to input &
                               /// output data (point cloud, position, ...)
 
@@ -212,7 +211,6 @@ class LocalPlannerNode {
   void checkPx4Parameters();
 
  private:
-
   avoidance::LocalPlannerNodeConfig rqt_param_config_;
 
   ros::NodeHandle nh_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -236,13 +236,18 @@ class LocalPlannerNode {
   void checkPx4Parameters();
 
  private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle nh_private_;
 
   avoidance::LocalPlannerNodeConfig rqt_param_config_;
 
   mavros_msgs::Altitude ground_distance_msg_;
   int path_length_ = 0;
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ros::Timer cmdloop_timer_;
+  ros::CallbackQueue cmdloop_queue_;
+  ros::AsyncSpinner cmdloop_spinner_;
 
   // Subscribers
   ros::Subscriber pose_sub_;
@@ -262,6 +267,7 @@ class LocalPlannerNode {
   NavigationState nav_state_ = NavigationState::none;
   bool new_goal_ = false;
   bool data_ready_ = false;
+  double spin_dt_;
 
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;
   boost::recursive_mutex config_mutex_;
@@ -312,6 +318,7 @@ class LocalPlannerNode {
   * @param[in] msg, vehicle position and orientation in ENU frame
   **/
   void stateCallback(const mavros_msgs::State& msg);
+  void cmdLoopCallback(const ros::TimerEvent& event);
 
   /**
   * @brief     reads parameters from launch file and yaml file

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -267,6 +267,13 @@ class LocalPlannerNode {
   NavigationState nav_state_ = NavigationState::none;
   bool new_goal_ = false;
   bool data_ready_ = false;
+  bool hover_;
+  bool planner_is_healthy_;
+  bool startup_;
+  bool callPx4Params_;
+  ros::Time start_time_;
+
+
   double spin_dt_;
 
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -127,6 +127,11 @@ class LocalPlannerNode {
   **/
   void threadFunction();
 
+  /**
+  * @brief     start spinners
+  **/
+  void startNode();
+
   void updatePlanner();
 
   /**

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -37,8 +37,6 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
 
   cmdloop_timer_ = nh_.createTimer(timer_options);
 
-  cmdloop_spinner_.start();
-
   // Set up Dynamic Reconfigure Server
   server_ = new dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>(
       config_mutex_, nh_);
@@ -113,6 +111,8 @@ LocalPlannerNode::~LocalPlannerNode() {
   delete server_;
   delete tf_listener_;
 }
+
+void LocalPlannerNode::startNode() { cmdloop_spinner_.start(); }
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -104,6 +104,9 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
 }
 
 LocalPlannerNode::~LocalPlannerNode() {
+  should_exit_ = true;
+  data_ready_cv_.notify_all();
+
   delete server_;
   delete tf_listener_;
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -18,10 +18,10 @@ namespace avoidance {
 LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
                                    const ros::NodeHandle& nh_private,
                                    const bool tf_spin_thread)
-        : nh_(nh),
-          nh_private_(nh_private),
-          cmdloop_spinner_(1, &cmdloop_queue_),
-          spin_dt_(0.1) {
+    : nh_(nh),
+      nh_private_(nh_private),
+      cmdloop_spinner_(1, &cmdloop_queue_),
+      spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
 
@@ -31,9 +31,9 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
       ros::Duration(tf::Transformer::DEFAULT_CACHE_TIME), tf_spin_thread);
 
   ros::TimerOptions timer_options(
-          ros::Duration(spin_dt_),
-          boost::bind(&LocalPlannerNode::cmdLoopCallback, this, _1),
-          &cmdloop_queue_);
+      ros::Duration(spin_dt_),
+      boost::bind(&LocalPlannerNode::cmdLoopCallback, this, _1),
+      &cmdloop_queue_);
 
   cmdloop_timer_ = nh_.createTimer(timer_options);
 
@@ -92,7 +92,8 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
   // pass initial goal into local planner
   local_planner_->applyGoal();
 
-  local_planner_->disable_rise_to_goal_altitude_ = disable_rise_to_goal_altitude_;
+  local_planner_->disable_rise_to_goal_altitude_ =
+      disable_rise_to_goal_altitude_;
   status_msg_.state = (int)MAV_STATE::MAV_STATE_BOOT;
 
   hover_ = false;
@@ -302,53 +303,51 @@ void LocalPlannerNode::stateCallback(const mavros_msgs::State& msg) {
 }
 
 void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
-      hover_ = false;
+  hover_ = false;
 
 #ifdef DISABLE_SIMULATION
-    startup_ = false;
+  startup_ = false;
 #else
-    // visualize world in RVIZ
-    if (!world_path_.empty() && startup_) {
-      if (world_visualizer_.visualizeRVIZWorld(world_path_)) {
-        ROS_WARN("Failed to visualize Rviz world");
-      }
-      startup_ = false;
+  // visualize world in RVIZ
+  if (!world_path_.empty() && startup_) {
+    if (world_visualizer_.visualizeRVIZWorld(world_path_)) {
+      ROS_WARN("Failed to visualize Rviz world");
     }
+    startup_ = false;
+  }
 
 #endif
 
-    // Process callbacks & wait for a position update
-    while (!position_received_ && ros::ok()) {
-      ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
+  // Process callbacks & wait for a position update
+  while (!position_received_ && ros::ok()) {
+    ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
+  }
+
+  // Check if all information was received
+  ros::Time now = ros::Time::now();
+  ros::Duration since_last_cloud = now - last_wp_time_;
+  ros::Duration since_start = now - start_time_;
+
+  checkFailsafe(since_last_cloud, since_start, planner_is_healthy_, hover_);
+
+  // If planner is not running, update planner info and get last results
+  updatePlanner();
+
+  // send waypoint
+  if (!never_run_ && planner_is_healthy_) {
+    calculateWaypoints(hover_);
+    if (!hover_) status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
+  } else {
+    for (size_t i = 0; i < cameras_.size(); ++i) {
+      // once the camera info have been set once, unsubscribe from topic
+      cameras_[i].camera_info_sub_.shutdown();
     }
+  }
 
-    // Check if all information was received
-    ros::Time now = ros::Time::now();
-    ros::Duration since_last_cloud = now - last_wp_time_;
-    ros::Duration since_start = now - start_time_;
+  position_received_ = false;
 
-    checkFailsafe(since_last_cloud, since_start, planner_is_healthy_,
-                       hover_);
-
-    // If planner is not running, update planner info and get last results
-    updatePlanner();
-
-    // send waypoint
-    if (!never_run_ && planner_is_healthy_) {
-      calculateWaypoints(hover_);
-      if (!hover_) status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
-    } else {
-      for (size_t i = 0; i < cameras_.size(); ++i) {
-        // once the camera info have been set once, unsubscribe from topic
-        cameras_[i].camera_info_sub_.shutdown();
-      }
-    }
-
-    position_received_ = false;
-
-    // publish system status
-    if (now - t_status_sent_ > ros::Duration(0.2))
-      publishSystemStatus();
+  // publish system status
+  if (now - t_status_sent_ > ros::Duration(0.2)) publishSystemStatus();
 
   return;
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -21,7 +21,6 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
     : nh_(nh), nh_private_(nh_private), spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
-  cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
 
   readParams();
 
@@ -110,7 +109,10 @@ LocalPlannerNode::~LocalPlannerNode() {
   delete tf_listener_;
 }
 
-void LocalPlannerNode::startNode() { cmdloop_spinner_->start(); }
+void LocalPlannerNode::startNode() {
+  cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
+  cmdloop_spinner_->start();
+}
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -27,13 +27,6 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
   tf_listener_ = new tf::TransformListener(
       ros::Duration(tf::Transformer::DEFAULT_CACHE_TIME), tf_spin_thread);
 
-  ros::TimerOptions timer_options(
-      ros::Duration(spin_dt_),
-      boost::bind(&LocalPlannerNode::cmdLoopCallback, this, _1),
-      &cmdloop_queue_);
-
-  cmdloop_timer_ = nh_.createTimer(timer_options);
-
   // Set up Dynamic Reconfigure Server
   server_ = new dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>(
       config_mutex_, nh_);
@@ -110,6 +103,12 @@ LocalPlannerNode::~LocalPlannerNode() {
 }
 
 void LocalPlannerNode::startNode() {
+  ros::TimerOptions timer_options(
+      ros::Duration(spin_dt_),
+      boost::bind(&LocalPlannerNode::cmdLoopCallback, this, _1),
+      &cmdloop_queue_);
+  cmdloop_timer_ = nh_.createTimer(timer_options);
+
   cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
   cmdloop_spinner_->start();
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -100,6 +100,9 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
   planner_is_healthy_ = true;
   startup_ = true;
   callPx4Params_ = true;
+  mission_ = false;
+  offboard_ = false;
+  armed_ = false;
   start_time_ = ros::Time::now();
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -88,8 +88,6 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
   planner_is_healthy_ = true;
   startup_ = true;
   callPx4Params_ = true;
-  mission_ = false;
-  offboard_ = false;
   armed_ = false;
   start_time_ = ros::Time::now();
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -18,12 +18,10 @@ namespace avoidance {
 LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
                                    const ros::NodeHandle& nh_private,
                                    const bool tf_spin_thread)
-    : nh_(nh),
-      nh_private_(nh_private),
-      cmdloop_spinner_(1, &cmdloop_queue_),
-      spin_dt_(0.1) {
+    : nh_(nh), nh_private_(nh_private), spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
+  cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
 
   readParams();
 
@@ -112,7 +110,7 @@ LocalPlannerNode::~LocalPlannerNode() {
   delete tf_listener_;
 }
 
-void LocalPlannerNode::startNode() { cmdloop_spinner_.start(); }
+void LocalPlannerNode::startNode() { cmdloop_spinner_->start(); }
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -8,6 +8,7 @@ int main(int argc, char** argv) {
   ros::NodeHandle nh_private("");
 
   LocalPlannerNode Node(nh, nh_private, true);
+  Node.startNode();
   ros::Duration(2).sleep();
 
   std::thread worker(&LocalPlannerNode::threadFunction, &Node);

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -1,12 +1,8 @@
-#include "local_planner/local_planner.h"
-#include "local_planner/common.h"
 #include "local_planner/local_planner_node.h"
-#include "local_planner/waypoint_generator.h"
 
-#include <boost/algorithm/string.hpp>
+using namespace avoidance;
 
 int main(int argc, char** argv) {
-  using namespace avoidance;
   ros::init(argc, argv, "local_planner_node");
   ros::NodeHandle nh("~");
   ros::NodeHandle nh_private("");

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -13,44 +13,14 @@ int main(int argc, char** argv) {
 
   LocalPlannerNode Node(nh, nh_private, true);
   ros::Duration(2).sleep();
-  ros::Time start_time = ros::Time::now();
-  bool hover = false;
-  bool planner_is_healthy = true;
-  avoidanceOutput planner_output;
-  Node.local_planner_->disable_rise_to_goal_altitude_ =
-      Node.disable_rise_to_goal_altitude_;
-  bool startup = true;
-  bool callPx4Params = true;
-  Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_BOOT;
 
   std::thread worker(&LocalPlannerNode::threadFunction, &Node);
 
   std::thread worker_params(&LocalPlannerNode::checkPx4Parameters, &Node);
-
-  // spin node, execute callbacks
-  while (ros::ok()) {
-    hover = false;
-
-#ifdef DISABLE_SIMULATION
-    startup = false;
-#else
-    // visualize world in RVIZ
-    if (!Node.world_path_.empty() && startup) {
-      if (Node.world_visualizer_.visualizeRVIZWorld(Node.world_path_)) {
-        ROS_WARN("Failed to visualize Rviz world");
-      }
-      startup = false;
-    }
-
-#endif
-
     ros::Duration timeout_termination =
         ros::Duration(Node.local_planner_->timeout_termination_);
     ros::Time start_query_position = ros::Time::now();
     bool sent_error = false;
-    // Process callbacks & wait for a position update
-    while (!Node.position_received_ && ros::ok()) {
-      ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
       ros::Duration since_query = ros::Time::now() - start_query_position;
       if (since_query > timeout_termination && !sent_error) {
         // clang-format off
@@ -68,39 +38,6 @@ int main(int argc, char** argv) {
         Node.publishSystemStatus();
         sent_error = true;
       }
-    }
-
-    // Check if all information was received
-    ros::Time now = ros::Time::now();
-    ros::Duration since_last_cloud = now - Node.last_wp_time_;
-    ros::Duration since_start = now - start_time;
-
-    Node.checkFailsafe(since_last_cloud, since_start, planner_is_healthy,
-                       hover);
-
-    // If planner is not running, update planner info and get last results
-    Node.updatePlanner();
-
-    // send waypoint
-    if (!Node.never_run_ && planner_is_healthy) {
-      Node.calculateWaypoints(hover);
-      if (!hover) Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
-    } else {
-      for (size_t i = 0; i < Node.cameras_.size(); ++i) {
-        // once the camera info have been set once, unsubscribe from topic
-        Node.cameras_[i].camera_info_sub_.shutdown();
-      }
-    }
-
-    Node.position_received_ = false;
-
-    // publish system status
-    if (now - Node.t_status_sent_ > ros::Duration(0.2))
-      Node.publishSystemStatus();
-  }
-
-  Node.should_exit_ = true;
-  Node.data_ready_cv_.notify_all();
   worker.join();
   worker_params.join();
 

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -14,13 +14,13 @@ int main(int argc, char** argv) {
   std::thread worker(&LocalPlannerNode::threadFunction, &Node);
 
   std::thread worker_params(&LocalPlannerNode::checkPx4Parameters, &Node);
-    ros::Duration timeout_termination =
-        ros::Duration(Node.local_planner_->timeout_termination_);
-    ros::Time start_query_position = ros::Time::now();
-    bool sent_error = false;
-      ros::Duration since_query = ros::Time::now() - start_query_position;
-      if (since_query > timeout_termination && !sent_error) {
-        // clang-format off
+  ros::Duration timeout_termination =
+      ros::Duration(Node.local_planner_->timeout_termination_);
+  ros::Time start_query_position = ros::Time::now();
+  bool sent_error = false;
+  ros::Duration since_query = ros::Time::now() - start_query_position;
+  if (since_query > timeout_termination && !sent_error) {
+    // clang-format off
     	  ROS_WARN("\033[1;33m Planner abort: missing required data \n \033[0m");
     	  ROS_WARN("----------------------------- Debugging Info -----------------------------");
     	  ROS_WARN("Local planner has not received a position from FCU, check the following: ");
@@ -30,11 +30,11 @@ int main(int argc, char** argv) {
     	  ROS_WARN("   Example direct connection to serial port: /dev/ttyUSB0:921600");
     	  ROS_WARN("   Example connection over mavlink router: udp://:14540@localhost:14557");
     	  ROS_WARN("--------------------------------------------------------------------------");
-        // clang-format on
-        Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
-        Node.publishSystemStatus();
-        sent_error = true;
-      }
+    // clang-format on
+    Node.status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
+    Node.publishSystemStatus();
+    sent_error = true;
+  }
   worker.join();
   worker_params.join();
 


### PR DESCRIPTION
This PR moves the while loop that lived in `local_planner_node_main` into `local_planner_node`, by using the `ros::AsyncSpinner`. This replaces #211 

- Using AsyncSpinner ensures the planner runs at a fixed specified rate
- This also enables `roscpp` to handle threading, which we can expand to other processes
- We can have less public members in the local planner node

I am not sure what to make of the `threadFunction`, should we also try to move this to a separate spinner?

This has been SITL tested. 