### PR TITLE
Change offtrack entry check to correct velocity

### DIFF
--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -59,9 +59,10 @@ void WaypointGenerator::calculateWaypoint() {
         closest_pt_ = prev_goal_.head<2>() +
                       (u_prev_to_goal * u_prev_to_goal.dot(prev_to_pos));
 
-        // if the vehicle is more than speed_ away from the line previous to
-        // current goal, set temporary goal on the line  entering at 60 degrees
-        if ((pos_2f - closest_pt_).norm() > speed_) {
+        // if the vehicle is more than the cruise velocity away from the line
+        // previous to current goal, set temporary goal on the line  entering
+        // at 60 degrees
+        if ((pos_2f - closest_pt_).norm() > planner_info_.cruise_velocity) {
           float len = (pos_2f - closest_pt_).norm() *
                       std::cos(DEG_TO_RAD * 60.0f) /
                       std::sin(DEG_TO_RAD * 60.0f);


### PR DESCRIPTION
This commit changes the condition to enter/exit offtrack state
to use planner_info.cruise_velocity instead of speed_. This is
critical, since speed_ is an internal member used to scale the waypoint
depending on orientation.

Previously this led to zig-zagging when there are no obstacles, due to the planner going in and out of the offtrack state continously.

![image](https://user-images.githubusercontent.com/14265408/57459962-871b5900-7274-11e9-9c0c-a6e63cf61334.png)
