### PR TITLE
Publish rvizworld even after rviz respawn

### DIFF
--- a/avoidance/include/avoidance/rviz_world_loader.h
+++ b/avoidance/include/avoidance/rviz_world_loader.h
@@ -41,10 +41,15 @@ class WorldVisualizer {
   int resolveUri(std::string& uri);
 
   ros::NodeHandle nh_;
+
+  ros::Timer loop_timer_;
+
   ros::Publisher world_pub_;
   ros::Publisher drone_pub_;
 
   std::string world_path_;
+
+  void loopCallback(const ros::TimerEvent& event);
 
  public:
   WorldVisualizer(const ros::NodeHandle& nh);

--- a/avoidance/include/avoidance/rviz_world_loader.h
+++ b/avoidance/include/avoidance/rviz_world_loader.h
@@ -40,11 +40,14 @@ class WorldVisualizer {
   **/
   int resolveUri(std::string& uri);
 
+  ros::NodeHandle nh_;
   ros::Publisher world_pub_;
   ros::Publisher drone_pub_;
 
+  std::string world_path_;
+
  public:
-  WorldVisualizer();
+  WorldVisualizer(const ros::NodeHandle& nh);
 
   /**
   * @brief      initializes all publishers used for local planner visualization

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -7,11 +7,14 @@ namespace avoidance {
 WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
   world_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/world", 1);
   drone_pub_ = nh_.advertise<visualization_msgs::Marker>("/drone", 1);
+  loop_timer_ =
+      nh_.createTimer(ros::Duration(2.0), &WorldVisualizer::loopCallback, this);
 
   nh_.param<std::string>("world_name", world_path_, "");
+}
 
+void WorldVisualizer::loopCallback(const ros::TimerEvent& event) {
   // visualize world in RVIZ
-  ros::Duration(1.0).sleep();
   if (!world_path_.empty()) {
     if (visualizeRVIZWorld(world_path_))
       ROS_WARN("[WorldVisualizer] Failed to visualize Rviz world");

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -4,11 +4,18 @@
 
 namespace avoidance {
 
-WorldVisualizer::WorldVisualizer() {}
+WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
+  world_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/world", 1);
+  drone_pub_ = nh_.advertise<visualization_msgs::Marker>("/drone", 1);
 
-void WorldVisualizer::initializePublishers(ros::NodeHandle& nh) {
-  world_pub_ = nh.advertise<visualization_msgs::MarkerArray>("/world", 1);
-  drone_pub_ = nh.advertise<visualization_msgs::Marker>("/drone", 1);
+  nh_.param<std::string>("world_name", world_path_, "");
+
+  // visualize world in RVIZ
+  ros::Duration(0.1).sleep();
+  if (!world_path_.empty()) {
+    if (visualizeRVIZWorld(world_path_))
+      ROS_WARN("[WorldVisualizer] Failed to visualize Rviz world");      
+  }
 }
 
 int WorldVisualizer::resolveUri(std::string& uri) {

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -14,7 +14,7 @@ WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
   ros::Duration(1.0).sleep();
   if (!world_path_.empty()) {
     if (visualizeRVIZWorld(world_path_))
-      ROS_WARN("[WorldVisualizer] Failed to visualize Rviz world");      
+      ROS_WARN("[WorldVisualizer] Failed to visualize Rviz world");
   }
 }
 

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -11,7 +11,7 @@ WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
   nh_.param<std::string>("world_name", world_path_, "");
 
   // visualize world in RVIZ
-  ros::Duration(0.1).sleep();
+  ros::Duration(1.0).sleep();
   if (!world_path_.empty()) {
     if (visualizeRVIZWorld(world_path_))
       ROS_WARN("[WorldVisualizer] Failed to visualize Rviz world");      

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -266,7 +266,6 @@ class LocalPlannerNode {
   bool data_ready_ = false;
   bool hover_;
   bool planner_is_healthy_;
-  bool startup_;
   bool position_not_received_error_sent_ = false;
   bool callPx4Params_;
   bool disable_rise_to_goal_altitude_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -89,7 +89,7 @@ class LocalPlannerNode {
   LocalPlannerVisualization visualizer_;
 
 #ifndef DISABLE_SIMULATION
-  WorldVisualizer world_visualizer_;
+  std::unique_ptr<WorldVisualizer> world_visualizer_;
 #endif
 
   std::mutex running_mutex_;  ///< guard against concurrent access to input &

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -23,7 +23,7 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
   wp_generator_.reset(new WaypointGenerator());
 
 #ifndef DISABLE_SIMULATION
-  world_visualizer_.reset(new WorldVisualizer(nh));
+  world_visualizer_.reset(new WorldVisualizer(nh_));
 #endif
 
   readParams();

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -18,9 +18,13 @@ namespace avoidance {
 LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
                                    const ros::NodeHandle& nh_private,
                                    const bool tf_spin_thread)
-    : nh_(nh), nh_private_(nh_private), world_visualizer_(nh), spin_dt_(0.1) {
+    : nh_(nh), nh_private_(nh_private), spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
+  
+  #ifndef DISABLE_SIMULATION
+    world_visualizer_.reset(new WorldVisualizer(nh)); 
+  #endif
 
   readParams();
 
@@ -269,7 +273,7 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
 #ifndef DISABLE_SIMULATION
   // visualize drone in RVIZ
   if (!world_path_.empty()) {
-    if (world_visualizer_.visualizeDrone(msg)) {
+    if (world_visualizer_->visualizeDrone(msg)) {
       ROS_WARN("Failed to visualize drone in RViz");
     }
   }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -21,10 +21,10 @@ LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
     : nh_(nh), nh_private_(nh_private), spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
-  
-  #ifndef DISABLE_SIMULATION
-    world_visualizer_.reset(new WorldVisualizer(nh)); 
-  #endif
+
+#ifndef DISABLE_SIMULATION
+  world_visualizer_.reset(new WorldVisualizer(nh));
+#endif
 
   readParams();
 


### PR DESCRIPTION
This PR makes the rvizworldloader publish the marker array representing the world from the loop inside the rvizworldloader object, rather than in the `cmdloop` of the localplanner as currently done with `ifndef`

- This enables the world to be still visible even after rviz has been respawned
- This  gets rid of `startup_` state in `local_planner_node` which was needed only for initially publishing the world.
- No need to initialize the publishers manually
- Get rid of some `#ifdef` in the `cmdloop`
