### PR TITLE
Use firmware parameters

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -34,13 +34,4 @@ gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  
 gen.add("tree_discount_factor_",    double_t,    0, "Discount factor in tree cost function", 0.8,  0, 1)
 gen.add("max_path_length_",    double_t,    0, "Maximum length of planned paths", 3,  0, 15)
 
-# waypoint_generator
-gen.add("goal_acceptance_radius_in_", double_t, 0, "Radius of a sphere around a waypoint to set it as reached", 0.5,  0.1, 5.0)
-gen.add("goal_acceptance_radius_out_", double_t, 0, "Radius of a sphere around a waypoint to set it as not reached", 1.5,  0.1, 10.0)
-gen.add("factor_close_to_goal_start_speed_limitation_", double_t, 0, "", 3.0,  0.1, 20.0)
-gen.add("factor_close_to_goal_stop_speed_limitation_", double_t, 0, "", 4.0,  0.1, 20.0)
-gen.add("max_speed_close_to_goal_factor_", double_t, 0, "", 0.1,  0.1, 20.0)
-gen.add("min_speed_close_to_goal_", double_t, 0, "Speed close to goal", 0.5,  0.1, 14.0)
-
-
 exit(gen.generate(PACKAGE, "avoidance", "LocalPlannerNode"))

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -12,7 +12,7 @@ gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smoothness", 1.5, 0.5, 20.0)
 gen.add("velocity_around_obstacles_", double_t, 0, "Maximally allowed drone velocity in the proximity of obstacles [m/s]", 2.0, 0.0, 5.0)
