### PR TITLE
Increase clipping box size

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,7 +7,7 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 7,  0, 20)
+gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 12,  0, 20)
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 3.0, 0.5, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0.5, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function wight for path smoothness", 1.5, 0.5, 20.0)


### PR DESCRIPTION
Reviewing data from Realsense cameras showed that it was better with larger clipping radius. It was due to a miscalibrated camera that we used the very conservative data before.

This has improved the avoidance performance considerably, since it now sees obstacles ~5m earlier than before.
Flight logs before:
https://logs.px4.io/plot_app?log=f03365d4-4494-4524-a442-1ba139022cc5

After:
https://logs.px4.io/plot_app?log=7894ef1b-07fc-415f-b684-dc20dde12773

Notice the smoother turns, and less time spent at 0 velocity due to last moment braking.

The larger distances also enable potentially higher flight speeds.
