### PR TITLE
Changes for compatibility with new librealsense

### DIFF
--- a/local_planner/launch/rs_depthcloud.launch
+++ b/local_planner/launch/rs_depthcloud.launch
@@ -55,12 +55,7 @@ Processing enabled by this node:
   <arg name="depth_height"        default="480"/>
   <arg name="enable_depth"        default="true"/>
 
-  <arg name="infra1_width"        default="480"/>
-  <arg name="infra1_height"       default="270"/>
   <arg name="enable_infra1"       default="true"/>
-
-  <arg name="infra2_width"        default="480"/>
-  <arg name="infra2_height"       default="270"/>
   <arg name="enable_infra2"       default="true"/>
 
   <arg name="color_width"         default="640"/>
@@ -69,12 +64,9 @@ Processing enabled by this node:
 
   <arg name="fisheye_fps"         default="30"/>
   <arg name="depth_fps"           default="30"/>
-  <arg name="infra1_fps"          default="30"/>
-  <arg name="infra2_fps"          default="30"/>
   <arg name="color_fps"           default="30"/>
   <arg name="gyro_fps"            default="1000"/>
   <arg name="accel_fps"           default="1000"/>
-  <arg name="enable_imu"          default="true"/>
 
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="true"/>
@@ -135,22 +127,14 @@ Processing enabled by this node:
       <arg name="color_height"             value="$(arg color_height)"/>
       <arg name="enable_color"             value="$(arg enable_color)"/>
 
-      <arg name="infra1_width"             value="$(arg infra1_width)"/>
-      <arg name="infra1_height"            value="$(arg infra1_height)"/>
       <arg name="enable_infra1"            value="$(arg enable_infra1)"/>
-
-      <arg name="infra2_width"             value="$(arg infra2_width)"/>
-      <arg name="infra2_height"            value="$(arg infra2_height)"/>
       <arg name="enable_infra2"            value="$(arg enable_infra2)"/>
 
       <arg name="fisheye_fps"              value="$(arg fisheye_fps)"/>
       <arg name="depth_fps"                value="$(arg depth_fps)"/>
-      <arg name="infra1_fps"               value="$(arg infra1_fps)"/>
-      <arg name="infra2_fps"               value="$(arg infra2_fps)"/>
       <arg name="color_fps"                value="$(arg color_fps)"/>
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
-      <arg name="enable_imu"               value="$(arg enable_imu)"/>
     </include>
 
 

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -63,10 +63,7 @@ for camera in $CAMERA_CONFIGS; do
 				<arg name="tf_prefix"             value="$1" />
 				<arg name="serial_no"             value="$2"/>
 				<arg name="depth_fps"             value="$DEPTH_CAMERA_FRAME_RATE"/>
-				<arg name="infra1_fps"            value="$DEPTH_CAMERA_FRAME_RATE"/>
-				<arg name="infra2_fps"            value="$DEPTH_CAMERA_FRAME_RATE"/>
 				<arg name="enable_pointcloud"     value="false"/>
-				<arg name="enable_imu"            value="false"/>
 				<arg name="enable_fisheye"        value="false"/>
 			</include>
 		EOM


### PR DESCRIPTION
Remove parameters which were removed in the Realsense ROS wrapper, which is required for the new librealsense.

Tested against librealsense 2.20.0 and the intel-ros/realsense 2.2.3