### PR TITLE
docker: Missing deps and outdated file path

### DIFF
--- a/docker/components/local-planner-node/Dockerfile
+++ b/docker/components/local-planner-node/Dockerfile
@@ -6,8 +6,10 @@ ENV AVOIDANCE_DIR ${CATKIN_WS}/src/local-planner
 
 RUN apt-get update && \
     apt-get install -y libopencv-dev \
+                       libyaml-cpp-dev \
                        python-catkin-tools \
                        ros-kinetic-mavros-msgs \
+                       ros-kinetic-mavros-extras \
                        ros-kinetic-pcl-ros
 
 COPY local_planner ${AVOIDANCE_DIR}

--- a/docker/components/sitl-server/Dockerfile
+++ b/docker/components/sitl-server/Dockerfile
@@ -31,7 +31,7 @@ RUN ["/bin/bash", "-c", " \
         DONT_RUN=1 make posix_sitl_default gazebo \
 "]
 
-RUN echo "param set MAV_BROADCAST 1" >> ${FIRMWARE_DIR}/posix-configs/SITL/init/ekf2/iris
+RUN echo "param set MAV_BROADCAST 1" >> ${FIRMWARE_DIR}/ROMFS/px4fmu_common/init.d-posix/10016_iris}
 
 ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["world_path:=\"/root/sim/worlds/test_city_2.world\""]


### PR DESCRIPTION
* For local-planner-node cmake would fail because of `libyaml-cpp` and `mavros-extras` missing. 
* The init files in px4 have been moved around / unified. There I'm not sure if the suggested file is the correct one. 