### PR TITLE
add different timeout value for booting

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -14,7 +14,7 @@ gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smooth
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
-gen.add("timeout_startup_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 3, 0, 60)
+gen.add("timeout_startup_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 5, 0, 60)
 gen.add("timeout_critical_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 0.5, 0, 10)
 gen.add("timeout_termination_", double_t, 0, "After this timeout the companion status is MAV_STATE_FLIGHT_TERMINATION", 15, 0, 1000)
 gen.add("max_point_age_s_", double_t, 0, "maximum age of a remembered data point", 20, 0, 500)

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -14,6 +14,7 @@ gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smooth
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
 gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
+gen.add("timeout_startup_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 3, 0, 60)
 gen.add("timeout_critical_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 0.5, 0, 10)
 gen.add("timeout_termination_", double_t, 0, "After this timeout the companion status is MAV_STATE_FLIGHT_TERMINATION", 15, 0, 1000)
 gen.add("max_point_age_s_", double_t, 0, "maximum age of a remembered data point", 20, 0, 500)

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -148,6 +148,7 @@ class LocalPlanner {
   bool smooth_waypoints_ = true;
   bool disable_rise_to_goal_altitude_ = false;
 
+  double timeout_startup_;
   double timeout_critical_;
   double timeout_termination_;
   double starting_height_ = 0.0;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -38,6 +38,7 @@ void LocalPlanner::dynamicReconfigureSetParams(
   max_point_age_s_ = static_cast<float>(config.max_point_age_s_);
   no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
   min_realsense_dist_ = static_cast<float>(config.min_realsense_dist_);
+  timeout_startup_ = config.timeout_startup_;
   timeout_critical_ = config.timeout_critical_;
   timeout_termination_ = config.timeout_termination_;
   children_per_node_ = config.children_per_node_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -708,6 +708,8 @@ void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
       ros::Duration(local_planner_->timeout_termination_);
   ros::Duration timeout_critical =
       ros::Duration(local_planner_->timeout_critical_);
+  ros::Duration timeout_startup =
+      ros::Duration(local_planner_->timeout_startup_);
 
   if (since_last_cloud > timeout_termination &&
       since_start > timeout_termination) {
@@ -717,7 +719,7 @@ void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
       ROS_WARN("\033[1;33m Planner abort: missing required data \n \033[0m");
     }
   } else {
-    if (since_last_cloud > timeout_critical && since_start > timeout_critical) {
+    if (since_last_cloud > timeout_critical && since_start > timeout_startup) {
       if (position_received_) {
         hover = true;
         setSystemStatus(MAV_STATE::MAV_STATE_CRITICAL);

--- a/local_planner/test/test_local_planner_node.cpp
+++ b/local_planner/test/test_local_planner_node.cpp
@@ -20,7 +20,7 @@ TEST(LocalPlannerNodeTests, failsafe) {
       avoidance::LocalPlannerNodeConfig::__getDefault__();
 
   ros::Duration since_last_cloud = ros::Duration(0.0);
-  ros::Duration since_start = ros::Duration(0.0);
+  ros::Duration since_start = ros::Duration(config.timeout_startup_);
   double time_increment = 0.2f;
   int active_n_iter = std::ceil(config.timeout_critical_ / time_increment);
   int critical_n_iter = std::ceil(config.timeout_termination_ / time_increment);


### PR DESCRIPTION
we used the same value for timeout (0.5s) at boot. This seems not to be enough time to receive the first pointcloud. I added a separate value for timeout at startup to avoid getting into timeout state at every boot.