### PR TITLE
Change histogram image color coding

### DIFF
--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -118,8 +118,9 @@ void LocalPlanner::generateHistogramImage(Histogram& histogram) {
   // fill image data
   for (int e = GRID_LENGTH_E - 1; e >= 0; e--) {
     for (int z = 0; z < GRID_LENGTH_Z; z++) {
+      float dist = histogram.get_dist(e, z);
       float depth_val =
-          255.f * histogram.get_dist(e, z) / histogram_box_.radius_;
+          dist > 0.01f ? 255.f - 255.f * dist / histogram_box_.radius_ : 0.f;
       histogram_image_data_.push_back(
           (int)std::max(0.0f, std::min(255.f, depth_val)));
     }


### PR DESCRIPTION
This commit changes the histogram image such that a black pixel
represents a point far away, while a white pixel represents a point
very close. This is more intuitive, since no points in a given
histogram cell correspond with open space, which is also black in
the histogram image.