### PR TITLE
Change VEHICLE_CONFIG convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Once the catkin workspace has been built, to run the planner with a Realsense D4
 
 1. `export CAMERA_CONFIGS="camera_namespace, realsense_serial_n, tf_x, tf_y, tf_z, tf_yaw, tf_pitch, tf_roll"` where `tf_*` represents the displacement between the camera and the flight controller. If more than one camera is present, list the different camera configuration separated by a semicolon. Within each camera configuration the parameters are separated by commas.  
 2. `export DEPTH_CAMERA_FRAME_RATE=frame_rate`. If this variable isn't set, the default frame rate will be taken.
-3. `export VEHICLE_CONFIG=params.yaml` where the yaml file contains the value of some parameters different from the defaults set in the cfg file. If this variable isn't set, the default parameters values will be used.
+3. `export VEHICLE_CONFIG=/path/to/params.yaml` where the yaml file contains the value of some parameters different from the defaults set in the cfg file. If this variable isn't set, the default parameters values will be used.
 
 For example:
 ```bash

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -62,7 +62,7 @@ done
 
 if [ ! -z $VEHICLE_CONFIG ]; then
 cat >> local_planner/launch/avoidance.launch <<- EOM
-  <node name="dynparam" pkg="dynamic_reconfigure" type="dynparam" args="load local_planner_node \$(find local_planner)/cfg/$VEHICLE_CONFIG.yaml" />
+  <node name="dynparam" pkg="dynamic_reconfigure" type="dynparam" args="load local_planner_node $VEHICLE_CONFIG" />
 EOM
 echo "Adding vehicle paramters: $VEHICLE_CONFIG"
 fi


### PR DESCRIPTION
Now VEHICLE_CONFIG must contain the absolute path to the yaml
file, as described in the README.

This helps because now the vehicle-specific parameters don't need
to be inside the avoidance repository.