### PR TITLE
bug fix: enable drone to fly without smoothing

### DIFF
--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -37,7 +37,7 @@ class WaypointGenerator {
   Eigen::Vector3f prev_goal_ = Eigen::Vector3f(NAN, NAN, NAN);
   Eigen::Vector2f closest_pt_ = Eigen::Vector2f(NAN, NAN);
   Eigen::Vector3f tmp_goal_ = Eigen::Vector3f(NAN, NAN, NAN);
-  float curr_yaw_ = NAN;
+  float curr_yaw_rad_ = NAN;
   ros::Time last_time_{99999.};
   ros::Time current_time_{99999.};
 
@@ -45,9 +45,9 @@ class WaypointGenerator {
   float smoothing_speed_z_{3.0f};
 
   bool is_airborne_ = false;
-  float setpoint_yaw_ = 0.0f;
+  float setpoint_yaw_rad_ = 0.0f;
   float setpoint_yaw_velocity_ = 0.0f;
-  float heading_at_goal_ = NAN;
+  float heading_at_goal_rad_ = NAN;
   float speed_ = 1.0f;
   float h_FOV_deg_ = 59.0f;
   float v_FOV_deg_ = 46.0f;

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -111,7 +111,7 @@ void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose,
   velocity_ = vel;
   goal_ = goal;
   prev_goal_ = prev_goal;
-  curr_yaw_ = getYawFromQuaternion(q) * DEG_TO_RAD;
+  curr_yaw_rad_ = getYawFromQuaternion(q) * DEG_TO_RAD;
 
   if (stay) {
     planner_info_.waypoint_type = hover;
@@ -142,7 +142,7 @@ void WaypointGenerator::transformPositionToVelocityWaypoint() {
   output_.angular_velocity_wp.x() = 0.0f;
   output_.angular_velocity_wp.y() = 0.0f;
   output_.angular_velocity_wp.z() =
-      getAngularVelocity(setpoint_yaw_, curr_yaw_);
+      getAngularVelocity(setpoint_yaw_rad_, curr_yaw_rad_);
 }
 
 // when taking off, first publish waypoints to reach the goal altitude
@@ -211,25 +211,31 @@ void WaypointGenerator::smoothWaypoint(float dt) {
 void WaypointGenerator::nextSmoothYaw(float dt) {
   // Use xy smoothing constant for yaw, since this makes more sense than z,
   // and we dont want to introduce yet another parameter
-  const float P_constant_xy = smoothing_speed_xy_;
-  const float D_constant_xy =
-      2.f * std::sqrt(P_constant_xy);  // critically damped
 
-  const float desired_setpoint_yaw = nextYaw(position_, output_.goto_position);
-  const float desired_yaw_velocity = 0.0;
+  if (smoothing_speed_xy_ > 0) {
+    const float P_constant_xy = smoothing_speed_xy_;
+    const float D_constant_xy =
+        2.f * std::sqrt(P_constant_xy);  // critically damped
 
-  float yaw_diff = std::isfinite(desired_setpoint_yaw)
-                       ? desired_setpoint_yaw - setpoint_yaw_
-                       : 0.0f;
+    const float desired_setpoint_yaw_rad =
+        nextYaw(position_, output_.goto_position);
+    const float desired_yaw_velocity = 0.0;
 
-  wrapAngleToPlusMinusPI(yaw_diff);
-  const float p = yaw_diff * P_constant_xy;
-  const float d =
-      (desired_yaw_velocity - setpoint_yaw_velocity_) * D_constant_xy;
+    float yaw_diff = std::isfinite(desired_setpoint_yaw_rad)
+                         ? desired_setpoint_yaw_rad - setpoint_yaw_rad_
+                         : 0.0f;
 
-  setpoint_yaw_velocity_ += (p + d) * dt;
-  setpoint_yaw_ += setpoint_yaw_velocity_ * dt;
-  wrapAngleToPlusMinusPI(setpoint_yaw_);
+    wrapAngleToPlusMinusPI(yaw_diff);
+    const float p = yaw_diff * P_constant_xy;
+    const float d =
+        (desired_yaw_velocity - setpoint_yaw_velocity_) * D_constant_xy;
+
+    setpoint_yaw_velocity_ += (p + d) * dt;
+    setpoint_yaw_rad_ += setpoint_yaw_velocity_ * dt;
+    wrapAngleToPlusMinusPI(setpoint_yaw_rad_);
+  } else {
+    setpoint_yaw_rad_ = nextYaw(position_, output_.goto_position);
+  }
 }
 
 void WaypointGenerator::adaptSpeed() {
@@ -241,16 +247,15 @@ void WaypointGenerator::adaptSpeed() {
     output_.adapted_goto_position = goal_;
 
     // First time we reach this goal, remember the heading
-    if (!std::isfinite(heading_at_goal_)) {
-      heading_at_goal_ = curr_yaw_;
+    if (!std::isfinite(heading_at_goal_rad_)) {
+      heading_at_goal_rad_ = curr_yaw_rad_;
     }
-    setpoint_yaw_ = heading_at_goal_;
-
+    setpoint_yaw_rad_ = heading_at_goal_rad_;
   } else {
     // Scale the speed by a factor that is 0 if the waypoint is outside the FOV
     if (output_.waypoint_type != reachHeight) {
       float angle_diff_deg =
-          std::abs(nextYaw(position_, output_.goto_position) - curr_yaw_) *
+          std::abs(nextYaw(position_, output_.goto_position) - curr_yaw_rad_) *
           180.f / M_PI_F;
       angle_diff_deg =
           std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
@@ -264,7 +269,7 @@ void WaypointGenerator::adaptSpeed() {
     if (pose_to_wp.norm() > 0.1f) pose_to_wp.normalize();
     pose_to_wp *= std::min(speed_, goal_dist);
 
-    heading_at_goal_ = NAN;
+    heading_at_goal_rad_ = NAN;
     output_.adapted_goto_position = position_ + pose_to_wp;
   }
 
@@ -292,7 +297,7 @@ void WaypointGenerator::getPathMsg() {
       "[WG] Final waypoint: [%f %f %f].", output_.smoothed_goto_position.x(),
       output_.smoothed_goto_position.y(), output_.smoothed_goto_position.z());
   createPoseMsg(output_.position_wp, output_.orientation_wp,
-                output_.smoothed_goto_position, setpoint_yaw_);
+                output_.smoothed_goto_position, setpoint_yaw_rad_);
   transformPositionToVelocityWaypoint();
 }
 

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -212,13 +212,14 @@ void WaypointGenerator::nextSmoothYaw(float dt) {
   // Use xy smoothing constant for yaw, since this makes more sense than z,
   // and we dont want to introduce yet another parameter
 
+  const float desired_setpoint_yaw_rad =
+      nextYaw(position_, output_.goto_position);
+
   if (smoothing_speed_xy_ > 0) {
     const float P_constant_xy = smoothing_speed_xy_;
     const float D_constant_xy =
         2.f * std::sqrt(P_constant_xy);  // critically damped
 
-    const float desired_setpoint_yaw_rad =
-        nextYaw(position_, output_.goto_position);
     const float desired_yaw_velocity = 0.0;
 
     float yaw_diff = std::isfinite(desired_setpoint_yaw_rad)
@@ -234,7 +235,7 @@ void WaypointGenerator::nextSmoothYaw(float dt) {
     setpoint_yaw_rad_ += setpoint_yaw_velocity_ * dt;
     wrapAngleToPlusMinusPI(setpoint_yaw_rad_);
   } else {
-    setpoint_yaw_rad_ = nextYaw(position_, output_.goto_position);
+    setpoint_yaw_rad_ = desired_setpoint_yaw_rad;
   }
 }
 


### PR DESCRIPTION
Setting smoothing velocity to zero should disable the smoothing. There was a bug in which the zero value was still used in the yaw smoothing which led to weird behavior.

Rename some variables to include units, such that they don't confuse me anymore