### PR TITLE
Visualize drone pose from rvizworldloader

### DIFF
--- a/avoidance/include/avoidance/rviz_world_loader.h
+++ b/avoidance/include/avoidance/rviz_world_loader.h
@@ -44,6 +44,7 @@ class WorldVisualizer {
 
   ros::Timer loop_timer_;
 
+  ros::Subscriber pose_sub_;
   ros::Publisher world_pub_;
   ros::Publisher drone_pub_;
 
@@ -59,6 +60,11 @@ class WorldVisualizer {
   * @param      nh, nodehandle to initialize publishers
   **/
   void initializePublishers(ros::NodeHandle& nh);
+
+  /**
+  * @brief      callback for subscribing mav pose topic
+  **/
+  void positionCallback(const geometry_msgs::PoseStamped& msg);
 
   /**
   * @brief      parse the yaml file and publish world marker

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -5,6 +5,11 @@
 namespace avoidance {
 
 WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
+
+  pose_sub_ = nh_.subscribe<const geometry_msgs::PoseStamped&>(
+      "/mavros/local_position/pose", 1, &WorldVisualizer::positionCallback,
+      this);
+
   world_pub_ = nh_.advertise<visualization_msgs::MarkerArray>("/world", 1);
   drone_pub_ = nh_.advertise<visualization_msgs::Marker>("/drone", 1);
   loop_timer_ =
@@ -150,6 +155,15 @@ int WorldVisualizer::visualizeDrone(const geometry_msgs::PoseStamped& pose) {
   drone_pub_.publish(drone);
 
   return 0;
+}
+
+void WorldVisualizer::positionCallback(const geometry_msgs::PoseStamped& msg) {
+  // visualize drone in RVIZ
+  if (!world_path_.empty()) {
+    if (visualizeDrone(msg)) {
+      ROS_WARN("Failed to visualize drone in RViz");
+    }
+  }
 }
 
 // extraction operators

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -5,7 +5,6 @@
 namespace avoidance {
 
 WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
-
   pose_sub_ = nh_.subscribe<const geometry_msgs::PoseStamped&>(
       "/mavros/local_position/pose", 1, &WorldVisualizer::positionCallback,
       this);

--- a/global_planner/src/nodes/path_handler_node.cpp
+++ b/global_planner/src/nodes/path_handler_node.cpp
@@ -135,7 +135,6 @@ void PathHandlerNode::dynamicReconfigureCallback(
 }
 
 void PathHandlerNode::cmdLoopCallback(const ros::TimerEvent& event) {
-
   if (shouldPublishThreePoints()) {
     publishThreePointMsg();
   } else {

--- a/global_planner/src/nodes/path_handler_node.cpp
+++ b/global_planner/src/nodes/path_handler_node.cpp
@@ -135,17 +135,6 @@ void PathHandlerNode::dynamicReconfigureCallback(
 }
 
 void PathHandlerNode::cmdLoopCallback(const ros::TimerEvent& event) {
-#ifndef DISABLE_SIMULATION
-  // visualize world in RVIZ
-  if (!world_path_.empty() && startup_) {
-    if (world_visualizer_->visualizeRVIZWorld(world_path_)) {
-      ROS_WARN("Failed to visualize Rviz world");
-    }
-    startup_ = false;
-  }
-#else
-  startup_ = false;
-#endif
 
   if (shouldPublishThreePoints()) {
     publishThreePointMsg();
@@ -219,14 +208,6 @@ void PathHandlerNode::positionCallback(
       // }
     }
   }
-#ifndef DISABLE_SIMULATION
-  // visualize drone in RVIZ
-  if (!world_path_.empty()) {
-    if (world_visualizer_->visualizeDrone(pose_msg)) {
-      ROS_WARN("Failed to visualize drone in RViz");
-    }
-  }
-#endif
 }
 
 void PathHandlerNode::fillUnusedTrajectoryPoint(

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -75,7 +75,6 @@ class LocalPlannerNode {
                    const bool tf_spin_thread = true);
   ~LocalPlannerNode();
 
-  std::string world_path_;
   std::atomic<bool> should_exit_{false};
 
   std::vector<cameraData> cameras_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -268,7 +268,6 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
   last_pose_ = newest_pose_;
   newest_pose_ = msg;
   position_received_ = true;
-
 }
 
 void LocalPlannerNode::velocityCallback(

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -125,7 +125,6 @@ void LocalPlannerNode::readParams() {
   nh_.getParam("pointcloud_topics", camera_topics);
   initializeCameraSubscribers(camera_topics);
 
-  nh_.param<std::string>("world_name", world_path_, "");
   goal_msg_.pose.position = goal;
 }
 
@@ -270,14 +269,6 @@ void LocalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
   newest_pose_ = msg;
   position_received_ = true;
 
-#ifndef DISABLE_SIMULATION
-  // visualize drone in RVIZ
-  if (!world_path_.empty()) {
-    if (world_visualizer_->visualizeDrone(msg)) {
-      ROS_WARN("Failed to visualize drone in RViz");
-    }
-  }
-#endif
 }
 
 void LocalPlannerNode::velocityCallback(


### PR DESCRIPTION
This PR moves visualizing the drone of into the `WorldVisualizer` by directly subscribing to the pose topic.

This eliminates the need of calling `visualizeDrone` topic from the `local_planner` and `global_planner` nodes.

- The only `#ifndef` statement in both `global_planner` and `local_planner` is the declaration of `WorldVisualizer`
- A nice side effect is that a 1s-2s delay of the drone appearing after the world appearing in rviz disappears with this PR.

Tested in SITL for both `global_planner` and `local_planner`