### PR TITLE
Stop storing status_msg as status

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -96,8 +96,6 @@ class LocalPlannerNode {
                    const bool tf_spin_thread = true);
   ~LocalPlannerNode();
 
-  mavros_msgs::CompanionProcessStatus status_msg_;
-
   std::string world_path_;
   std::atomic<bool> should_exit_{false};
 
@@ -201,6 +199,16 @@ class LocalPlannerNode {
   void publishSystemStatus();
 
   /**
+  * @brief      set avoidance system status
+  **/
+  void setSystemStatus(MAV_STATE state);
+
+  /**
+  * @brief      get avoidance system status
+  **/
+  MAV_STATE getSystemStatus();
+
+  /**
   * @brief      check healthiness of the avoidance system to trigger failsafe in
   *             the FCU
   * @param[in]  since_last_cloud, time elapsed since the last waypoint was
@@ -265,12 +273,17 @@ class LocalPlannerNode {
   geometry_msgs::PoseStamped goal_msg_;
   geometry_msgs::TwistStamped vel_msg_;
   geometry_msgs::PoseStamped prev_goal_;
+  mavros_msgs::Altitude ground_distance_msg_;
+
   bool new_goal_ = false;
+
   NavigationState nav_state_ = NavigationState::none;
-  bool armed_ = false;
+  MAV_STATE companion_state_ = MAV_STATE::MAV_STATE_STANDBY;
+
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;
   tf::TransformListener* tf_listener_;
-  mavros_msgs::Altitude ground_distance_msg_;
+
+  bool armed_ = false;
   bool data_ready_ = false;
   bool hover_;
   bool planner_is_healthy_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -327,7 +327,7 @@ void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
     ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
     ros::Duration since_query = ros::Time::now() - start_query_position;
     if (since_query > ros::Duration(local_planner_->timeout_termination_)) {
-      status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
+      setSystemStatus(MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
       publishSystemStatus();
       if (!position_not_received_error_sent_) {
         // clang-format off

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -82,7 +82,7 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
 
   local_planner_->disable_rise_to_goal_altitude_ =
       disable_rise_to_goal_altitude_;
-  status_msg_.state = (int)MAV_STATE::MAV_STATE_BOOT;
+  setSystemStatus(MAV_STATE::MAV_STATE_BOOT);
 
   hover_ = false;
   planner_is_healthy_ = true;
@@ -359,7 +359,7 @@ void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
   // send waypoint
   if (!never_run_ && planner_is_healthy_) {
     calculateWaypoints(hover_);
-    if (!hover_) status_msg_.state = (int)MAV_STATE::MAV_STATE_ACTIVE;
+    if (!hover_) setSystemStatus(MAV_STATE::MAV_STATE_ACTIVE);
   } else {
     for (size_t i = 0; i < cameras_.size(); ++i) {
       // once the camera info have been set once, unsubscribe from topic
@@ -374,6 +374,13 @@ void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
 
   return;
 }
+
+void LocalPlannerNode::setSystemStatus(MAV_STATE state) {
+  companion_state_ = state;
+}
+
+MAV_STATE LocalPlannerNode::getSystemStatus() { return companion_state_; }
+
 void LocalPlannerNode::calculateWaypoints(bool hover) {
   bool is_airborne = armed_ && (nav_state_ != NavigationState::none);
 
@@ -426,9 +433,13 @@ void LocalPlannerNode::calculateWaypoints(bool hover) {
 }
 
 void LocalPlannerNode::publishSystemStatus() {
-  status_msg_.header.stamp = ros::Time::now();
-  status_msg_.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
-  mavros_system_status_pub_.publish(status_msg_);
+  mavros_msgs::CompanionProcessStatus msg;
+
+  msg.header.stamp = ros::Time::now();
+  msg.component = 196;  // MAV_COMPONENT_ID_AVOIDANCE
+  msg.state = (int)companion_state_;
+
+  mavros_system_status_pub_.publish(msg);
   t_status_sent_ = ros::Time::now();
 }
 
@@ -702,14 +713,14 @@ void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
       since_start > timeout_termination) {
     if (planner_is_healthy) {
       planner_is_healthy = false;
-      status_msg_.state = (int)MAV_STATE::MAV_STATE_FLIGHT_TERMINATION;
+      setSystemStatus(MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
       ROS_WARN("\033[1;33m Planner abort: missing required data \n \033[0m");
     }
   } else {
     if (since_last_cloud > timeout_critical && since_start > timeout_critical) {
       if (position_received_) {
         hover = true;
-        status_msg_.state = (int)MAV_STATE::MAV_STATE_CRITICAL;
+        setSystemStatus(MAV_STATE::MAV_STATE_CRITICAL);
         std::string not_received = "";
         for (size_t i = 0; i < cameras_.size(); i++) {
           if (!cameras_[i].received_) {

--- a/local_planner/test/test_local_planner_node.cpp
+++ b/local_planner/test/test_local_planner_node.cpp
@@ -14,7 +14,7 @@ TEST(LocalPlannerNodeTests, failsafe) {
 
   Node.position_received_ = true;
   Node.never_run_ = false;
-  Node.status_msg_.state = static_cast<int>(MAV_STATE::MAV_STATE_ACTIVE);
+  Node.setSystemStatus(MAV_STATE::MAV_STATE_ACTIVE);
 
   avoidance::LocalPlannerNodeConfig config =
       avoidance::LocalPlannerNodeConfig::__getDefault__();
@@ -31,8 +31,7 @@ TEST(LocalPlannerNodeTests, failsafe) {
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
     EXPECT_TRUE(planner_is_healthy);
-    EXPECT_EQ(Node.status_msg_.state,
-              static_cast<int>(MAV_STATE::MAV_STATE_ACTIVE));
+    EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_ACTIVE);
   }
 
   for (int i = active_n_iter; i < critical_n_iter; i++) {
@@ -41,8 +40,7 @@ TEST(LocalPlannerNodeTests, failsafe) {
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
     EXPECT_TRUE(planner_is_healthy);
-    EXPECT_EQ(Node.status_msg_.state,
-              static_cast<int>(MAV_STATE::MAV_STATE_CRITICAL));
+    EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_CRITICAL);
   }
 
   for (int i = critical_n_iter; i < 91; i++) {
@@ -51,7 +49,6 @@ TEST(LocalPlannerNodeTests, failsafe) {
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
     EXPECT_FALSE(planner_is_healthy);
-    EXPECT_EQ(Node.status_msg_.state,
-              static_cast<int>(MAV_STATE::MAV_STATE_FLIGHT_TERMINATION));
+    EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
   }
 }


### PR DESCRIPTION
This PR stops the system status being stored as a companionstatus message, but directly on MAV_STATE

- This makes changing the system state more simpler as you don't need to understand the companionStatus message structure
- This fits better with the implemenation in global planner https://github.com/PX4/avoidance/blob/e723f87c18723954c9a8f8ec8974581b6cc89bcb/global_planner/src/nodes/path_handler_node.cpp#L269-L275

