### PR TITLE
use reprojection of combined histogram for starplanner instead of cropped cloud

### DIFF
--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -34,7 +34,6 @@ class StarPlanner {
   std::vector<int> reprojected_points_age_;
   std::vector<int> path_node_origins_;
 
-  pcl::PointCloud<pcl::PointXYZ> pointcloud_;
   pcl::PointCloud<pcl::PointXYZ> reprojected_points_;
 
   Eigen::Vector3f goal_ = Eigen::Vector3f(NAN, NAN, NAN);
@@ -108,12 +107,6 @@ class StarPlanner {
   * @param[in] goal, current goal position
   **/
   void setGoal(const Eigen::Vector3f& pose);
-
-  /**
-  * @brief     setter method for pointcloud
-  * @param[in] cropped_cloud, current point cloud cropped around the vehicle
-  **/
-  void setCloud(const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud);
 
   /**
   * @brief     build tree of candidates directions towards the goal

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -110,7 +110,6 @@ void LocalPlanner::runPlanner() {
 void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
   // construct histogram if it is needed
   // or if it is required by the FCU
-  reprojectPoints(polar_histogram_);
   Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
   Histogram new_histogram = Histogram(ALPHA_RES);
   to_fcu_histogram_.setZero();
@@ -125,6 +124,9 @@ void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
     updateObstacleDistanceMsg(to_fcu_histogram_);
   }
   polar_histogram_ = new_histogram;
+
+  // create 3D points from combined histogram
+  reprojectPoints(polar_histogram_);
 
   // generate histogram image for logging
   generateHistogramImage(polar_histogram_);
@@ -225,7 +227,6 @@ void LocalPlanner::determineStrategy() {
           star_planner_->setFOV(h_FOV_, v_FOV_);
           star_planner_->setReprojectedPoints(reprojected_points_,
                                               reprojected_points_age_);
-          star_planner_->setCloud(final_cloud_);
 
           // set last chosen direction for smoothing
           PolarPoint last_wp_pol =

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -39,11 +39,6 @@ void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   curr_yaw_histogram_frame_deg_ = curr_yaw;
 }
 
-void StarPlanner::setCloud(
-    const pcl::PointCloud<pcl::PointXYZ>& cropped_cloud) {
-  pointcloud_ = cropped_cloud;
-}
-
 void StarPlanner::setGoal(const Eigen::Vector3f& goal) {
   goal_ = goal;
   tree_age_ = 1000;
@@ -141,14 +136,10 @@ void StarPlanner::buildLookAheadTree() {
                  tree_[origin].yaw_,
                  0.0f);  // assume pitch is zero at every node
 
-    Histogram propagated_histogram = Histogram(2 * ALPHA_RES);
-    Histogram histogram = Histogram(ALPHA_RES);
+    Histogram histogram = Histogram(2 * ALPHA_RES);
 
-    propagateHistogram(propagated_histogram, reprojected_points_,
-                       reprojected_points_age_, origin_position);
-    generateNewHistogram(histogram, pointcloud_, origin_position);
-    combinedHistogram(hist_is_empty, histogram, propagated_histogram, false,
-                      z_FOV_idx, e_FOV_min, e_FOV_max);
+    propagateHistogram(histogram, reprojected_points_, reprojected_points_age_,
+                       origin_position);
 
     // calculate candidates
     Eigen::MatrixXf cost_matrix;

--- a/local_planner/test/test_star_planner.cpp
+++ b/local_planner/test/test_star_planner.cpp
@@ -38,16 +38,16 @@ class StarPlannerTests : public ::testing::Test {
     goal.y() = 14.0f;
     goal.z() = 4.0f;
 
-    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::PointCloud<pcl::PointXYZ> reprojected_points;
+    std::vector<int> reprojected_points_age;
     for (float x = obstacle_min_x; x < obstacle_max_x; x += 0.05f) {
       for (float z = goal.z() - obstacle_half_height;
            z < goal.z() + obstacle_half_height; z += 0.05f) {
-        cloud.push_back(pcl::PointXYZ(x, obstacle_y, z));
+        reprojected_points.push_back(pcl::PointXYZ(x, obstacle_y, z));
+        reprojected_points_age.push_back(0);
       }
     }
     costParameters cost_params;
-    const pcl::PointCloud<pcl::PointXYZ> reprojected_points;
-    const std::vector<int> reprojected_points_age;
 
     star_planner.setParams(cost_params);
     star_planner.setFOV(270.0f, 45.0f);
@@ -55,7 +55,6 @@ class StarPlannerTests : public ::testing::Test {
                                       reprojected_points_age);
     star_planner.setPose(position, 0.0f);
     star_planner.setGoal(goal);
-    star_planner.setCloud(cloud);
   }
   void TearDown() override {}
 };


### PR DESCRIPTION
old structure:

crop new cloud -> reproject points (old, combined histogram) -> build new hist and propagated hist -> combined hist -> star_planner (cropped cloud, reprojected points)

new structure:

crop new cloud -> build new hist and propagated hist -> combined hist -> reproject points (combined hist) -> star_planner (reprojected points)


This change allows the star planner to act on a tiny pointcloud (reprojected points of the combined histogram). The cropped cloud does not have to be passed into the starplanner anymore (one less copy) and the calculation per node get much simpler due to the smaller pointcloud it is using.