### PR TITLE
Remove unused parameters

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -18,7 +18,6 @@ gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0
 gen.add("timeout_critical_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 0.5, 0, 10)
 gen.add("timeout_termination_", double_t, 0, "After this timeout the companion status is MAV_STATE_FLIGHT_TERMINATION", 15, 0, 1000)
 gen.add("max_point_age_s_", double_t, 0, "maximum age of a remembered data point", 20, 0, 500)
-gen.add("velocity_sigmoid_slope_", double_t, 0, "the bigger the bigger the acceleration", 3, 0, 10)
 gen.add("smoothing_speed_xy_", double_t, 0, "response speed of the smoothing system in xy (set to 0 to disable)", 10, 0, 30)
 gen.add("smoothing_speed_z_", double_t, 0, "response speed of the smoothing system in z (set to 0 to disable)", 3, 0, 30)
 gen.add("smoothing_margin_degrees_", double_t, 0, "smoothing radius for obstacle cost in cost histogram", 40, 0, 90)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -11,7 +11,6 @@ gen.add("box_radius_",    double_t,    0, "Data points farther away will be disc
 gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 10.0, 0, 20.0)
 gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0, 20.0)
 gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smoothness", 1.5, 0.5, 20.0)
-gen.add("keep_distance_", double_t, 0, "Distance at which the UAV stops in front of an obstacle", 2.0, 1.0, 8.0)
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -83,7 +83,6 @@ class LocalPlanner {
   ros::Time integral_time_old_;
   float no_progress_slope_;
   float new_yaw_;
-  float velocity_sigmoid_slope_ = 1.0;
   float min_realsense_dist_ = 0.2f;
   float smoothing_margin_degrees_ = 30.f;
   float max_point_age_s_ = 10;

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -79,7 +79,6 @@ class LocalPlanner {
   float curr_yaw_fcu_frame_deg_, curr_yaw_histogram_frame_deg_;
   float curr_pitch_deg_;  // for pitch angles the histogram frame matches the
                           // fcu frame
-  float keep_distance_;
   ros::Time integral_time_old_;
   float no_progress_slope_;
   float new_yaw_;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -36,7 +36,6 @@ void LocalPlanner::dynamicReconfigureSetParams(
   cost_params_.heading_cost_param = config.heading_cost_param_;
   cost_params_.smooth_cost_param = config.smooth_cost_param_;
   max_point_age_s_ = static_cast<float>(config.max_point_age_s_);
-  velocity_sigmoid_slope_ = static_cast<float>(config.velocity_sigmoid_slope_);
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
   min_realsense_dist_ = static_cast<float>(config.min_realsense_dist_);
   timeout_critical_ = config.timeout_critical_;


### PR DESCRIPTION
This PR removes two unused parameters: 
`keep_distance_` has been replaced to use the PX4 parameter `MPC_COL_PREV_D`
`velocity_sigmoid_slope_` hasn't been used in a while, the sigmoid setpoint smoothing is long gone