### PR TITLE
use the current position in reprojection

### DIFF
--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -358,10 +358,10 @@ void LocalPlanner::reprojectPoints(Histogram histogram) {
         p_pol[3].z -= half_res;
 
         // transform from Polar to Cartesian
-        temp_array[0] = polarToCartesian(p_pol[0], position_old_);
-        temp_array[1] = polarToCartesian(p_pol[1], position_old_);
-        temp_array[2] = polarToCartesian(p_pol[2], position_old_);
-        temp_array[3] = polarToCartesian(p_pol[3], position_old_);
+        temp_array[0] = polarToCartesian(p_pol[0], position_);
+        temp_array[1] = polarToCartesian(p_pol[1], position_);
+        temp_array[2] = polarToCartesian(p_pol[2], position_);
+        temp_array[3] = polarToCartesian(p_pol[3], position_);
 
         for (int i = 0; i < 4; i++) {
           dist = (position_ - temp_array[i]).norm();


### PR DESCRIPTION
Bug was introduced in [#278](https://github.com/PX4/avoidance/pull/278) found by @sunzj 

As now the current histogram is reprojected, also the current position should be used.