### PR TITLE
Get rid of redundant state planner_is_healthy

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -96,7 +96,6 @@ class LocalPlannerNode {
 
   std::mutex data_ready_mutex_;
   std::condition_variable data_ready_cv_;
-  bool never_run_ = true;
   bool position_received_ = false;
 
   /**

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -175,7 +175,7 @@ class LocalPlannerNode {
   * @param[out] hover, true if the vehicle is hovering
   **/
   void checkFailsafe(ros::Duration since_last_cloud, ros::Duration since_start,
-                     bool& planner_is_healthy, bool& hover);
+                     bool& hover);
 
   /**
   * @brief     polls PX4 Firmware paramters every 30 seconds

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -334,7 +334,7 @@ void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
   updatePlanner();
 
   // send waypoint
-  calculateWaypoints(hover_);
+  if(companion_state_ == MAV_STATE::MAV_STATE_ACTIVE) calculateWaypoints(hover_);
 
   if (!never_run_){
     for (size_t i = 0; i < cameras_.size(); ++i) {

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -334,9 +334,10 @@ void LocalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
   updatePlanner();
 
   // send waypoint
-  if(companion_state_ == MAV_STATE::MAV_STATE_ACTIVE) calculateWaypoints(hover_);
+  if (companion_state_ == MAV_STATE::MAV_STATE_ACTIVE)
+    calculateWaypoints(hover_);
 
-  if (!never_run_){
+  if (!never_run_) {
     for (size_t i = 0; i < cameras_.size(); ++i) {
       // once the camera info have been set once, unsubscribe from topic
       cameras_[i].camera_info_sub_.shutdown();
@@ -615,8 +616,7 @@ void LocalPlannerNode::threadFunction() {
 }
 
 void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
-                                     ros::Duration since_start,
-                                     bool& hover) {
+                                     ros::Duration since_start, bool& hover) {
   ros::Duration timeout_termination =
       ros::Duration(local_planner_->timeout_termination_);
   ros::Duration timeout_critical =
@@ -653,8 +653,7 @@ void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
             "\033[1;33m Pointcloud timeout: No position received, no WP to "
             "output.... \n \033[0m");
       }
-    }
-    else{
+    } else {
       if (!hover) setSystemStatus(MAV_STATE::MAV_STATE_ACTIVE);
     }
   }

--- a/local_planner/test/test_local_planner_node.cpp
+++ b/local_planner/test/test_local_planner_node.cpp
@@ -12,7 +12,6 @@ TEST(LocalPlannerNodeTests, failsafe) {
   bool hover = false;
 
   Node.position_received_ = true;
-  Node.never_run_ = false;
   Node.setSystemStatus(MAV_STATE::MAV_STATE_ACTIVE);
 
   avoidance::LocalPlannerNodeConfig config =

--- a/local_planner/test/test_local_planner_node.cpp
+++ b/local_planner/test/test_local_planner_node.cpp
@@ -9,7 +9,6 @@ TEST(LocalPlannerNodeTests, failsafe) {
   ros::NodeHandle nh("~");
   ros::NodeHandle nh_private("");
   LocalPlannerNode Node(nh, nh_private, false);
-  bool planner_is_healthy = true;
   bool hover = false;
 
   Node.position_received_ = true;
@@ -26,29 +25,23 @@ TEST(LocalPlannerNodeTests, failsafe) {
   int critical_n_iter = std::ceil(config.timeout_termination_ / time_increment);
 
   for (int i = 0; i < active_n_iter; i++) {
-    Node.checkFailsafe(since_last_cloud, since_start, planner_is_healthy,
-                       hover);
+    Node.checkFailsafe(since_last_cloud, since_start, hover);
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
-    EXPECT_TRUE(planner_is_healthy);
     EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_ACTIVE);
   }
 
   for (int i = active_n_iter; i < critical_n_iter; i++) {
-    Node.checkFailsafe(since_last_cloud, since_start, planner_is_healthy,
-                       hover);
+    Node.checkFailsafe(since_last_cloud, since_start, hover);
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
-    EXPECT_TRUE(planner_is_healthy);
     EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_CRITICAL);
   }
 
   for (int i = critical_n_iter; i < 91; i++) {
-    Node.checkFailsafe(since_last_cloud, since_start, planner_is_healthy,
-                       hover);
+    Node.checkFailsafe(since_last_cloud, since_start, hover);
     since_last_cloud = since_last_cloud + ros::Duration(time_increment);
     since_start = since_start + ros::Duration(time_increment);
-    EXPECT_FALSE(planner_is_healthy);
     EXPECT_EQ(Node.getSystemStatus(), MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
   }
 }


### PR DESCRIPTION
Currently the status of the planner is monitored by two states
- `planner_is_healthy`
- `never_run_`

This PR gets rid of redundant state `planner_is_healthy`

As far as I can see, with the current logic there is no additional information we are getting by using `planner_is_healthy` as a state

This also makes all `setSystemSatus` calls to be inside the `checkFailsafe` function.