### PR TITLE
Fov empty priority

### DIFF
--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -7,6 +7,7 @@
 #include "candidate_direction.h"
 #include "cost_parameters.h"
 #include "histogram.h"
+#include "planner_functions.h"
 
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
@@ -71,7 +72,6 @@ class LocalPlanner {
   bool reach_altitude_ = false;
   bool waypoint_outside_FOV_ = false;
 
-  int e_FOV_max_, e_FOV_min_;
   size_t dist_incline_window_size_ = 50;
   int origin_;
   int tree_age_ = 0;
@@ -90,12 +90,12 @@ class LocalPlanner {
   float smoothing_margin_degrees_ = 30.f;
   float max_point_age_s_ = 10;
 
+  FOV_indices FOV_;
+
   waypoint_choice waypoint_type_;
   ros::Time last_path_time_;
   ros::Time last_pointcloud_process_time_;
 
-  std::vector<int> e_FOV_idx_;
-  std::vector<int> z_FOV_idx_;
   std::deque<float> goal_dist_incline_;
   std::vector<float> cost_path_candidates_;
   std::vector<int> cost_idx_sorted_;
@@ -142,8 +142,8 @@ class LocalPlanner {
   void generateHistogramImage(Histogram& histogram);
 
  public:
-  float h_FOV_ = 59.0f;
-  float v_FOV_ = 46.0f;
+  float h_FOV_deg_ = 59.0f;
+  float v_FOV_deg_ = 46.0f;
   Box histogram_box_;
   std::vector<uint8_t> histogram_image_data_;
   std::vector<uint8_t> cost_image_data_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -17,6 +17,12 @@
 
 namespace avoidance {
 
+struct FOV_indices {
+  std::vector<int> z_idx_vec;
+  int e_idx_min;
+  int e_idx_max;
+};
+
 /**
 * @brief      crops and subsamples the incomming data, then combines it with
 *             the data from the last timestep
@@ -38,16 +44,13 @@ void processPointcloud(
 * @brief      calculates the histogram cells within the Field of View
 * @param[in]  h_FOV, horizontal Field of View [rad]
 * @param[in]  v_FOV, vertical Field of View [rad]
-* @param[out] z_FOV_idx, array of azimuth indexes inside the FOV
-* @param[out] e_FOV_min, minimum elevation index inside the FOV
-* @param[out] e_FOV_max, maximum elevation index inside the FOV
+* @param[out] FOV, indices lying inside the current FOV
 * @param[in]  yaw, vehicle yaw [rad]
 * @param[in]  pitch, vehicle pitch [rad]
 * @note       azimuth angle is wrapped, elevation is not
 **/
-void calculateFOV(float h_FOV, float v_FOV, std::vector<int>& z_FOV_idx,
-                  int& e_FOV_min, int& e_FOV_max, float yaw_fcu_frame,
-                  float pitch_fcu_frame);
+void calculateFOV(float h_FOV, float v_fov, FOV_indices& FOV,
+                  float yaw_fcu_frame, float pitch_fcu_frame);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -29,6 +29,7 @@ struct FOV_indices {
 * @param      final_cloud, processed data to be used for planning
 * @param[in]  complete_cloud, array of pointclouds from the sensors
 * @param[in]  histogram_box, geometry definition of the bounding box
+* @param[in]  FOV, histogram indices currently lying inside the FOV
 * @param[in]  position, current vehicle position
 * @param[in]  min_realsense_dist, minimum sensor range [m]
 * @param[in]  max_age, maximum age (compute cycles) to keep data
@@ -37,7 +38,7 @@ struct FOV_indices {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const Eigen::Vector3f& position,
+    Box histogram_box, const FOV_indices& FOV, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s);
 
 /**
@@ -51,6 +52,14 @@ void processPointcloud(
 **/
 void calculateFOV(float h_FOV, float v_fov, FOV_indices& FOV,
                   float yaw_fcu_frame, float pitch_fcu_frame);
+
+/**
+* @brief      determines whether point is inside FOV
+* @param[in]  FOV, indices lying inside the current FOV
+* @param[in]  point_idx, histogram indices of the point
+* @return     whether point is inside the FOV
+**/
+bool pointInsideFOV(const FOV_indices& FOV, const Eigen::Vector2i& point_idx);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -59,7 +59,7 @@ void calculateFOV(float h_FOV, float v_fov, FOV_indices& FOV,
 * @param[in]  point_idx, histogram indices of the point
 * @return     whether point is inside the FOV
 **/
-bool pointInsideFOV(const FOV_indices& FOV, const Eigen::Vector2i& point_idx);
+bool pointInsideFOV(const FOV_indices& FOV, const PolarPoint& p_pol);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -21,8 +21,9 @@ namespace avoidance {
 class TreeNode;
 
 class StarPlanner {
-  float h_FOV_ = 59.0f;
-  float v_FOV_ = 46.0f;
+  float h_FOV_deg_ = 59.0f;
+  float v_FOV_deg_ = 46.0f;
+
   int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   float tree_node_distance_ = 1.0f;

--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -47,8 +47,8 @@ class WaypointGenerator {
   float setpoint_yaw_velocity_ = 0.0f;
   float heading_at_goal_ = NAN;
   float speed_ = 1.0f;
-  float h_FOV_ = 59.0f;
-  float v_FOV_ = 46.0f;
+  float h_FOV_deg_ = 59.0f;
+  float v_FOV_deg_ = 46.0f;
 
   Eigen::Vector3f hover_position_;
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -87,7 +87,7 @@ void LocalPlanner::runPlanner() {
 
   float elapsed_since_last_processing = static_cast<float>(
       (ros::Time::now() - last_pointcloud_process_time_).toSec());
-  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_,
+  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, FOV_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing);
   last_pointcloud_process_time_ = ros::Time::now();

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -1,7 +1,6 @@
 #include "local_planner/local_planner.h"
 
 #include "local_planner/common.h"
-#include "local_planner/planner_functions.h"
 #include "local_planner/star_planner.h"
 #include "local_planner/tree_node.h"
 
@@ -80,9 +79,9 @@ void LocalPlanner::runPlanner() {
            static_cast<int>(original_cloud_vector_.size()));
 
   // calculate Field of View
-  z_FOV_idx_.clear();
-  calculateFOV(h_FOV_, v_FOV_, z_FOV_idx_, e_FOV_min_, e_FOV_max_,
-               curr_yaw_histogram_frame_deg_, curr_pitch_deg_);
+  FOV_.z_idx_vec.clear();
+  calculateFOV(h_FOV_deg_, v_FOV_deg_, FOV_, curr_yaw_histogram_frame_deg_,
+               curr_pitch_deg_);
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
@@ -166,7 +165,7 @@ void LocalPlanner::determineStrategy() {
                     smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
 
       star_planner_->setParams(cost_params_);
-      star_planner_->setFOV(h_FOV_, v_FOV_);
+      star_planner_->setFOV(h_FOV_deg_, v_FOV_deg_);
       star_planner_->setPointcloud(final_cloud_);
 
       // set last chosen direction for smoothing
@@ -194,10 +193,10 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
 
   // turn idxs 180 degress to point to local north instead of south
   std::vector<int> z_FOV_idx_north;
-  z_FOV_idx_north.reserve(z_FOV_idx_.size());
+  z_FOV_idx_north.reserve(FOV_.z_idx_vec.size());
 
-  for (size_t i = 0; i < z_FOV_idx_.size(); i++) {
-    int new_idx = z_FOV_idx_[i] + GRID_LENGTH_Z / 2;
+  for (size_t i = 0; i < FOV_.z_idx_vec.size(); i++) {
+    int new_idx = FOV_.z_idx_vec[i] + GRID_LENGTH_Z / 2;
 
     if (new_idx >= GRID_LENGTH_Z) {
       new_idx = new_idx - GRID_LENGTH_Z;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -487,13 +487,13 @@ void LocalPlannerNode::cameraInfoCallback(
   // v_fov = 2 * atan (image_height / (2 * focal_length_y))
   // Assumption: if there are n cameras the total horizonal field of view is n
   // times the horizontal field of view of a single camera
-  local_planner_->h_FOV_ = static_cast<float>(
+  local_planner_->h_FOV_deg_ = static_cast<float>(
       static_cast<double>(cameras_.size()) * 2.0 *
       atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
-  local_planner_->v_FOV_ = static_cast<float>(
+  local_planner_->v_FOV_deg_ = static_cast<float>(
       2.0 * atan(static_cast<double>(msg->height) / (2.0 * msg->K[4])) * 180.0 /
       M_PI);
-  wp_generator_->setFOV(local_planner_->h_FOV_, local_planner_->v_FOV_);
+  wp_generator_->setFOV(local_planner_->h_FOV_deg_, local_planner_->v_FOV_deg_);
 }
 
 void LocalPlannerNode::fillUnusedTrajectoryPoint(

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -59,7 +59,7 @@ void processPointcloud(
         PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
         if (high_res_histogram.get_dist(p_ind.y(), p_ind.x()) == 0 &&
-            xyzi.intensity < max_age && !pointInsideFOV(FOV, p_ind)) {
+            xyzi.intensity < max_age && !pointInsideFOV(FOV, p_pol)) {
           final_cloud.points.push_back(
               toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
           high_res_histogram.set_dist(p_ind.y(), p_ind.x(), 1);
@@ -105,11 +105,11 @@ void calculateFOV(float h_fov, float v_fov, FOV_indices& FOV,
   }
 }
 
-bool pointInsideFOV(const FOV_indices& FOV, const Eigen::Vector2i& point_idx) {
+bool pointInsideFOV(const FOV_indices& FOV, const PolarPoint& p_pol) {
+  Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES);
   bool inside_FOV_z = std::find(FOV.z_idx_vec.begin(), FOV.z_idx_vec.end(),
-                                point_idx.x()) != FOV.z_idx_vec.end();
-  bool inside_FOV_e =
-      point_idx.y() > FOV.e_idx_min && point_idx.y() < FOV.e_idx_max;
+                                p_ind.x()) != FOV.z_idx_vec.end();
+  bool inside_FOV_e = p_ind.y() > FOV.e_idx_min && p_ind.y() < FOV.e_idx_max;
   return inside_FOV_z && inside_FOV_e;
 }
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -13,7 +13,7 @@ namespace avoidance {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const Eigen::Vector3f& position,
+    Box histogram_box, const FOV_indices& FOV, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s) {
   pcl::PointCloud<pcl::PointXYZI> old_cloud;
   std::swap(final_cloud, old_cloud);
@@ -59,7 +59,7 @@ void processPointcloud(
         PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
         if (high_res_histogram.get_dist(p_ind.y(), p_ind.x()) == 0 &&
-            xyzi.intensity < max_age) {
+            xyzi.intensity < max_age && !pointInsideFOV(FOV, p_ind)) {
           final_cloud.points.push_back(
               toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
           high_res_histogram.set_dist(p_ind.y(), p_ind.x(), 1);
@@ -103,6 +103,14 @@ void calculateFOV(float h_fov, float v_fov, FOV_indices& FOV,
       FOV.z_idx_vec.push_back(i);
     }
   }
+}
+
+bool pointInsideFOV(const FOV_indices& FOV, const Eigen::Vector2i& point_idx) {
+  bool inside_FOV_z = std::find(FOV.z_idx_vec.begin(), FOV.z_idx_vec.end(),
+                                point_idx.x()) != FOV.z_idx_vec.end();
+  bool inside_FOV_e =
+      point_idx.y() > FOV.e_idx_min && point_idx.y() < FOV.e_idx_max;
+  return inside_FOV_z && inside_FOV_e;
 }
 
 // Generate new histogram from pointcloud

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -75,9 +75,8 @@ void processPointcloud(
 }
 
 // Calculate FOV. Azimuth angle is wrapped, elevation is not!
-void calculateFOV(float h_fov, float v_fov, std::vector<int>& z_FOV_idx,
-                  int& e_FOV_min, int& e_FOV_max, float yaw_deg_histogram_frame,
-                  float pitch_deg) {
+void calculateFOV(float h_fov, float v_fov, FOV_indices& FOV,
+                  float yaw_deg_histogram_frame, float pitch_deg) {
   PolarPoint max_angle(pitch_deg + v_fov / 2.0f,
                        yaw_deg_histogram_frame + h_fov / 2.0f, 1.f);
   PolarPoint min_angle(pitch_deg - v_fov / 2.0f,
@@ -85,23 +84,23 @@ void calculateFOV(float h_fov, float v_fov, std::vector<int>& z_FOV_idx,
   Eigen::Vector2i max_ind = polarToHistogramIndex(max_angle, ALPHA_RES);
   Eigen::Vector2i min_ind = polarToHistogramIndex(min_angle, ALPHA_RES);
 
-  e_FOV_max = max_ind.y();
-  e_FOV_min = min_ind.y();
+  FOV.e_idx_max = max_ind.y();
+  FOV.e_idx_min = min_ind.y();
 
   // indices not wrapped
   if (max_ind.x() > min_ind.x()) {
     for (int i = min_ind.x(); i <= max_ind.x(); i++) {
-      z_FOV_idx.push_back(i);
+      FOV.z_idx_vec.push_back(i);
     }
   }
 
   // indices wrapped
   if (min_ind.x() > max_ind.x()) {
     for (int i = 0; i <= max_ind.x(); i++) {
-      z_FOV_idx.push_back(i);
+      FOV.z_idx_vec.push_back(i);
     }
     for (int i = min_ind.x(); i < GRID_LENGTH_Z; i++) {
-      z_FOV_idx.push_back(i);
+      FOV.z_idx_vec.push_back(i);
     }
   }
 }

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -30,8 +30,8 @@ void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) {
 }
 
 void StarPlanner::setFOV(float h_FOV, float v_FOV) {
-  h_FOV_ = h_FOV;
-  v_FOV_ = v_FOV;
+  h_FOV_deg_ = h_FOV;
+  v_FOV_deg_ = v_FOV;
 }
 
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
@@ -127,10 +127,8 @@ void StarPlanner::buildLookAheadTree() {
     bool hist_is_empty = false;  // unused
 
     // build new histogram
-    std::vector<int> z_FOV_idx;
-    int e_FOV_min, e_FOV_max;
-    calculateFOV(h_FOV_, v_FOV_, z_FOV_idx, e_FOV_min, e_FOV_max,
-                 tree_[origin].yaw_,
+    FOV_indices FOV;
+    calculateFOV(h_FOV_deg_, v_FOV_deg_, FOV, tree_[origin].yaw_,
                  0.0f);  // assume pitch is zero at every node
 
     Histogram histogram = Histogram(ALPHA_RES);

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -76,8 +76,8 @@ void WaypointGenerator::calculateWaypoint() {
 }
 
 void WaypointGenerator::setFOV(float h_FOV, float v_FOV) {
-  h_FOV_ = h_FOV;
-  v_FOV_ = v_FOV;
+  h_FOV_deg_ = h_FOV;
+  v_FOV_deg_ = v_FOV;
 }
 
 void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose,
@@ -236,8 +236,8 @@ void WaypointGenerator::adaptSpeed() {
       angle_diff_deg =
           std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
       angle_diff_deg =
-          std::min(h_FOV_ / 2, angle_diff_deg);  // Clamp at h_FOV/2
-      speed_ *= (1.0f - 2 * angle_diff_deg / h_FOV_);
+          std::min(h_FOV_deg_ / 2, angle_diff_deg);  // Clamp at h_FOV/2
+      speed_ *= (1.0f - 2 * angle_diff_deg / h_FOV_deg_);
     }
 
     // Scale the pose_to_wp by the speed

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -67,7 +67,8 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   // GIVEN: a local planner, a scan with obstacles everywhere, pose and goal
   float shift = 0.f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.h_FOV_ * M_PI_F / 180.f / 2.f);
+  float fov_half_y =
+      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -118,7 +119,8 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // GIVEN: a local planner, a scan with obstacles on the right, pose and goal
   float shift = -0.5f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.h_FOV_ * M_PI_F / 180.f / 2.f);
+  float fov_half_y =
+      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -165,7 +167,8 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   // GIVEN: a local planner, a scan with obstacles on the left, pose and goal
   float shift = 0.5f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.h_FOV_ * M_PI_F / 180.f / 2.f);
+  float fov_half_y =
+      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -183,8 +183,11 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   FOV_indices FOV_zero;  // empty FOV, no remembered points will be forgotten
                          // due to inside FOV
-  FOV_indices FOV_regular;
+  FOV_zero.e_idx_max = 0;
+  FOV_zero.e_idx_min = 0;
+  FOV_zero.z_idx_vec.push_back(0);
 
+  FOV_indices FOV_regular;
   FOV_regular.e_idx_max = 10;
   FOV_regular.e_idx_min = 6;
   FOV_regular.z_idx_vec.push_back(21);


### PR DESCRIPTION
This PR should reduce noise by giving the new data absolute priority inside the FOV. This means that inside the FOV the remembered points are not taken into account. If there is an empty spot inside the FOV it will stay empty even if the remembered points say otherwise.