-gen.add("velocity_far_from_obstacles_", double_t, 0, "Maximally allowed drone velocity when no obstacles are in sight [m/s]", 3.0, 0.0, 10.0)
+gen.add("keep_distance_", double_t, 0, "Distance at which the UAV stops in front of an obstacle", 2.0, 1.0, 8.0)
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
@@ -26,7 +26,6 @@ gen.add("smoothing_margin_degrees_", double_t, 0, "smoothing radius for obstacle
 
 gen.add("use_vel_setpoints_", bool_t, 0, "Enable velocity setpoints (if false, position setpoints are used)", False)
 gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, allow rising", True)
-gen.add("send_obstacles_fcu_", bool_t, 0, "Send 2D obstacle representation to the FCU", True)
 
 # star_planner
 gen.add("children_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -11,7 +11,6 @@ gen.add("box_radius_",    double_t,    0, "Data points farther away will be disc
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 10.0, 0, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smoothness", 1.5, 0.5, 20.0)
-gen.add("velocity_around_obstacles_", double_t, 0, "Maximally allowed drone velocity in the proximity of obstacles [m/s]", 2.0, 0.0, 5.0)
 gen.add("keep_distance_", double_t, 0, "Distance at which the UAV stops in front of an obstacle", 2.0, 1.0, 8.0)
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)

--- a/local_planner/include/local_planner/avoidance_output.h
+++ b/local_planner/include/local_planner/avoidance_output.h
@@ -12,10 +12,7 @@ enum waypoint_choice { hover, tryPath, direct, reachHeight };
 struct avoidanceOutput {
   waypoint_choice waypoint_type;
   bool obstacle_ahead;  // true is there is an obstacle ahead of the vehicle
-  float velocity_around_obstacles;    // maximal velocity in the proximity of
-                                      // obstacles
-  float velocity_far_from_obstacles;  // maximal velocity with no obstacles in
-                                      // sight
+  float cruise_velocity;  // mission cruise velocity
   ros::Time last_path_time;           // finish built time for the VFH+* tree
 
   Eigen::Vector3f take_off_pose;  // last vehicle position when not armed

--- a/local_planner/include/local_planner/avoidance_output.h
+++ b/local_planner/include/local_planner/avoidance_output.h
@@ -11,9 +11,9 @@ enum waypoint_choice { hover, tryPath, direct, reachHeight };
 
 struct avoidanceOutput {
   waypoint_choice waypoint_type;
-  bool obstacle_ahead;  // true is there is an obstacle ahead of the vehicle
+  bool obstacle_ahead;    // true is there is an obstacle ahead of the vehicle
   float cruise_velocity;  // mission cruise velocity
-  ros::Time last_path_time;           // finish built time for the VFH+* tree
+  ros::Time last_path_time;  // finish built time for the VFH+* tree
 
   Eigen::Vector3f take_off_pose;  // last vehicle position when not armed
 

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -81,7 +81,6 @@ class LocalPlanner {
   float curr_yaw_fcu_frame_deg_, curr_yaw_histogram_frame_deg_;
   float curr_pitch_deg_;  // for pitch angles the histogram frame matches the
                           // fcu frame
-  float velocity_around_obstacles_;
   float keep_distance_;
   ros::Time integral_time_old_;
   float no_progress_slope_;

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -163,7 +163,7 @@ class LocalPlanner {
   float speed_ = 1.0f;
   float ground_distance_ = 2.0;
 
-  ModelParameters model_params_; // PX4 Firmware paramters
+  ModelParameters px4_; // PX4 Firmware paramters
 
   Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
   sensor_msgs::LaserScan distance_data_ = {};

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -163,7 +163,7 @@ class LocalPlanner {
   float speed_ = 1.0f;
   float ground_distance_ = 2.0;
 
-  ModelParameters px4_; // PX4 Firmware paramters
+  ModelParameters px4_;  // PX4 Firmware paramters
 
   Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
   sensor_msgs::LaserScan distance_data_ = {};

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -34,6 +34,35 @@ namespace avoidance {
 class StarPlanner;
 class TreeNode;
 
+/**
+* @brief struct to contain the parameters needed for the model based trajectory
+*planning
+* when MPC_AUTO_MODE is set to 1 (default) then all members are used for the
+*jerk limited
+* trajectory on the flight controller side
+* when MPC_AUTO_MODE is set to 0, only up_accl, down_accl, xy_acc are used on
+*the
+* flight controller side
+**/
+struct ModelParameters {
+  // clang-format off
+  int param_mpc_auto_mode = 1; // Auto sub-mode - 0: default line tracking, 1 jerk-limited trajectory
+  float param_mpc_jerk_min = 8.0f; // Velocity-based jerk limit
+  float param_acc_up_max = 10.0f;   // Maximum vertical acceleration in velocity controlled modes upward
+  float param_mpc_z_vel_max_up = 3.0f;   // Maximum vertical ascent velocity
+  float param_mpc_acc_down_max = 10.0f; // Maximum vertical acceleration in velocity controlled modes down
+  float param_mpc_vel_max_dn = 1.0f; // Maximum vertical descent velocity
+  float param_mpc_acc_hor = 5.0f;  // Maximum horizontal acceleration for auto mode and
+                      // maximum deceleration for manual mode
+  float param_mpc_xy_cruise = 1.0f;   // Desired horizontal velocity in mission
+  float param_mpc_tko_speed = 1.0f; // Takeoff climb rate
+  float param_mpc_land_speed = 0.7f;   // Landing descend rate
+  // limitations given by sensors
+  float param_ekf2_rng_a_hmax = 5.0f;
+  float param_ekf2_rng_a_vmax = 5.0f;
+  // clang-format on
+};
+
 class LocalPlanner {
  private:
   bool adapt_cost_params_;
@@ -130,6 +159,8 @@ class LocalPlanner {
   double starting_height_ = 0.0;
   float speed_ = 1.0f;
   float ground_distance_ = 2.0;
+
+  ModelParameters model_params_; // PX4 Firmware paramters
 
   Eigen::Vector3f take_off_pose_ = Eigen::Vector3f::Zero();
   sensor_msgs::LaserScan distance_data_ = {};

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -58,9 +58,8 @@ struct ModelParameters {
   float param_mpc_xy_cruise = NAN;   // Desired horizontal velocity in mission
   float param_mpc_tko_speed = NAN; // Takeoff climb rate
   float param_mpc_land_speed = NAN;   // Landing descend rate
-  // limitations given by sensors
-  float param_ekf2_rng_a_hmax = NAN;
-  float param_ekf2_rng_a_vmax = NAN;
+
+  // TODO: add estimator limitations for max speed and height
 
   float param_mpc_col_prev_d = NAN; // Collision Prevention distance to keep from obstacle. -1 for disabled
   // clang-format on

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -47,7 +47,8 @@ class TreeNode;
 struct ModelParameters {
   // clang-format off
   int param_mpc_auto_mode = 1; // Auto sub-mode - 0: default line tracking, 1 jerk-limited trajectory
-  float param_mpc_jerk_min = 8.0f; // Velocity-based jerk limit
+  float param_mpc_jerk_min = 8.0f; // Velocity-based minimum jerk limit
+  float param_mpc_jerk_max = 20.f; // Velocity-based maximum jerk limit
   float param_acc_up_max = 10.0f;   // Maximum vertical acceleration in velocity controlled modes upward
   float param_mpc_z_vel_max_up = 3.0f;   // Maximum vertical ascent velocity
   float param_mpc_acc_down_max = 10.0f; // Maximum vertical acceleration in velocity controlled modes down

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -46,23 +46,23 @@ class TreeNode;
 **/
 struct ModelParameters {
   // clang-format off
-  int param_mpc_auto_mode = 1; // Auto sub-mode - 0: default line tracking, 1 jerk-limited trajectory
-  float param_mpc_jerk_min = 8.0f; // Velocity-based minimum jerk limit
-  float param_mpc_jerk_max = 20.f; // Velocity-based maximum jerk limit
-  float param_acc_up_max = 10.0f;   // Maximum vertical acceleration in velocity controlled modes upward
-  float param_mpc_z_vel_max_up = 3.0f;   // Maximum vertical ascent velocity
-  float param_mpc_acc_down_max = 10.0f; // Maximum vertical acceleration in velocity controlled modes down
-  float param_mpc_vel_max_dn = 1.0f; // Maximum vertical descent velocity
-  float param_mpc_acc_hor = 5.0f;  // Maximum horizontal acceleration for auto mode and
+  int param_mpc_auto_mode = -1; // Auto sub-mode - 0: default line tracking, 1 jerk-limited trajectory
+  float param_mpc_jerk_min = NAN; // Velocity-based minimum jerk limit
+  float param_mpc_jerk_max = NAN; // Velocity-based maximum jerk limit
+  float param_acc_up_max = NAN;   // Maximum vertical acceleration in velocity controlled modes upward
+  float param_mpc_z_vel_max_up = NAN;   // Maximum vertical ascent velocity
+  float param_mpc_acc_down_max = NAN; // Maximum vertical acceleration in velocity controlled modes down
+  float param_mpc_vel_max_dn = NAN; // Maximum vertical descent velocity
+  float param_mpc_acc_hor = NAN;  // Maximum horizontal acceleration for auto mode and
                       // maximum deceleration for manual mode
-  float param_mpc_xy_cruise = 1.0f;   // Desired horizontal velocity in mission
-  float param_mpc_tko_speed = 1.0f; // Takeoff climb rate
-  float param_mpc_land_speed = 0.7f;   // Landing descend rate
+  float param_mpc_xy_cruise = NAN;   // Desired horizontal velocity in mission
+  float param_mpc_tko_speed = NAN; // Takeoff climb rate
+  float param_mpc_land_speed = NAN;   // Landing descend rate
   // limitations given by sensors
-  float param_ekf2_rng_a_hmax = 5.0f;
-  float param_ekf2_rng_a_vmax = 5.0f;
+  float param_ekf2_rng_a_hmax = NAN;
+  float param_ekf2_rng_a_vmax = NAN;
 
-  float param_mpc_col_prev_d = -1.0f; // Collision Prevention distance to keep from obstacle. -1 for disabled
+  float param_mpc_col_prev_d = NAN; // Collision Prevention distance to keep from obstacle. -1 for disabled
   // clang-format on
 };
 

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -249,6 +249,11 @@ class LocalPlanner {
   * @brief     starts a iteration of the local planner algorithm
   **/
   void runPlanner();
+
+  /**
+  * @brief     setter method for PX4 Firmware paramters
+  **/
+  void setDefaultPx4Parameters();
 };
 }
 

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -60,6 +60,8 @@ struct ModelParameters {
   // limitations given by sensors
   float param_ekf2_rng_a_hmax = 5.0f;
   float param_ekf2_rng_a_vmax = 5.0f;
+
+  float param_mpc_col_prev_d = -1.0f; // Collision Prevention distance to keep from obstacle. -1 for disabled
   // clang-format on
 };
 
@@ -80,7 +82,7 @@ class LocalPlanner {
   float curr_pitch_deg_;  // for pitch angles the histogram frame matches the
                           // fcu frame
   float velocity_around_obstacles_;
-  float velocity_far_from_obstacles_;
+  float keep_distance_;
   ros::Time integral_time_old_;
   float no_progress_slope_;
   float new_yaw_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -132,6 +132,7 @@ class LocalPlannerNode {
                               /// output data (point cloud, position, ...)
 
   std::mutex data_ready_mutex_;
+  std::mutex px4_params_mutex_;
   std::condition_variable data_ready_cv_;
 
   /**
@@ -219,6 +220,11 @@ class LocalPlannerNode {
   void checkFailsafe(ros::Duration since_last_cloud, ros::Duration since_start,
                      bool& planner_is_healthy, bool& hover);
 
+  /**
+  * @brief     polls PX4 Firmware paramters every 30 seconds
+  **/
+  void checkPx4Parameters();
+
  private:
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
@@ -238,8 +244,6 @@ class LocalPlannerNode {
   ros::Subscriber goal_topic_sub_;
   ros::Subscriber distance_sensor_sub_;
   ros::Subscriber px4_param_sub_;
-
-  ros::Time param_update_time_ = ros::Time(0.0);
 
   std::vector<float> algo_time;
 
@@ -340,11 +344,6 @@ class LocalPlannerNode {
   * @brief     sends out emulated LaserScan data to the flight controller
   **/
   void publishLaserScan() const;
-
-  /**
-  * @brief     polls PX4 Firmware paramters every 30 seconds
-  **/
-  void checkPx4Parameters();
 };
 }
 #endif  // LOCAL_PLANNER_LOCAL_PLANNER_NODE_H

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -68,35 +68,6 @@ struct cameraData {
   bool transformed_;
 };
 
-/**
-* @brief struct to contain the parameters needed for the model based trajectory
-*planning
-* when MPC_AUTO_MODE is set to 1 (default) then all members are used for the
-*jerk limited
-* trajectory on the flight controller side
-* when MPC_AUTO_MODE is set to 0, only up_accl, down_accl, xy_acc are used on
-*the
-* flight controller side
-**/
-struct ModelParameters {
-  // clang-format off
-  int mpc_auto_mode = 1; // Auto sub-mode - 0: default line tracking, 1 jerk-limited trajectory
-  float jerk_min = 8.0f; // Velocity-based jerk limit
-  float up_acc = 10.0f;   // Maximum vertical acceleration in velocity controlled modes upward
-  float up_vel = 3.0f;   // Maximum vertical ascent velocity
-  float down_acc = 10.0f; // Maximum vertical acceleration in velocity controlled modes down
-  float down_vel = 1.0f; // Maximum vertical descent velocity
-  float xy_acc = 5.0f;  // Maximum horizontal acceleration for auto mode and
-                      // maximum deceleration for manual mode
-  float xy_vel = 1.0f;   // Desired horizontal velocity in mission
-  float takeoff_speed = 1.0f; // Takeoff climb rate
-  float land_speed = 0.7f;   // Landing descend rate
-  // limitations given by sensors
-  float distance_sensor_max_height = 5.0f;
-  float distance_sensor_max_vel = 5.0f;
-  // clang-format on
-};
-
 enum class MAV_STATE {
   MAV_STATE_UNINIT,
   MAV_STATE_BOOT,
@@ -125,8 +96,6 @@ class LocalPlannerNode {
   std::atomic<bool> should_exit_{false};
 
   std::vector<cameraData> cameras_;
-
-  ModelParameters model_params_;
 
   ros::CallbackQueue pointcloud_queue_;
   ros::CallbackQueue main_queue_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -124,7 +124,6 @@ class LocalPlannerNode {
   ros::Publisher mavros_vel_setpoint_pub_;
   ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher mavros_obstacle_distance_pub_;
-  ros::ServiceClient mavros_set_mode_client_;
   ros::ServiceClient get_px4_param_client_;
   ros::Publisher mavros_system_status_pub_;
   tf::TransformListener* tf_listener_;
@@ -240,6 +239,8 @@ class LocalPlannerNode {
   ros::Subscriber distance_sensor_sub_;
   ros::Subscriber px4_param_sub_;
 
+  ros::Time param_update_time_ = ros::Time(0.0);
+
   std::vector<float> algo_time;
 
   geometry_msgs::TwistStamped vel_msg_;
@@ -339,6 +340,11 @@ class LocalPlannerNode {
   * @brief     sends out emulated LaserScan data to the flight controller
   **/
   void publishLaserScan() const;
+
+  /**
+  * @brief     polls PX4 Firmware paramters every 30 seconds
+  **/
+  void checkPx4Parameters();
 };
 }
 #endif  // LOCAL_PLANNER_LOCAL_PLANNER_NODE_H

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -338,8 +338,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
   out.velocity_around_obstacles = velocity_around_obstacles_;
-  out.velocity_far_from_obstacles =
-      std::isfinite(px4_.param_mpc_xy_cruise) ? px4_.param_mpc_xy_cruise : 3.f;
+  out.velocity_far_from_obstacles = px4_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -36,8 +36,6 @@ void LocalPlanner::dynamicReconfigureSetParams(
   cost_params_.goal_cost_param = config.goal_cost_param_;
   cost_params_.heading_cost_param = config.heading_cost_param_;
   cost_params_.smooth_cost_param = config.smooth_cost_param_;
-  velocity_around_obstacles_ =
-      static_cast<float>(config.velocity_around_obstacles_);
   max_point_age_s_ = static_cast<float>(config.max_point_age_s_);
   velocity_sigmoid_slope_ = static_cast<float>(config.velocity_sigmoid_slope_);
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
@@ -337,7 +335,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
   out.waypoint_type = waypoint_type_;
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
-  out.velocity_around_obstacles = velocity_around_obstacles_;
+  out.velocity_around_obstacles = px4_.param_mpc_xy_cruise / 2.0f;
   out.velocity_far_from_obstacles = px4_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -38,8 +38,6 @@ void LocalPlanner::dynamicReconfigureSetParams(
   cost_params_.smooth_cost_param = config.smooth_cost_param_;
   velocity_around_obstacles_ =
       static_cast<float>(config.velocity_around_obstacles_);
-  velocity_far_from_obstacles_ =
-      static_cast<float>(config.velocity_far_from_obstacles_);
   max_point_age_s_ = static_cast<float>(config.max_point_age_s_);
   velocity_sigmoid_slope_ = static_cast<float>(config.velocity_sigmoid_slope_);
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
@@ -59,7 +57,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
 
   use_vel_setpoints_ = config.use_vel_setpoints_;
   adapt_cost_params_ = config.adapt_cost_params_;
-  send_obstacles_fcu_ = config.send_obstacles_fcu_;
+  send_obstacles_fcu_ = model_params_.param_mpc_col_prev_d > 0.f;
 
   star_planner_->dynamicReconfigureSetStarParams(config, level);
 
@@ -325,7 +323,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
   out.velocity_around_obstacles = velocity_around_obstacles_;
-  out.velocity_far_from_obstacles = velocity_far_from_obstacles_;
+  out.velocity_far_from_obstacles = model_params_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -323,7 +323,8 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
   out.velocity_around_obstacles = velocity_around_obstacles_;
-  out.velocity_far_from_obstacles = std::isfinite(px4_.param_mpc_xy_cruise) ? px4_.param_mpc_xy_cruise : 3.f;
+  out.velocity_far_from_obstacles =
+      std::isfinite(px4_.param_mpc_xy_cruise) ? px4_.param_mpc_xy_cruise : 3.f;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -316,8 +316,6 @@ void LocalPlanner::setDefaultPx4Parameters() {
   px4_.param_mpc_xy_cruise = 3.f;
   px4_.param_mpc_tko_speed = 1.f;
   px4_.param_mpc_land_speed = 0.7f;
-  px4_.param_ekf2_rng_a_hmax = 5.f;
-  px4_.param_ekf2_rng_a_vmax = 5.f;
   px4_.param_mpc_col_prev_d = 4.f;
 }
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -304,6 +304,23 @@ void LocalPlanner::setCurrentVelocity(const Eigen::Vector3f& vel) {
   velocity_ = vel;
 }
 
+void LocalPlanner::setDefaultPx4Parameters() {
+  px4_.param_mpc_auto_mode = 1;
+  px4_.param_mpc_jerk_min = 8.f;
+  px4_.param_mpc_jerk_max = 20.f;
+  px4_.param_acc_up_max = 10.f;
+  px4_.param_mpc_z_vel_max_up = 3.f;
+  px4_.param_mpc_acc_down_max = 10.f;
+  px4_.param_mpc_vel_max_dn = 1.f;
+  px4_.param_mpc_acc_hor = 5.f;
+  px4_.param_mpc_xy_cruise = 3.f;
+  px4_.param_mpc_tko_speed = 1.f;
+  px4_.param_mpc_land_speed = 0.7f;
+  px4_.param_ekf2_rng_a_hmax = 5.f;
+  px4_.param_ekf2_rng_a_vmax = 5.f;
+  px4_.param_mpc_col_prev_d = 4.f;
+}
+
 void LocalPlanner::getTree(
     std::vector<TreeNode>& tree, std::vector<int>& closed_set,
     std::vector<Eigen::Vector3f>& path_node_positions) const {

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -57,7 +57,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
 
   use_vel_setpoints_ = config.use_vel_setpoints_;
   adapt_cost_params_ = config.adapt_cost_params_;
-  send_obstacles_fcu_ = model_params_.param_mpc_col_prev_d > 0.f;
+  send_obstacles_fcu_ = px4_.param_mpc_col_prev_d > 0.f;
 
   star_planner_->dynamicReconfigureSetStarParams(config, level);
 
@@ -323,7 +323,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
   out.velocity_around_obstacles = velocity_around_obstacles_;
-  out.velocity_far_from_obstacles = model_params_.param_mpc_xy_cruise;
+  out.velocity_far_from_obstacles = px4_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -323,7 +323,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
   out.velocity_around_obstacles = velocity_around_obstacles_;
-  out.velocity_far_from_obstacles = px4_.param_mpc_xy_cruise;
+  out.velocity_far_from_obstacles = std::isfinite(px4_.param_mpc_xy_cruise) ? px4_.param_mpc_xy_cruise : 3.f;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -335,8 +335,7 @@ avoidanceOutput LocalPlanner::getAvoidanceOutput() const {
   out.waypoint_type = waypoint_type_;
 
   out.obstacle_ahead = !polar_histogram_.isEmpty();
-  out.velocity_around_obstacles = px4_.param_mpc_xy_cruise / 2.0f;
-  out.velocity_far_from_obstacles = px4_.param_mpc_xy_cruise;
+  out.cruise_velocity = px4_.param_mpc_xy_cruise;
   out.last_path_time = last_path_time_;
 
   out.take_off_pose = take_off_pose_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -376,57 +376,57 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
   // add new else if case with correct value type
 
   if (msg.param_id == "EKF2_RNG_A_HMAX") {
-    local_planner_->model_params_.param_ekf2_rng_a_hmax = msg.value.real;
+    local_planner_->px4_.param_ekf2_rng_a_hmax = msg.value.real;
   } else if (msg.param_id == "EKF2_RNG_A_VMAX") {
-    local_planner_->model_params_.param_ekf2_rng_a_vmax = msg.value.real;
+    local_planner_->px4_.param_ekf2_rng_a_vmax = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_DOWN_MAX") {
-    printf("model parameter acceleration down is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_acc_down_max, msg.value.real);
-    local_planner_->model_params_.param_mpc_acc_down_max = msg.value.real;
+    ROS_INFO("parameter acceleration down is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_acc_down_max, msg.value.real);
+    local_planner_->px4_.param_mpc_acc_down_max = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_HOR") {
-    printf("model parameter acceleration horizontal is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_acc_hor, msg.value.real);
-    local_planner_->model_params_.param_mpc_acc_hor = msg.value.real;
+    ROS_INFO("parameter acceleration horizontal is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_acc_hor, msg.value.real);
+    local_planner_->px4_.param_mpc_acc_hor = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_UP_MAX") {
-    printf("model parameter acceleration up is set from  %f to %f \n",
-           local_planner_->model_params_.param_acc_up_max, msg.value.real);
-    local_planner_->model_params_.param_acc_up_max = msg.value.real;
+    ROS_INFO("parameter acceleration up is set from  %f to %f \n",
+           local_planner_->px4_.param_acc_up_max, msg.value.real);
+    local_planner_->px4_.param_acc_up_max = msg.value.real;
   } else if (msg.param_id == "MPC_AUTO_MODE") {
-    printf("model parameter auto mode is set from  %i to %li \n",
-           local_planner_->model_params_.param_mpc_auto_mode, msg.value.integer);
-    local_planner_->model_params_.param_mpc_auto_mode = msg.value.integer;
+    ROS_INFO("parameter auto mode is set from  %i to %li \n",
+           local_planner_->px4_.param_mpc_auto_mode, msg.value.integer);
+    local_planner_->px4_.param_mpc_auto_mode = msg.value.integer;
   } else if (msg.param_id == "MPC_JERK_MIN") {
-    printf("model parameter jerk minimum is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_jerk_min, msg.value.real);
-    local_planner_->model_params_.param_mpc_jerk_min = msg.value.real;
+    ROS_INFO("parameter jerk minimum is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_jerk_min, msg.value.real);
+    local_planner_->px4_.param_mpc_jerk_min = msg.value.real;
   }  else if (msg.param_id == "MPC_JERK_MAX") {
-    printf("model parameter jerk maximum is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_jerk_max, msg.value.real);
-    local_planner_->model_params_.param_mpc_jerk_max = msg.value.real;
+    ROS_INFO("parameter jerk maximum is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_jerk_max, msg.value.real);
+    local_planner_->px4_.param_mpc_jerk_max = msg.value.real;
   } else if (msg.param_id == "MPC_LAND_SPEED") {
-    printf("model parameter landing speed is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_land_speed, msg.value.real);
-    local_planner_->model_params_.param_mpc_land_speed = msg.value.real;
+    ROS_INFO("parameter landing speed is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_land_speed, msg.value.real);
+    local_planner_->px4_.param_mpc_land_speed = msg.value.real;
   } else if (msg.param_id == "MPC_TKO_SPEED") {
-    printf("model parameter takeoff speed is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_tko_speed, msg.value.real);
-    local_planner_->model_params_.param_mpc_tko_speed = msg.value.real;
+    ROS_INFO("parameter takeoff speed is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_tko_speed, msg.value.real);
+    local_planner_->px4_.param_mpc_tko_speed = msg.value.real;
   } else if (msg.param_id == "MPC_XY_CRUISE") {
-    printf("model parameter velocity horizontal is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_xy_cruise, msg.value.real);
-    local_planner_->model_params_.param_mpc_xy_cruise = msg.value.real;
+    ROS_INFO("parameter velocity horizontal is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_xy_cruise, msg.value.real);
+    local_planner_->px4_.param_mpc_xy_cruise = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_DN") {
-    printf("model parameter velocity down is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_vel_max_dn, msg.value.real);
-    local_planner_->model_params_.param_mpc_vel_max_dn = msg.value.real;
+    ROS_INFO("parameter velocity down is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_vel_max_dn, msg.value.real);
+    local_planner_->px4_.param_mpc_vel_max_dn = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_UP") {
-    printf("model parameter velocity up is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_z_vel_max_up, msg.value.real);
-    local_planner_->model_params_.param_mpc_z_vel_max_up = msg.value.real;
+    ROS_INFO("parameter velocity up is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_z_vel_max_up, msg.value.real);
+    local_planner_->px4_.param_mpc_z_vel_max_up = msg.value.real;
   } else if (msg.param_id == "MPC_COL_PREV_D") {
-    printf("model parameter collision prevention distance is set from  %f to %f \n",
-           local_planner_->model_params_.param_mpc_col_prev_d, msg.value.real);
-    local_planner_->model_params_.param_mpc_col_prev_d = msg.value.real;
+    ROS_INFO("parameter collision prevention distance is set from  %f to %f \n",
+           local_planner_->px4_.param_mpc_col_prev_d, msg.value.real);
+    local_planner_->px4_.param_mpc_col_prev_d = msg.value.real;
   }
 }
 
@@ -442,9 +442,9 @@ void LocalPlannerNode::printPointInfo(double x, double y, double z) {
   beta_z = beta_z + (ALPHA_RES - beta_z % ALPHA_RES);  //[-170,+190]
   beta_e = beta_e + (ALPHA_RES - beta_e % ALPHA_RES);  //[-80,+90]
 
-  printf("----- Point: %f %f %f -----\n", x, y, z);
-  printf("Elevation %d Azimuth %d \n", beta_e, beta_z);
-  printf("-------------------------------------------- \n");
+  ROS_INFO("----- Point: %f %f %f -----\n", x, y, z);
+  ROS_INFO("Elevation %d Azimuth %d \n", beta_e, beta_z);
+  ROS_INFO("-------------------------------------------- \n");
 }
 
 void LocalPlannerNode::pointCloudCallback(

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -376,49 +376,49 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
   // add new else if case with correct value type
 
   if (msg.param_id == "EKF2_RNG_A_HMAX") {
-    model_params_.distance_sensor_max_height = msg.value.real;
+    local_planner_->model_params_.param_ekf2_rng_a_hmax = msg.value.real;
   } else if (msg.param_id == "EKF2_RNG_A_VMAX") {
-    model_params_.distance_sensor_max_vel = msg.value.real;
+    local_planner_->model_params_.param_ekf2_rng_a_vmax = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_DOWN_MAX") {
     printf("model parameter acceleration down is set from  %f to %f \n",
-           model_params_.down_acc, msg.value.real);
-    model_params_.down_acc = msg.value.real;
+           local_planner_->model_params_.param_mpc_acc_down_max, msg.value.real);
+    local_planner_->model_params_.param_mpc_acc_down_max = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_HOR") {
     printf("model parameter acceleration horizontal is set from  %f to %f \n",
-           model_params_.xy_acc, msg.value.real);
-    model_params_.xy_acc = msg.value.real;
+           local_planner_->model_params_.param_mpc_acc_hor, msg.value.real);
+    local_planner_->model_params_.param_mpc_acc_hor = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_UP_MAX") {
     printf("model parameter acceleration up is set from  %f to %f \n",
-           model_params_.up_acc, msg.value.real);
-    model_params_.up_acc = msg.value.real;
+           local_planner_->model_params_.param_acc_up_max, msg.value.real);
+    local_planner_->model_params_.param_acc_up_max = msg.value.real;
   } else if (msg.param_id == "MPC_AUTO_MODE") {
     printf("model parameter auto mode is set from  %i to %li \n",
-           model_params_.mpc_auto_mode, msg.value.integer);
-    model_params_.mpc_auto_mode = msg.value.integer;
+           local_planner_->model_params_.param_mpc_auto_mode, msg.value.integer);
+    local_planner_->model_params_.param_mpc_auto_mode = msg.value.integer;
   } else if (msg.param_id == "MPC_JERK_MIN") {
     printf("model parameter jerk minimum is set from  %f to %f \n",
-           model_params_.jerk_min, msg.value.real);
-    model_params_.jerk_min = msg.value.real;
+           local_planner_->model_params_.param_mpc_jerk_min, msg.value.real);
+    local_planner_->model_params_.param_mpc_jerk_min = msg.value.real;
   } else if (msg.param_id == "MPC_LAND_SPEED") {
     printf("model parameter landing speed is set from  %f to %f \n",
-           model_params_.land_speed, msg.value.real);
-    model_params_.land_speed = msg.value.real;
+           local_planner_->model_params_.param_mpc_land_speed, msg.value.real);
+    local_planner_->model_params_.param_mpc_land_speed = msg.value.real;
   } else if (msg.param_id == "MPC_TKO_SPEED") {
     printf("model parameter takeoff speed is set from  %f to %f \n",
-           model_params_.takeoff_speed, msg.value.real);
-    model_params_.takeoff_speed = msg.value.real;
+           local_planner_->model_params_.param_mpc_tko_speed, msg.value.real);
+    local_planner_->model_params_.param_mpc_tko_speed = msg.value.real;
   } else if (msg.param_id == "MPC_XY_CRUISE") {
     printf("model parameter velocity horizontal is set from  %f to %f \n",
-           model_params_.xy_vel, msg.value.real);
-    model_params_.xy_vel = msg.value.real;
+           local_planner_->model_params_.param_mpc_xy_cruise, msg.value.real);
+    local_planner_->model_params_.param_mpc_xy_cruise = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_DN") {
     printf("model parameter velocity down is set from  %f to %f \n",
-           model_params_.down_acc, msg.value.real);
-    model_params_.down_vel = msg.value.real;
+           local_planner_->model_params_.param_mpc_vel_max_dn, msg.value.real);
+    local_planner_->model_params_.param_mpc_vel_max_dn = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_UP") {
     printf("model parameter velocity up is set from  %f to %f \n",
-           model_params_.up_vel, msg.value.real);
-    model_params_.up_vel = msg.value.real;
+           local_planner_->model_params_.param_mpc_z_vel_max_up, msg.value.real);
+    local_planner_->model_params_.param_mpc_z_vel_max_up = msg.value.real;
   }
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -419,6 +419,10 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
     printf("model parameter velocity up is set from  %f to %f \n",
            local_planner_->model_params_.param_mpc_z_vel_max_up, msg.value.real);
     local_planner_->model_params_.param_mpc_z_vel_max_up = msg.value.real;
+  } else if (msg.param_id == "MPC_COL_PREV_D") {
+    printf("model parameter collision prevention distance is set from  %f to %f \n",
+           local_planner_->model_params_.param_mpc_col_prev_d, msg.value.real);
+    local_planner_->model_params_.param_mpc_col_prev_d = msg.value.real;
   }
 }
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -426,6 +426,22 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
   }
 }
 
+void LocalPlannerNode::checkPx4Parameters() {
+  if ((ros::Time::now() - param_update_time_) > ros::Duration(30.0)) {
+    param_update_time_ = ros::Time::now();
+    mavros_msgs::ParamGet req;
+    req.request.param_id = "MPC_XY_CRUISE";
+    if (get_px4_param_client_.call(req) && req.response.success) {
+      local_planner_->px4_.param_mpc_xy_cruise = req.response.value.real;
+    }
+    req.response.success = false;
+    req.request.param_id = "MPC_COL_PREV_D";
+    if (get_px4_param_client_.call(req) && req.response.success) {
+      local_planner_->px4_.param_mpc_col_prev_d = req.response.value.real;
+    }
+  }
+}
+
 void LocalPlannerNode::printPointInfo(double x, double y, double z) {
   Eigen::Vector3f drone_pos = local_planner_->getPosition();
   int beta_z = floor((atan2(x - drone_pos.x(), y - drone_pos.y()) * 180.0 /
@@ -571,6 +587,7 @@ void LocalPlannerNode::threadFunction() {
       std::lock_guard<std::mutex> guard(running_mutex_);
       never_run_ = false;
       std::clock_t start_time = std::clock();
+      checkPx4Parameters();
       local_planner_->runPlanner();
       visualizer_.visualizePlannerData(
           *(local_planner_.get()), newest_waypoint_position_,

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -381,51 +381,51 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
     local_planner_->px4_.param_ekf2_rng_a_vmax = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_DOWN_MAX") {
     ROS_INFO("parameter acceleration down is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_acc_down_max, msg.value.real);
+             local_planner_->px4_.param_mpc_acc_down_max, msg.value.real);
     local_planner_->px4_.param_mpc_acc_down_max = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_HOR") {
     ROS_INFO("parameter acceleration horizontal is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_acc_hor, msg.value.real);
+             local_planner_->px4_.param_mpc_acc_hor, msg.value.real);
     local_planner_->px4_.param_mpc_acc_hor = msg.value.real;
   } else if (msg.param_id == "MPC_ACC_UP_MAX") {
     ROS_INFO("parameter acceleration up is set from  %f to %f \n",
-           local_planner_->px4_.param_acc_up_max, msg.value.real);
+             local_planner_->px4_.param_acc_up_max, msg.value.real);
     local_planner_->px4_.param_acc_up_max = msg.value.real;
   } else if (msg.param_id == "MPC_AUTO_MODE") {
     ROS_INFO("parameter auto mode is set from  %i to %li \n",
-           local_planner_->px4_.param_mpc_auto_mode, msg.value.integer);
+             local_planner_->px4_.param_mpc_auto_mode, msg.value.integer);
     local_planner_->px4_.param_mpc_auto_mode = msg.value.integer;
   } else if (msg.param_id == "MPC_JERK_MIN") {
     ROS_INFO("parameter jerk minimum is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_jerk_min, msg.value.real);
+             local_planner_->px4_.param_mpc_jerk_min, msg.value.real);
     local_planner_->px4_.param_mpc_jerk_min = msg.value.real;
-  }  else if (msg.param_id == "MPC_JERK_MAX") {
+  } else if (msg.param_id == "MPC_JERK_MAX") {
     ROS_INFO("parameter jerk maximum is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_jerk_max, msg.value.real);
+             local_planner_->px4_.param_mpc_jerk_max, msg.value.real);
     local_planner_->px4_.param_mpc_jerk_max = msg.value.real;
   } else if (msg.param_id == "MPC_LAND_SPEED") {
     ROS_INFO("parameter landing speed is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_land_speed, msg.value.real);
+             local_planner_->px4_.param_mpc_land_speed, msg.value.real);
     local_planner_->px4_.param_mpc_land_speed = msg.value.real;
   } else if (msg.param_id == "MPC_TKO_SPEED") {
     ROS_INFO("parameter takeoff speed is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_tko_speed, msg.value.real);
+             local_planner_->px4_.param_mpc_tko_speed, msg.value.real);
     local_planner_->px4_.param_mpc_tko_speed = msg.value.real;
   } else if (msg.param_id == "MPC_XY_CRUISE") {
     ROS_INFO("parameter velocity horizontal is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_xy_cruise, msg.value.real);
+             local_planner_->px4_.param_mpc_xy_cruise, msg.value.real);
     local_planner_->px4_.param_mpc_xy_cruise = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_DN") {
     ROS_INFO("parameter velocity down is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_vel_max_dn, msg.value.real);
+             local_planner_->px4_.param_mpc_vel_max_dn, msg.value.real);
     local_planner_->px4_.param_mpc_vel_max_dn = msg.value.real;
   } else if (msg.param_id == "MPC_Z_VEL_MAX_UP") {
     ROS_INFO("parameter velocity up is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_z_vel_max_up, msg.value.real);
+             local_planner_->px4_.param_mpc_z_vel_max_up, msg.value.real);
     local_planner_->px4_.param_mpc_z_vel_max_up = msg.value.real;
   } else if (msg.param_id == "MPC_COL_PREV_D") {
     ROS_INFO("parameter collision prevention distance is set from  %f to %f \n",
-           local_planner_->px4_.param_mpc_col_prev_d, msg.value.real);
+             local_planner_->px4_.param_mpc_col_prev_d, msg.value.real);
     local_planner_->px4_.param_mpc_col_prev_d = msg.value.real;
   }
 }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -399,6 +399,10 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
     printf("model parameter jerk minimum is set from  %f to %f \n",
            local_planner_->model_params_.param_mpc_jerk_min, msg.value.real);
     local_planner_->model_params_.param_mpc_jerk_min = msg.value.real;
+  }  else if (msg.param_id == "MPC_JERK_MAX") {
+    printf("model parameter jerk maximum is set from  %f to %f \n",
+           local_planner_->model_params_.param_mpc_jerk_max, msg.value.real);
+    local_planner_->model_params_.param_mpc_jerk_max = msg.value.real;
   } else if (msg.param_id == "MPC_LAND_SPEED") {
     printf("model parameter landing speed is set from  %f to %f \n",
            local_planner_->model_params_.param_mpc_land_speed, msg.value.real);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -375,11 +375,7 @@ void LocalPlannerNode::px4ParamsCallback(const mavros_msgs::Param& msg) {
   // when adding new parameter to the struct ModelParameters,
   // add new else if case with correct value type
 
-  if (msg.param_id == "EKF2_RNG_A_HMAX") {
-    local_planner_->px4_.param_ekf2_rng_a_hmax = msg.value.real;
-  } else if (msg.param_id == "EKF2_RNG_A_VMAX") {
-    local_planner_->px4_.param_ekf2_rng_a_vmax = msg.value.real;
-  } else if (msg.param_id == "MPC_ACC_DOWN_MAX") {
+  if (msg.param_id == "MPC_ACC_DOWN_MAX") {
     ROS_INFO("parameter acceleration down is set from  %f to %f \n",
              local_planner_->px4_.param_mpc_acc_down_max, msg.value.real);
     local_planner_->px4_.param_mpc_acc_down_max = msg.value.real;

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -25,6 +25,8 @@ int main(int argc, char** argv) {
 
   std::thread worker(&LocalPlannerNode::threadFunction, &Node);
 
+  std::thread worker_params(&LocalPlannerNode::checkPx4Parameters, &Node);
+
   // spin node, execute callbacks
   while (ros::ok()) {
     hover = false;
@@ -79,6 +81,7 @@ int main(int argc, char** argv) {
   Node.should_exit_ = true;
   Node.data_ready_cv_.notify_all();
   worker.join();
+  worker_params.join();
 
   for (size_t i = 0; i < Node.cameras_.size(); ++i) {
     Node.cameras_[i].cloud_ready_cv_->notify_all();

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -214,11 +214,7 @@ void WaypointGenerator::nextSmoothYaw(float dt) {
 }
 
 void WaypointGenerator::adaptSpeed() {
-  if (!planner_info_.obstacle_ahead) {
-    speed_ = planner_info_.velocity_far_from_obstacles;
-  } else {
-    speed_ = planner_info_.velocity_around_obstacles;
-  }
+  speed_ = planner_info_.cruise_velocity;
 
   // If the goal is so close, that the speed-adapted way point would overreach
   Eigen::Vector3f pose_to_goal = goal_ - position_;

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -17,9 +17,9 @@ class LocalPlannerTests : public ::testing::Test {
   void SetUp() override {
     ros::Time::init();
 
+    planner.setDefaultPx4Parameters();
     avoidance::LocalPlannerNodeConfig config =
         avoidance::LocalPlannerNodeConfig::__getDefault__();
-    config.send_obstacles_fcu_ = true;
     planner.dynamicReconfigureSetParams(config, 1);
 
     // start with basic pose

--- a/local_planner/test/test_waypoint_generator.cpp
+++ b/local_planner/test/test_waypoint_generator.cpp
@@ -25,8 +25,7 @@ class WaypointGeneratorTests : public ::testing::Test,
 
     avoidance_output.waypoint_type = direct;
     avoidance_output.obstacle_ahead = false;
-    avoidance_output.velocity_around_obstacles = 1.0;
-    avoidance_output.velocity_far_from_obstacles = 3.0;
+    avoidance_output.cruise_velocity = 1.0;
     avoidance_output.last_path_time = ros::Time(0.28);
 
     PolarPoint p_pol = histogramIndexToPolar(15, 35, 6, 0.f);


### PR DESCRIPTION
- rename parameters using Firmware convention
- use MPC_XY_CRUISE as max velocity when there aren't any obstacles
- use MPC_COL_PREV_D to decide if the distance data are sent to the Firmware
- remove unused dynamic reconfigure paramters
- add MPC_JERK_MAX since only the min was retrieved 