### PR TITLE
Move loop out of constructor in global_planner

### DIFF
--- a/global_planner/src/nodes/path_handler_node.cpp
+++ b/global_planner/src/nodes/path_handler_node.cpp
@@ -2,8 +2,7 @@
 
 namespace global_planner {
 
-PathHandlerNode::PathHandlerNode() :
-spin_dt_(0.1) {
+PathHandlerNode::PathHandlerNode() : spin_dt_(0.1) {
   nh_ = ros::NodeHandle("~");
 
   // Set up Dynamic Reconfigure Server
@@ -60,7 +59,6 @@ spin_dt_(0.1) {
 
   cmdloop_spinner_.reset(new ros::AsyncSpinner(1, &cmdloop_queue_));
   cmdloop_spinner_->start();
-
 }
 
 PathHandlerNode::~PathHandlerNode() {}

--- a/global_planner/src/nodes/path_handler_node.h
+++ b/global_planner/src/nodes/path_handler_node.h
@@ -46,6 +46,9 @@ class PathHandlerNode {
   ros::NodeHandle nh_;
   dynamic_reconfigure::Server<global_planner::PathHandlerNodeConfig> server_;
 
+  ros::Timer cmdloop_timer_;
+  ros::CallbackQueue cmdloop_queue_;
+
   // Parameters (Rosparam)
   geometry_msgs::Point start_pos_;
   double start_yaw_;
@@ -80,6 +83,10 @@ class PathHandlerNode {
 
   tf::TransformListener listener_;
 
+  std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
+
+  double spin_dt_;
+
   // Methods
   void readParams();
   bool shouldPublishThreePoints();
@@ -93,6 +100,12 @@ class PathHandlerNode {
   void receivePath(const nav_msgs::Path& msg);
   void receivePathWithRisk(const PathWithRiskMsg& msg);
   void positionCallback(const geometry_msgs::PoseStamped& pose_msg);
+
+  /**
+  * @brief     callaback for main loop
+  **/
+  void cmdLoopCallback(const ros::TimerEvent& event);
+
   // Publishers
   void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
   void transformPoseToObstacleAvoidance(mavros_msgs::Trajectory& obst_avoid,

--- a/global_planner/src/nodes/path_handler_node.h
+++ b/global_planner/src/nodes/path_handler_node.h
@@ -44,35 +44,11 @@ class PathHandlerNode {
 
  private:
   ros::NodeHandle nh_;
-  dynamic_reconfigure::Server<global_planner::PathHandlerNodeConfig> server_;
 
   ros::Timer cmdloop_timer_;
   ros::CallbackQueue cmdloop_queue_;
 
-  // Parameters (Rosparam)
-  geometry_msgs::Point start_pos_;
-  double start_yaw_;
-  // Parameters (Dynamic Reconfiguration)
-  bool three_point_mode_;
-  bool ignore_path_messages_;
-  double min_speed_;
-  double max_speed_;
-  double three_point_speed_;
-  double direct_goal_alt_;
-
-  double speed_ = min_speed_;
-  geometry_msgs::PoseStamped current_goal_;
-  geometry_msgs::PoseStamped last_goal_;
-  geometry_msgs::PoseStamped last_pos_;
-
-  std::vector<geometry_msgs::PoseStamped> path_;
-  std::map<tf::Vector3, double> path_risk_;
-
-  ros::Subscriber direct_goal_sub_;
-  ros::Subscriber path_sub_;
-  ros::Subscriber path_with_risk_sub_;
-  ros::Subscriber ground_truth_sub_;
-
+  // Publishers
   ros::Publisher mavros_waypoint_publisher_;
   ros::Publisher current_waypoint_publisher_;
   ros::Publisher three_point_path_publisher_;
@@ -81,11 +57,36 @@ class PathHandlerNode {
   ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher mavros_system_status_pub_;
 
-  tf::TransformListener listener_;
+  // Subscribers
+  ros::Subscriber direct_goal_sub_;
+  ros::Subscriber path_sub_;
+  ros::Subscriber path_with_risk_sub_;
+  ros::Subscriber ground_truth_sub_;
 
+  // Parameters (Rosparam)
+  geometry_msgs::Point start_pos_;
+  geometry_msgs::PoseStamped current_goal_;
+  geometry_msgs::PoseStamped last_goal_;
+  geometry_msgs::PoseStamped last_pos_;
+
+  dynamic_reconfigure::Server<global_planner::PathHandlerNodeConfig> server_;
   std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
 
+  double start_yaw_;
+  // Parameters (Dynamic Reconfiguration)
+  bool three_point_mode_;
+  bool ignore_path_messages_;
+  double min_speed_;
+  double max_speed_;
+  double three_point_speed_;
+  double direct_goal_alt_;
+  double speed_ = min_speed_;
   double spin_dt_;
+
+  std::vector<geometry_msgs::PoseStamped> path_;
+  std::map<tf::Vector3, double> path_risk_;
+
+  tf::TransformListener listener_;
 
   // Methods
   void readParams();


### PR DESCRIPTION
A loop was being run from a constructor in the `path_handler_node`

This PR moves the loop into a `ros::Asyncspinner` which runs the pathhandler node at a fixed rate.

Tested in SITL