### PR TITLE
Fix Deadzone FOV bug

### DIFF
--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -29,7 +29,6 @@ struct FOV_indices {
 * @param      final_cloud, processed data to be used for planning
 * @param[in]  complete_cloud, array of pointclouds from the sensors
 * @param[in]  histogram_box, geometry definition of the bounding box
-* @param[in]  FOV, histogram indices currently lying inside the FOV
 * @param[in]  position, current vehicle position
 * @param[in]  min_realsense_dist, minimum sensor range [m]
 * @param[in]  max_age, maximum age (compute cycles) to keep data
@@ -41,7 +40,7 @@ struct FOV_indices {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const FOV_indices& FOV, const Eigen::Vector3f& position,
+    Box histogram_box, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell);
 
@@ -56,14 +55,6 @@ void processPointcloud(
 **/
 void calculateFOV(float h_FOV, float v_fov, FOV_indices& FOV,
                   float yaw_fcu_frame, float pitch_fcu_frame);
-
-/**
-* @brief      determines whether point is inside FOV
-* @param[in]  FOV, indices lying inside the current FOV
-* @param[in]  point_idx, histogram indices of the point
-* @return     whether point is inside the FOV
-**/
-bool pointInsideFOV(const FOV_indices& FOV, const PolarPoint& p_pol);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -21,9 +21,6 @@ namespace avoidance {
 class TreeNode;
 
 class StarPlanner {
-  float h_FOV_deg_ = 59.0f;
-  float v_FOV_deg_ = 46.0f;
-
   int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   float tree_node_distance_ = 1.0f;
@@ -76,13 +73,6 @@ class StarPlanner {
   * @param[in] projected_last_wp, last waypoint projected out to goal distance
   **/
   void setLastDirection(const Eigen::Vector3f& projected_last_wp);
-
-  /**
-  * @brief     setter method for Fielf of View
-  * @param[in] h_FOV, horizontal Field of View [deg]
-  * @param[in] v_FOV, vertical Field of View [deg]
-  **/
-  void setFOV(float h_FOV, float v_FOV);
 
   /**
   * @brief     setter method for star_planner pointcloud

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -167,7 +167,6 @@ void LocalPlanner::determineStrategy() {
                     smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
 
       star_planner_->setParams(cost_params_);
-      star_planner_->setFOV(h_FOV_deg_, v_FOV_deg_);
       star_planner_->setPointcloud(final_cloud_);
 
       // set last chosen direction for smoothing

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -88,7 +88,7 @@ void LocalPlanner::runPlanner() {
 
   float elapsed_since_last_processing = static_cast<float>(
       (ros::Time::now() - last_pointcloud_process_time_).toSec());
-  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, FOV_,
+  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
   last_pointcloud_process_time_ = ros::Time::now();

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -22,7 +22,7 @@ void processPointcloud(
   final_cloud.width = 0;
   final_cloud.points.reserve((2 * GRID_LENGTH_Z) * (2 * GRID_LENGTH_E));
 
-  float  distance = 0.f;
+  float distance = 0.f;
   float h_min = 180.f, h_max = -180.f;
 
   // counter to keep track of how many points lie in a given cell
@@ -68,8 +68,7 @@ void processPointcloud(
         // complete_cloud, as well as outside FOV and 'young' enough
         if (histogram_points_counter(p_ind.y(), p_ind.x()) <
                 min_num_points_per_cell &&
-            xyzi.intensity < max_age &&
-            (p_pol.z < h_min || p_pol.z > h_max)) {
+            xyzi.intensity < max_age && (p_pol.z < h_min || p_pol.z > h_max)) {
           final_cloud.points.push_back(
               toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
 

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -30,11 +30,6 @@ void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) {
   projected_last_wp_ = projected_last_wp;
 }
 
-void StarPlanner::setFOV(float h_FOV, float v_FOV) {
-  h_FOV_deg_ = h_FOV;
-  v_FOV_deg_ = v_FOV;
-}
-
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   position_ = pos;
   curr_yaw_histogram_frame_deg_ = curr_yaw;


### PR DESCRIPTION
This commit fixes a bug observed in real flight:
Due to overestimation of the actual FOV of the point cloud, points were never remembered because they disappeard in the blind spot.

This commit replaces the inside-FOV detection in the point cloud processing to use the max and min horizontal angle of the incoming points.