### PR TITLE
Remove repeated info outputs in visualizer

### DIFF
--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -120,7 +120,7 @@ int WorldVisualizer::visualizeRVIZWorld(const std::string& world_path) {
   }
 
   world_pub_.publish(marker_array);
-  ROS_INFO("Successfully loaded rviz world");
+  ROS_INFO_ONCE("Successfully loaded rviz world");
   return 0;
 }
 


### PR DESCRIPTION
After visualizing the world moved to `WorldVisualizer`, `ROSINFO` is flooding the console output with `Successfully loaded rviz world` as below
```
[ INFO] [1557945199.308421401, 20.588000000]: Creating 1 swatches
[ INFO] [1557945200.522503617, 21.600000000]: Creating 1 swatches
[ INFO] [1557945200.961392230, 22.000000000]: Successfully loaded rviz world
[ INFO] [1557945201.408963923, 22.436000000]: HP: requesting home position
[ INFO] [1557945201.611341746, 22.636000000]: Creating 1 swatches
[ INFO] [1557945202.603751584, 23.612000000]: Creating 1 swatches
[ INFO] [1557945203.004797869, 24.004000000]: Successfully loaded rviz world
[ INFO] [1557945203.467378202, 24.452000000]: Creating 1 swatches
[ INFO] [1557945204.459814082, 25.212000000]: Creating 1 swatches
[ INFO] [1557945205.228142521, 25.920000000]: Creating 1 swatches
[ INFO] [1557945205.317867858, 26.004000000]: Successfully loaded rviz world
```
This PR makes the statement be printed only once