### PR TITLE
Get rid of unnecessary sleep

### DIFF
--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -9,7 +9,6 @@ int main(int argc, char** argv) {
 
   LocalPlannerNode Node(nh, nh_private, true);
   Node.startNode();
-  ros::Duration(2).sleep();
 
   std::thread worker(&LocalPlannerNode::threadFunction, &Node);
 


### PR DESCRIPTION
This PR gets rid of a 2 second sleep between starting the node and the threads.

I don't think this sleep is necessary anymore, since we don't need to wait for the node to come up.

I Have tested this in SITL. As far as I can see, this will only delay the ROS node from starting.

