### PR TITLE
Remove FOV indices

### DIFF
--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -42,9 +42,30 @@ struct PolarPoint {
   float r;
 };
 
+/**
+* Struct defining the Field of View of the sensor. This is defined by
+* the current yaw and pitch (in local frame) and the horizontal and vertical
+* field of view of the sensor
+*/
+struct FOV {
+  FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
+  float yaw_deg;
+  float pitch_deg;
+  float h_fov_deg;
+  float v_fov_deg;
+};
+
 #define M_PI_F 3.14159265358979323846f
 const float DEG_TO_RAD = M_PI_F / 180.f;
 const float RAD_TO_DEG = 180.0f / M_PI_F;
+
+/**
+* @brief      determines whether point is inside FOV
+* @param[in]  FOV, struct defining current field of view
+* @param[in]  p_pol, polar representation of the point in question
+* @return     whether point is inside the FOV
+**/
+bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
 
 /**
 * @brief     calculates the distance between two polar points

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -49,7 +49,8 @@ struct PolarPoint {
 */
 struct FOV {
   FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
-  FOV(float y, float p, float h, float v) : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v) {};
+  FOV(float y, float p, float h, float v)
+      : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
   float yaw_deg;
   float pitch_deg;
   float h_fov_deg;

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -49,6 +49,7 @@ struct PolarPoint {
 */
 struct FOV {
   FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
+  FOV(float y, float p, float h, float v) : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v) {};
   float yaw_deg;
   float pitch_deg;
   float h_fov_deg;

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -9,11 +9,11 @@
 namespace avoidance {
 
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
-    return p_pol.z <= fov.yaw_deg + fov.h_fov_deg / 2.f &&
-           p_pol.z >= fov.yaw_deg - fov.h_fov_deg / 2.f &&
-           p_pol.e <= fov.pitch_deg + fov.v_fov_deg / 2.f &&
-           p_pol.e >= fov.pitch_deg - fov.v_fov_deg / 2.f;
-  }
+  return p_pol.z <= fov.yaw_deg + fov.h_fov_deg / 2.f &&
+         p_pol.z >= fov.yaw_deg - fov.h_fov_deg / 2.f &&
+         p_pol.e <= fov.pitch_deg + fov.v_fov_deg / 2.f &&
+         p_pol.e >= fov.pitch_deg - fov.v_fov_deg / 2.f;
+}
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
   return sqrt((p1.e - p2.e) * (p1.e - p2.e) + (p1.z - p2.z) * (p1.z - p2.z));

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -8,6 +8,13 @@
 
 namespace avoidance {
 
+bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
+    return p_pol.z <= fov.yaw_deg + fov.h_fov_deg / 2.f &&
+           p_pol.z >= fov.yaw_deg - fov.h_fov_deg / 2.f &&
+           p_pol.e <= fov.pitch_deg + fov.v_fov_deg / 2.f &&
+           p_pol.e >= fov.pitch_deg - fov.v_fov_deg / 2.f;
+  }
+
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
   return sqrt((p1.e - p2.e) * (p1.e - p2.e) + (p1.z - p2.z) * (p1.z - p2.z));
 }

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -5,7 +5,7 @@
 
 using namespace avoidance;
 
