### PR TITLE
Early stopping if can't find expanded node

### DIFF
--- a/local_planner/include/local_planner/tree_node.h
+++ b/local_planner/include/local_planner/tree_node.h
@@ -17,6 +17,7 @@ class TreeNode {
   int origin_;
   int depth_;
   float yaw_;
+  bool closed_;
 
   TreeNode();
   TreeNode(int from, int d, const Eigen::Vector3f& pos);

--- a/local_planner/src/nodes/tree_node.cpp
+++ b/local_planner/src/nodes/tree_node.cpp
@@ -9,7 +9,8 @@ TreeNode::TreeNode()
       last_z_{0.0f},
       origin_{0},
       depth_{0},
-      yaw_{0.0f} {
+      yaw_{0.0f},
+      closed_{false} {
   position_ = Eigen::Vector3f::Zero();
 }
 
@@ -20,7 +21,8 @@ TreeNode::TreeNode(int from, int d, const Eigen::Vector3f& pos)
       last_z_{0.0f},
       origin_{from},
       depth_{d},
-      yaw_{0.0f} {
+      yaw_{0.0f},
+      closed_{false} {
   position_ = pos;
 }
 

--- a/tools/fix_style.sh
+++ b/tools/fix_style.sh
@@ -16,5 +16,6 @@ do
         clang-format-3.8 -i -style=${STYLE} $arg
     elif [ -d $arg ]; then
         find $arg -iname '*.h' -o -iname '*.cpp' | xargs clang-format-3.8 -i -style=${STYLE}
+        find $arg -iname '*.h' -o -iname '*.cpp' | xargs chmod 644
     fi
 done


### PR DESCRIPTION
*Define variable outside the loop.
*Early stopping if can't find expanded node.
*Change the mode of source file to 644 in fix_style.

Gazebo Simulation test pass.