### PR TITLE
trajectory_simulator: include <vector> for std::vector usage

### DIFF
--- a/local_planner/include/local_planner/trajectory_simulator.h
+++ b/local_planner/include/local_planner/trajectory_simulator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eigen3/Eigen/Core>
+#include <vector>
 
 namespace avoidance {
 


### PR DESCRIPTION
While building latest master of Avoidance in an Ubuntu 18.04 system with ROS Melodic, I faced the following:
```sh
.../avoidance/local_planner/include/local_planner/trajectory_simulator.h:27:8: error: 'vector' in namespace 'std' does not name a template type
   std::vector<simulation_state> generate_trajectory(
        ^~~~~~
.../avoidance/local_planner/src/utils/trajectory_simulator.cpp:25:6: error: 'vector' in namespace 'std' does not name a template type
 std::vector<simulation_state> TrajectorySimulator::generate_trajectory(
      ^~~~~~
make[2]: *** [CMakeFiles/local_planner.dir/src/utils/trajectory_simulator.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/local_planner.dir/all] Error 2
.../avoidance/local_planner/include/local_planner/trajectory_simulator.h:27:8: error: 'vector' in namespace 'std' does not name a template type
   std::vector<simulation_state> generate_trajectory(
        ^~~~~~
.../avoidance/local_planner/src/utils/trajectory_simulator.cpp:25:6: error: 'vector' in namespace 'std' does not name a template type
 std::vector<simulation_state> TrajectorySimulator::generate_trajectory(
      ^~~~~~
make[2]: *** [CMakeFiles/local_planner.dir/src/utils/trajectory_simulator.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/local_planner.dir/all] Error 2
```

I found that including `<vector>` solves this issue. I don't know if this was reproduced as well on other machines, but at least it doesn't do harm.