-TEST(Common, pointInsideFOV){
+TEST(Common, pointInsideFOV) {
   // GIVEN: three points and a regular FOV
   FOV fov(34.0f, 12.0f, 90.0f, 60.0f);
   PolarPoint p_outside_yaw(-1.0f, 126.0f, 2.0f);

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -5,6 +5,24 @@
 
 using namespace avoidance;
 
+TEST(Common, pointInsideFOV){
+  // GIVEN: three points and a regular FOV
+  FOV fov(34.0f, 12.0f, 90.0f, 60.0f);
+  PolarPoint p_outside_yaw(-1.0f, 126.0f, 2.0f);
+  PolarPoint p_outside_pitch(-60.0f, 30.0f, 2.0f);
+  PolarPoint p_inside_fov(5.0f, 25.0f, 2.0f);
+
+  // WHEN: we check whether they are inside the FOV
+  bool outside_yaw = pointInsideFOV(fov, p_outside_yaw);
+  bool outside_pitch = pointInsideFOV(fov, p_outside_pitch);
+  bool inside = pointInsideFOV(fov, p_inside_fov);
+
+  // THEN: they should lie in the expected region
+  EXPECT_FALSE(outside_yaw);
+  EXPECT_FALSE(outside_pitch);
+  EXPECT_TRUE(inside);
+}
+
 TEST(PlannerFunctions, HistogramResolution) {
   // Test that the hardcoded histogram resolution ALPHA_RES is valid
   ASSERT_GT(ALPHA_RES, 0);

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -87,7 +87,7 @@ class LocalPlanner {
   float smoothing_margin_degrees_ = 30.f;
   float max_point_age_s_ = 10;
 
-  FOV_indices FOV_;
+  FOV fov_;
 
   waypoint_choice waypoint_type_;
   ros::Time last_path_time_;
@@ -139,8 +139,6 @@ class LocalPlanner {
   void generateHistogramImage(Histogram& histogram);
 
  public:
-  float h_FOV_deg_ = 59.0f;
-  float v_FOV_deg_ = 46.0f;
   Box histogram_box_;
   std::vector<uint8_t> histogram_image_data_;
   std::vector<uint8_t> cost_image_data_;
@@ -179,6 +177,13 @@ class LocalPlanner {
   * @param[in] mgs, goal message coming from the FCU
   **/
   void setGoal(const Eigen::Vector3f& goal);
+  /**
+  * @brief     setter method for field of view
+  * @param[in] horizontal angle in degrees of the sensor data
+  * @param[in] vertical angle in degrees of the sensor data
+  */
+  void setFOV(float h_FOV_deg, float v_FOV_deg);
+  
   /**
   * @brief     getter method for current goal
   * @returns   position of the goal

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -183,7 +183,13 @@ class LocalPlanner {
   * @param[in] vertical angle in degrees of the sensor data
   */
   void setFOV(float h_FOV_deg, float v_FOV_deg);
-  
+
+  /**
+  * @brief     Getters for the FOV
+  */
+  float getHFOV() { return fov_.h_fov_deg; }
+  float getVFOV() { return fov_.v_fov_deg; }
+
   /**
   * @brief     getter method for current goal
   * @returns   position of the goal

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -17,19 +17,13 @@
 
 namespace avoidance {
 
-struct FOV_indices {
-  std::vector<int> z_idx_vec;
-  int e_idx_min;
-  int e_idx_max;
-};
-
 /**
 * @brief      crops and subsamples the incomming data, then combines it with
 *             the data from the last timestep
 * @param      final_cloud, processed data to be used for planning
 * @param[in]  complete_cloud, array of pointclouds from the sensors
 * @param[in]  histogram_box, geometry definition of the bounding box
-* @param[in]  FOV, histogram indices currently lying inside the FOV
+* @param[in]  FOV, struct defining current field of view
 * @param[in]  position, current vehicle position
 * @param[in]  min_realsense_dist, minimum sensor range [m]
 * @param[in]  max_age, maximum age (compute cycles) to keep data
@@ -41,29 +35,10 @@ struct FOV_indices {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const FOV_indices& FOV, const Eigen::Vector3f& position,
+    Box histogram_box, const FOV& fov, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell);
 
-/**
-* @brief      calculates the histogram cells within the Field of View
-* @param[in]  h_FOV, horizontal Field of View [rad]
-* @param[in]  v_FOV, vertical Field of View [rad]
-* @param[out] FOV, indices lying inside the current FOV
-* @param[in]  yaw, vehicle yaw [rad]
-* @param[in]  pitch, vehicle pitch [rad]
-* @note       azimuth angle is wrapped, elevation is not
-**/
-void calculateFOV(float h_FOV, float v_fov, FOV_indices& FOV,
-                  float yaw_fcu_frame, float pitch_fcu_frame);
-
-/**
-* @brief      determines whether point is inside FOV
-* @param[in]  FOV, indices lying inside the current FOV
-* @param[in]  point_idx, histogram indices of the point
-* @return     whether point is inside the FOV
-**/
-bool pointInsideFOV(const FOV_indices& FOV, const PolarPoint& p_pol);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -39,7 +39,6 @@ void processPointcloud(
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell);
 
-
 /**
 * @brief      calculates a histogram from the current frame pointcloud around
 *             the current vehicle position

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -21,9 +21,6 @@ namespace avoidance {
 class TreeNode;
 
 class StarPlanner {
-  float h_FOV_deg_ = 59.0f;
-  float v_FOV_deg_ = 46.0f;
-
   int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   float tree_node_distance_ = 1.0f;
@@ -76,13 +73,6 @@ class StarPlanner {
   * @param[in] projected_last_wp, last waypoint projected out to goal distance
   **/
   void setLastDirection(const Eigen::Vector3f& projected_last_wp);
-
-  /**
-  * @brief     setter method for Fielf of View
-  * @param[in] h_FOV, horizontal Field of View [deg]
-  * @param[in] v_FOV, vertical Field of View [deg]
-  **/
-  void setFOV(float h_FOV, float v_FOV);
 
   /**
   * @brief     setter method for star_planner pointcloud

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -68,7 +68,7 @@ void LocalPlanner::setGoal(const Eigen::Vector3f& goal) {
   applyGoal();
 }
 
-void LocalPlanner::setFOV(float h_FOV_deg, float v_FOV_deg){
+void LocalPlanner::setFOV(float h_FOV_deg, float v_FOV_deg) {
   fov_.h_fov_deg = h_FOV_deg;
   fov_.v_fov_deg = v_FOV_deg;
 }
@@ -197,13 +197,14 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
   msg.range_max = histogram_box_.radius_;
   msg.ranges.reserve(GRID_LENGTH_Z);
 
-  for (int i = 0; i < GRID_LENGTH_Z; ++i){
+  for (int i = 0; i < GRID_LENGTH_Z; ++i) {
     // turn idxs 180 degress to point to local north instead of south
-    int j = (i +  GRID_LENGTH_Z / 2) % GRID_LENGTH_Z;
+    int j = (i + GRID_LENGTH_Z / 2) % GRID_LENGTH_Z;
     float dist = hist.get_dist(0, j);
 
     // special case: distance of 0 denotes 'no obstacle in sight'
-    msg.ranges.push_back(dist > min_realsense_dist_ ? dist : histogram_box_.radius_ + 1.0f);
+    msg.ranges.push_back(
+        dist > min_realsense_dist_ ? dist : histogram_box_.radius_ + 1.0f);
   }
 
   distance_data_ = msg;

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -68,6 +68,11 @@ void LocalPlanner::setGoal(const Eigen::Vector3f& goal) {
   applyGoal();
 }
 
+void LocalPlanner::setFOV(float h_FOV_deg, float v_FOV_deg){
+  fov_.h_fov_deg = h_FOV_deg;
+  fov_.v_fov_deg = v_FOV_deg;
+}
+
 Eigen::Vector3f LocalPlanner::getGoal() const { return goal_; }
 
 void LocalPlanner::applyGoal() {
@@ -80,15 +85,14 @@ void LocalPlanner::runPlanner() {
            static_cast<int>(original_cloud_vector_.size()));
 
   // calculate Field of View
-  FOV_.z_idx_vec.clear();
-  calculateFOV(h_FOV_deg_, v_FOV_deg_, FOV_, curr_yaw_histogram_frame_deg_,
-               curr_pitch_deg_);
+  fov_.yaw_deg = curr_yaw_histogram_frame_deg_;
+  fov_.pitch_deg = curr_pitch_deg_;
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
   float elapsed_since_last_processing = static_cast<float>(
       (ros::Time::now() - last_pointcloud_process_time_).toSec());
-  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, FOV_,
+  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
   last_pointcloud_process_time_ = ros::Time::now();
@@ -167,7 +171,6 @@ void LocalPlanner::determineStrategy() {
                     smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
 
       star_planner_->setParams(cost_params_);
-      star_planner_->setFOV(h_FOV_deg_, v_FOV_deg_);
       star_planner_->setPointcloud(final_cloud_);
 
       // set last chosen direction for smoothing
@@ -192,43 +195,15 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
   msg.angle_increment = static_cast<double>(ALPHA_RES) * M_PI / 180.0;
   msg.range_min = min_realsense_dist_;
   msg.range_max = histogram_box_.radius_;
-
-  // turn idxs 180 degress to point to local north instead of south
-  std::vector<int> z_FOV_idx_north;
-  z_FOV_idx_north.reserve(FOV_.z_idx_vec.size());
-
-  for (size_t i = 0; i < FOV_.z_idx_vec.size(); i++) {
-    int new_idx = FOV_.z_idx_vec[i] + GRID_LENGTH_Z / 2;
-
-    if (new_idx >= GRID_LENGTH_Z) {
-      new_idx = new_idx - GRID_LENGTH_Z;
-    }
-
-    z_FOV_idx_north.push_back(new_idx);
-  }
-
   msg.ranges.reserve(GRID_LENGTH_Z);
-  for (int idx = 0; idx < GRID_LENGTH_Z; idx++) {
-    float range;
 
-    if (std::find(z_FOV_idx_north.begin(), z_FOV_idx_north.end(), idx) ==
-        z_FOV_idx_north.end()) {
-      range = UINT16_MAX;
-    } else {
-      int hist_idx = idx - GRID_LENGTH_Z / 2;
+  for (int i = 0; i < GRID_LENGTH_Z; ++i){
+    // turn idxs 180 degress to point to local north instead of south
+    int j = (i +  GRID_LENGTH_Z / 2) % GRID_LENGTH_Z;
+    float dist = hist.get_dist(0, j);
 
-      if (hist_idx < 0) {
-        hist_idx = hist_idx + GRID_LENGTH_Z;
-      }
-
-      if (hist.get_dist(0, hist_idx) == 0.0f) {
-        range = msg.range_max + 1.0f;
-      } else {
-        range = hist.get_dist(0, hist_idx);
-      }
-    }
-
-    msg.ranges.push_back(range);
+    // special case: distance of 0 denotes 'no obstacle in sight'
+    msg.ranges.push_back(dist > min_realsense_dist_ ? dist : histogram_box_.radius_ + 1.0f);
   }
 
   distance_data_ = msg;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -557,9 +557,9 @@ void LocalPlannerNode::cameraInfoCallback(
   // v_fov = 2 * atan (image_height / (2 * focal_length_y))
   // Assumption: if there are n cameras the total horizonal field of view is n
   // times the horizontal field of view of a single camera
-  float h_fov =  static_cast<float>(
-     static_cast<double>(cameras_.size()) * 2.0 *
-     atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
+  float h_fov = static_cast<float>(
+      static_cast<double>(cameras_.size()) * 2.0 *
+      atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
   float v_fov = static_cast<float>(
       2.0 * atan(static_cast<double>(msg->height) / (2.0 * msg->K[4])) * 180.0 /
       M_PI);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -557,13 +557,15 @@ void LocalPlannerNode::cameraInfoCallback(
   // v_fov = 2 * atan (image_height / (2 * focal_length_y))
   // Assumption: if there are n cameras the total horizonal field of view is n
   // times the horizontal field of view of a single camera
-  local_planner_->h_FOV_deg_ = static_cast<float>(
-      static_cast<double>(cameras_.size()) * 2.0 *
-      atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
-  local_planner_->v_FOV_deg_ = static_cast<float>(
+  float h_fov =  static_cast<float>(
+     static_cast<double>(cameras_.size()) * 2.0 *
+     atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
+  float v_fov = static_cast<float>(
       2.0 * atan(static_cast<double>(msg->height) / (2.0 * msg->K[4])) * 180.0 /
       M_PI);
-  wp_generator_->setFOV(local_planner_->h_FOV_deg_, local_planner_->v_FOV_deg_);
+
+  local_planner_->setFOV(h_fov, v_fov);
+  wp_generator_->setFOV(h_fov, v_fov);
 }
 
 void LocalPlannerNode::fillUnusedTrajectoryPoint(

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -30,11 +30,6 @@ void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) {
   projected_last_wp_ = projected_last_wp;
 }
 
-void StarPlanner::setFOV(float h_FOV, float v_FOV) {
-  h_FOV_deg_ = h_FOV;
-  v_FOV_deg_ = v_FOV;
-}
-
 void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
   position_ = pos;
   curr_yaw_histogram_frame_deg_ = curr_yaw;

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -5,6 +5,9 @@
 #include "../include/local_planner/local_planner.h"
 #include "avoidance/common.h"
 
+#define TO_DEG 180.f / M_PI_F
+#define TO_RAD M_PI_F / 180.f
+
 // Stateless tests:
 // Create some hardcoded scan data of obstacles in different positions
 // For each one check that the planner response is correct
@@ -21,6 +24,7 @@ class LocalPlannerTests : public ::testing::Test {
     avoidance::LocalPlannerNodeConfig config =
         avoidance::LocalPlannerNodeConfig::__getDefault__();
     planner.dynamicReconfigureSetParams(config, 1);
+    planner.setFOV(59.0f, 46.0f);
 
     // start with basic pose
     Eigen::Vector3f pos(0.f, 0.f, 0.f);
@@ -68,7 +72,7 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   float shift = 0.f;
   float distance = 2.f;
   float fov_half_y =
-      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
+      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -85,9 +89,15 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
+  int idx_lower_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
+                       (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2 - atan2(min_y, distance) ) /
+                       (scan.angle_increment));
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    if (10 <= i && i <= 19)
+    if (idx_lower_obstacle_boundary_bin <= i && i <= idx_upper_obstacle_boundary_bin)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);
@@ -120,7 +130,7 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   float shift = -0.5f;
   float distance = 2.f;
   float fov_half_y =
-      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
+      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -137,9 +147,16 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
+  int idx_lower_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
+                       (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2 - atan2(min_y, distance) ) /
+                       (scan.angle_increment));
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    if (12 <= i && i <= 19)
+    if (idx_lower_obstacle_boundary_bin <= i &&
+        i <= idx_upper_obstacle_boundary_bin)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);
@@ -168,7 +185,7 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   float shift = 0.5f;
   float distance = 2.f;
   float fov_half_y =
-      distance * std::tan(planner.h_FOV_deg_ * M_PI_F / 180.f / 2.f);
+      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -185,8 +202,16 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
+  int idx_lower_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
+                       (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin =
+      static_cast<int>((M_PI_F / 2- atan2(min_y, distance)) /
+                       (scan.angle_increment));
+
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    if (10 <= i && i <= 17)
+    if (idx_lower_obstacle_boundary_bin <= i &&
+        i <= idx_upper_obstacle_boundary_bin)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -71,8 +71,7 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   // GIVEN: a local planner, a scan with obstacles everywhere, pose and goal
   float shift = 0.f;
   float distance = 2.f;
-  float fov_half_y =
-      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -89,15 +88,14 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
-  int idx_lower_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
-                       (scan.angle_increment));
-  int idx_upper_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2 - atan2(min_y, distance) ) /
-                       (scan.angle_increment));
+  int idx_lower_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(max_y, distance)) / (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(min_y, distance)) / (scan.angle_increment));
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
-    if (idx_lower_obstacle_boundary_bin <= i && i <= idx_upper_obstacle_boundary_bin)
+    if (idx_lower_obstacle_boundary_bin <= i &&
+        i <= idx_upper_obstacle_boundary_bin)
       EXPECT_LT(scan.ranges[i], distance * 1.5f);
     else
       EXPECT_GT(scan.ranges[i], scan.range_max);
@@ -129,8 +127,7 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // GIVEN: a local planner, a scan with obstacles on the right, pose and goal
   float shift = -0.5f;
   float distance = 2.f;
-  float fov_half_y =
-      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -147,12 +144,10 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
-  int idx_lower_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
-                       (scan.angle_increment));
-  int idx_upper_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2 - atan2(min_y, distance) ) /
-                       (scan.angle_increment));
+  int idx_lower_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(max_y, distance)) / (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(min_y, distance)) / (scan.angle_increment));
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
     if (idx_lower_obstacle_boundary_bin <= i &&
@@ -184,8 +179,7 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   // GIVEN: a local planner, a scan with obstacles on the left, pose and goal
   float shift = 0.5f;
   float distance = 2.f;
-  float fov_half_y =
-      distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -202,12 +196,10 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   // THEN: it should get a scan showing the obstacle
   sensor_msgs::LaserScan scan;
   planner.getObstacleDistanceData(scan);
-  int idx_lower_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2 - atan2(max_y, distance)) /
-                       (scan.angle_increment));
-  int idx_upper_obstacle_boundary_bin =
-      static_cast<int>((M_PI_F / 2- atan2(min_y, distance)) /
-                       (scan.angle_increment));
+  int idx_lower_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(max_y, distance)) / (scan.angle_increment));
+  int idx_upper_obstacle_boundary_bin = static_cast<int>(
+      (M_PI_F / 2 - atan2(min_y, distance)) / (scan.angle_increment));
 
   for (size_t i = 0; i < scan.ranges.size(); i++) {
     if (idx_lower_obstacle_boundary_bin <= i &&

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -108,42 +108,42 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   pcl::PointCloud<pcl::PointXYZI> processed_cloud1, processed_cloud2,
       processed_cloud3;
-  Eigen::Vector3f memory_point(-0.4f, 0.3f, -0.4f);
+  Eigen::Vector3f memory_point(1.4f, 0.0f, 0.0f);
   PolarPoint memory_point_polar =
       cartesianToPolar(position + memory_point, position);
-  processed_cloud1.push_back(toXYZI(position + memory_point, 5));
-  processed_cloud2.push_back(toXYZI(position + memory_point, 5));
-  processed_cloud3.push_back(toXYZI(position + memory_point, 5));
+  processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
+  processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
+  processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
+  std::cout << "mem point e: " << memory_point_polar.e << "z: " << memory_point_polar.z << std::endl;
 
-  FOV FOV_zero;  // empty FOV, no remembered points will be forgotten
-                 // due to inside FOV
-  FOV_zero.h_fov_deg = 0.f;
-  FOV_zero.v_fov_deg = 0.f;
+  FOV FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
+  FOV_zero.h_fov_deg = 0.0f;
+  FOV_zero.v_fov_deg = 0.0f;
   FOV_zero.yaw_deg = 1.0f;
   FOV_zero.pitch_deg = 1.0f;
 
   FOV FOV_regular;
   FOV_regular.h_fov_deg = 85.0f;
   FOV_regular.v_fov_deg = 65.0f;
-  FOV_regular.yaw_deg = 1.0f;
+  FOV_regular.yaw_deg = 90.0f; // in histogram frame!
   FOV_regular.pitch_deg = 1.0f;
 
   // WHEN: we filter the PointCloud with different values max_age
   processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,
-                    position, min_realsense_dist, 0.f, 0.5f, 1);
+                    position, min_realsense_dist, 0.0f, 0.5f, 1);
 
   processPointcloud(processed_cloud2, complete_cloud, histogram_box, FOV_zero,
-                    position, min_realsense_dist, 10.f, .5f, 1);
+                    position, min_realsense_dist, 10.0f, .5f, 1);
 
   processPointcloud(processed_cloud3, complete_cloud, histogram_box,
-                    FOV_regular, position, min_realsense_dist, 10.f, 0.5f, 1);
+                    FOV_regular, position, min_realsense_dist, 10.0f, 0.5f, 1);
 
   // THEN: we expect the first cloud to have 6 points
   // the second cloud should contain 7 points
-  EXPECT_EQ(processed_cloud1.size(), 6);
-  EXPECT_EQ(processed_cloud2.size(), 7);
+  EXPECT_EQ(6, processed_cloud1.size());
+  EXPECT_EQ(7, processed_cloud2.size());
   EXPECT_TRUE(pointInsideFOV(FOV_regular, memory_point_polar));
-  EXPECT_EQ(processed_cloud3.size(), 6);
+  EXPECT_EQ(6, processed_cloud3.size());
 }
 
 TEST(PlannerFunctions, testDirectionTree) {

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -79,72 +79,6 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   }
 }
 
-TEST(PlannerFunctions, calculateFOV) {
-  // GIVEN: the horizontal and vertical Field of View, the vehicle yaw and pitc
-  float h_fov = 90.0f;
-  float v_fov = 45.0f;
-  float yaw_z_greater_grid_length =
-      270.f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min >= GRID_LENGTH_Z
-  float yaw_z_max_greater_grid =
-      210.f;  // z_FOV_max >= GRID_LENGTH_Z && z_FOV_min < GRID_LENGTH_Z
-  float yaw_z_min_smaller_zero = -140.f;  // z_FOV_min < 0 && z_FOV_max >= 0
-  float yaw_z_smaller_zero = -235.f;      // z_FOV_max < 0 && z_FOV_min < 0
-  float pitch = 0.0f;
-
-  // WHEN: we calculate the Field of View
-  FOV_indices FOV_greater_grid_length;
-  FOV_indices FOV_max_greater_grid;
-  FOV_indices FOV_min_smaller_zero;
-  FOV_indices FOV_smaller_zero;
-
-  calculateFOV(h_fov, v_fov, FOV_greater_grid_length, yaw_z_greater_grid_length,
-               pitch);
-  calculateFOV(h_fov, v_fov, FOV_max_greater_grid, yaw_z_max_greater_grid,
-               pitch);
-  calculateFOV(h_fov, v_fov, FOV_min_smaller_zero, yaw_z_min_smaller_zero,
-               pitch);
-  calculateFOV(h_fov, v_fov, FOV_smaller_zero, yaw_z_smaller_zero, pitch);
-
-  // THEN: we expect polar histogram indexes that are in the Field of View
-  std::vector<int> output_z_greater_grid_length = {
-      7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
-  std::vector<int> output_z_max_greater_grid = {0, 1, 2,  3,  4,  5,  6,  7,
-                                                8, 9, 10, 11, 12, 57, 58, 59};
-  std::vector<int> output_z_min_smaller_zero = {0, 1, 2,  3,  4,  5,  6,  7,
-                                                8, 9, 10, 11, 12, 13, 14, 59};
-  std::vector<int> output_z_smaller_zero = {43, 44, 45, 46, 47, 48, 49, 50,
-                                            51, 52, 53, 54, 55, 56, 57, 58};
-
-  EXPECT_EQ(18, FOV_smaller_zero.e_idx_max);
-  EXPECT_EQ(11, FOV_smaller_zero.e_idx_min);
-
-  // vector sizes:
-  EXPECT_EQ(output_z_greater_grid_length.size(),
-            FOV_greater_grid_length.z_idx_vec.size());
-  EXPECT_EQ(output_z_max_greater_grid.size(), output_z_max_greater_grid.size());
-  EXPECT_EQ(output_z_min_smaller_zero.size(), output_z_min_smaller_zero.size());
-  EXPECT_EQ(output_z_smaller_zero.size(), output_z_smaller_zero.size());
-
-  for (size_t i = 0; i < FOV_greater_grid_length.z_idx_vec.size(); i++) {
-    EXPECT_EQ(output_z_greater_grid_length.at(i),
-              FOV_greater_grid_length.z_idx_vec.at(i));
-  }
-
-  for (size_t i = 0; i < FOV_max_greater_grid.z_idx_vec.size(); i++) {
-    EXPECT_EQ(output_z_max_greater_grid.at(i),
-              FOV_max_greater_grid.z_idx_vec.at(i));
-  }
-
-  for (size_t i = 0; i < FOV_min_smaller_zero.z_idx_vec.size(); i++) {
-    EXPECT_EQ(output_z_min_smaller_zero.at(i),
-              FOV_min_smaller_zero.z_idx_vec.at(i));
-  }
-
-  for (size_t i = 0; i < FOV_smaller_zero.z_idx_vec.size(); i++) {
-    EXPECT_EQ(output_z_smaller_zero.at(i), FOV_smaller_zero.z_idx_vec.at(i));
-  }
-}
-
 TEST(PlannerFunctionsTests, processPointcloud) {
   // GIVEN: two point clouds
   const Eigen::Vector3f position(1.5f, 1.0f, 4.5f);
@@ -181,16 +115,18 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   processed_cloud2.push_back(toXYZI(position + memory_point, 5));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5));
 
-  FOV_indices FOV_zero;  // empty FOV, no remembered points will be forgotten
-                         // due to inside FOV
-  FOV_zero.e_idx_max = 0;
-  FOV_zero.e_idx_min = 0;
-  FOV_zero.z_idx_vec.push_back(0);
+  FOV FOV_zero;  // empty FOV, no remembered points will be forgotten
+                 // due to inside FOV
+  FOV_zero.h_fov_deg = 0.f;
+  FOV_zero.v_fov_deg = 0.f;
+  FOV_zero.yaw_deg = 1.0f;
+  FOV_zero.pitch_deg = 1.0f;
 
-  FOV_indices FOV_regular;
-  FOV_regular.e_idx_max = 10;
-  FOV_regular.e_idx_min = 6;
-  FOV_regular.z_idx_vec.push_back(21);
+  FOV FOV_regular;
+  FOV_regular.h_fov_deg = 85.0f;
+  FOV_regular.v_fov_deg = 65.0f;
+  FOV_regular.yaw_deg = 1.0f;
+  FOV_regular.pitch_deg = 1.0f;
 
   // WHEN: we filter the PointCloud with different values max_age
   processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -114,8 +114,6 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
-  std::cout << "mem point e: " << memory_point_polar.e
-            << "z: " << memory_point_polar.z << std::endl;
 
   FOV FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
   FOV_zero.h_fov_deg = 0.0f;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -114,7 +114,8 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
-  std::cout << "mem point e: " << memory_point_polar.e << "z: " << memory_point_polar.z << std::endl;
+  std::cout << "mem point e: " << memory_point_polar.e
+            << "z: " << memory_point_polar.z << std::endl;
 
   FOV FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
   FOV_zero.h_fov_deg = 0.0f;
@@ -125,7 +126,7 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   FOV FOV_regular;
   FOV_regular.h_fov_deg = 85.0f;
   FOV_regular.v_fov_deg = 65.0f;
-  FOV_regular.yaw_deg = 90.0f; // in histogram frame!
+  FOV_regular.yaw_deg = 90.0f;  // in histogram frame!
   FOV_regular.pitch_deg = 1.0f;
 
   // WHEN: we filter the PointCloud with different values max_age

--- a/local_planner/test/test_star_planner.cpp
+++ b/local_planner/test/test_star_planner.cpp
@@ -48,7 +48,6 @@ class StarPlannerTests : public ::testing::Test {
     costParameters cost_params;
 
     star_planner.setParams(cost_params);
-    star_planner.setFOV(270.0f, 45.0f);
     star_planner.setPointcloud(cloud);
     star_planner.setPose(position, 0.0f);
     star_planner.setGoal(goal);


### PR DESCRIPTION
This is a refactor of the way the FOV is kept internally - with current orientation and sensor FOV instead of histogram indices.

The end goal of this refactor is to address #357 

This has the (theoretical) drawback that we could not account for discontinuous FOV anymore (multiple cameras...). This hasn't been done so far anyway
