### PR TITLE
Deprecate threePointMsg in global_planner

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -64,7 +64,6 @@ find_package(octomap REQUIRED)
 add_message_files(
   FILES
   PathWithRiskMsg.msg
-  ThreePointMsg.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/global_planner/msg/ThreePointMsg.msg
+++ b/global_planner/msg/ThreePointMsg.msg
@@ -1,7 +1,0 @@
-Header header
-geometry_msgs/Point prev
-geometry_msgs/Point ctrl
-geometry_msgs/Point next
-float64 duration
-float64 max_acc
-float64 acc_per_err

--- a/global_planner/src/nodes/global_planner_node.h
+++ b/global_planner/src/nodes/global_planner_node.h
@@ -69,16 +69,12 @@ class GlobalPlannerNode {
   ros::Subscriber ground_truth_sub_;
   ros::Subscriber velocity_sub_;
   ros::Subscriber clicked_point_sub_;
-  ros::Subscriber three_point_sub_;
   ros::Subscriber move_base_simple_sub_;
   ros::Subscriber laser_sensor_sub_;
   ros::Subscriber depth_camera_sub_;
   ros::Subscriber fcu_input_sub_;
 
   // Publishers
-  ros::Publisher three_points_pub_;
-  ros::Publisher three_points_smooth_pub_;
-  ros::Publisher three_points_revised_pub_;
   ros::Publisher global_path_pub_;
   ros::Publisher global_temp_path_pub_;
   ros::Publisher smooth_path_pub_;
@@ -101,7 +97,6 @@ class GlobalPlannerNode {
   void velocityCallback(const geometry_msgs::TwistStamped& msg);
   void positionCallback(const geometry_msgs::PoseStamped& msg);
   void clickedPointCallback(const geometry_msgs::PointStamped& msg);
-  void threePointCallback(const nav_msgs::Path& msg);
   void moveBaseSimpleCallback(const geometry_msgs::PoseStamped& msg);
   void laserSensorCallback(const sensor_msgs::LaserScan& msg);
   void octomapFullCallback(const octomap_msgs::Octomap& msg);

--- a/global_planner/src/nodes/path_handler_node.cpp
+++ b/global_planner/src/nodes/path_handler_node.cpp
@@ -72,7 +72,9 @@ void PathHandlerNode::readParams() {
   nh_.param<double>("start_pos_z", start_pos_.z, 3.5);
 }
 
-bool PathHandlerNode::isCloseToGoal() {  return distance(current_goal_, last_pos_) < 1.5; }
+bool PathHandlerNode::isCloseToGoal() {
+  return distance(current_goal_, last_pos_) < 1.5;
+}
 
 double PathHandlerNode::getRiskOfCurve(
     const std::vector<geometry_msgs::PoseStamped>& poses) {

--- a/global_planner/src/nodes/path_handler_node.h
+++ b/global_planner/src/nodes/path_handler_node.h
@@ -18,7 +18,6 @@
 
 #include <global_planner/PathHandlerNodeConfig.h>
 #include <global_planner/PathWithRiskMsg.h>
-#include <global_planner/ThreePointMsg.h>
 #include "global_planner/common.h"
 #include "global_planner/common_ros.h"
 
@@ -50,8 +49,6 @@ class PathHandlerNode {
   // Publishers
   ros::Publisher mavros_waypoint_publisher_;
   ros::Publisher current_waypoint_publisher_;
-  ros::Publisher three_point_path_publisher_;
-  ros::Publisher three_point_msg_publisher_;
   ros::Publisher avoidance_triplet_msg_publisher_;
   ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher mavros_system_status_pub_;
@@ -73,12 +70,10 @@ class PathHandlerNode {
 
   double start_yaw_;
   // Parameters (Dynamic Reconfiguration)
-  bool three_point_mode_;
   bool ignore_path_messages_;
   bool startup_;
   double min_speed_;
   double max_speed_;
-  double three_point_speed_;
   double direct_goal_alt_;
   double speed_ = min_speed_;
   double spin_dt_;
@@ -90,7 +85,6 @@ class PathHandlerNode {
 
   // Methods
   void readParams();
-  bool shouldPublishThreePoints();
   bool isCloseToGoal();
   double getRiskOfCurve(const std::vector<geometry_msgs::PoseStamped>& poses);
   void setCurrentPath(const std::vector<geometry_msgs::PoseStamped>& poses);
@@ -112,7 +106,6 @@ class PathHandlerNode {
   void transformPoseToObstacleAvoidance(mavros_msgs::Trajectory& obst_avoid,
                                         geometry_msgs::PoseStamped pose);
   void publishSetpoint();
-  void publishThreePointMsg();
   void publishSystemStatus();
 };
 


### PR DESCRIPTION
This PR deprecates the threePointMsg custom message implementation in `global_planner`.

Initially it was quite confusing for me to understand why this message exists in the first place. It seems like it was a interface that was a precursor of the Avoidance triplet. This Fixes #354 

This does not affect the performance of global_planner.

Tested in SITL, both in offboard and mission