### PR TITLE
Dynamically estimate FOV based on point cloud

### DIFF
--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -46,15 +46,16 @@ struct PolarPoint {
 
 /**
 * Struct defining the Field of View of the sensor. This is defined by
-* the current yaw and pitch (in local frame) and the horizontal and vertical
+* the current azimuth and elevation angles and the horizontal and vertical
 * field of view of the sensor
 */
 struct FOV {
-  FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
+  FOV()
+      : azimuth_deg(0.f), elevation_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
   FOV(float y, float p, float h, float v)
-      : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
-  float yaw_deg;
-  float pitch_deg;
+      : azimuth_deg(y), elevation_deg(p), h_fov_deg(h), v_fov_deg(v){};
+  float azimuth_deg;
+  float elevation_deg;
   float h_fov_deg;
   float v_fov_deg;
 };

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -156,14 +156,16 @@ float getPitchFromQuaternion(const Eigen::Quaternionf q);
 
 /**
 * @brief     wrappes the input angle in to plus minus PI space
-* @param[in, out] angle to be wrapped  [rad]
+* @param[in] angle to be wrapped  [rad]
+* @returns   wrapped angle [rad]
 **/
-void wrapAngleToPlusMinusPI(float& angle);
+float wrapAngleToPlusMinusPI(float angle);
 /**
 * @brief     wrappes the input angle in to plus minus 180 deg space
-* @param[in, out] angle to be wrapped  [deg]
+* @param[in] angle to be wrapped  [deg]
+* @returns   wrapped angle [deg]
 **/
-void wrapAngleToPlusMinus180(float& angle);
+float wrapAngleToPlusMinus180(float angle);
 /**
 * @brief     computes an angular velocity to reach the desired_yaw
 * @param[in] adesired_yaw  [rad]

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -61,6 +61,8 @@ struct FOV {
 };
 
 #define M_PI_F 3.14159265358979323846f
+#define WARN_UNUSED __attribute__((warn_unused_result))
+
 const float DEG_TO_RAD = M_PI_F / 180.f;
 const float RAD_TO_DEG = 180.0f / M_PI_F;
 
@@ -159,13 +161,13 @@ float getPitchFromQuaternion(const Eigen::Quaternionf q);
 * @param[in] angle to be wrapped  [rad]
 * @returns   wrapped angle [rad]
 **/
-float wrapAngleToPlusMinusPI(float angle);
+float WARN_UNUSED wrapAngleToPlusMinusPI(float angle);
 /**
 * @brief     wrappes the input angle in to plus minus 180 deg space
 * @param[in] angle to be wrapped  [deg]
 * @returns   wrapped angle [deg]
 **/
-float wrapAngleToPlusMinus180(float angle);
+float WARN_UNUSED wrapAngleToPlusMinus180(float angle);
 /**
 * @brief     computes an angular velocity to reach the desired_yaw
 * @param[in] adesired_yaw  [rad]

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -11,10 +11,10 @@ namespace avoidance {
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
   // pitch angle must be counted negative: zero pitch is level, positive pitch
   // is leaning down. Whereas a positive elevation angle is counted upwards
-  return p_pol.z <= fov.yaw_deg + fov.h_fov_deg / 2.f &&
-         p_pol.z >= fov.yaw_deg - fov.h_fov_deg / 2.f &&
-         p_pol.e <= -fov.pitch_deg + fov.v_fov_deg / 2.f &&
-         p_pol.e >= -fov.pitch_deg - fov.v_fov_deg / 2.f;
+  return p_pol.z <= fov.azimuth_deg + fov.h_fov_deg / 2.f &&
+         p_pol.z >= fov.azimuth_deg - fov.h_fov_deg / 2.f &&
+         p_pol.e <= -fov.elevation_deg + fov.v_fov_deg / 2.f &&
+         p_pol.e >= -fov.elevation_deg - fov.v_fov_deg / 2.f;
 }
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -9,12 +9,12 @@
 namespace avoidance {
 
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
-  // pitch angle must be counted negative: zero pitch is level, positive pitch
-  // is leaning down. Whereas a positive elevation angle is counted upwards
-  return p_pol.z <= fov.azimuth_deg + fov.h_fov_deg / 2.f &&
-         p_pol.z >= fov.azimuth_deg - fov.h_fov_deg / 2.f &&
-         p_pol.e <= -fov.elevation_deg + fov.v_fov_deg / 2.f &&
-         p_pol.e >= -fov.elevation_deg - fov.v_fov_deg / 2.f;
+  return p_pol.z <=
+             wrapAngleToPlusMinus180(fov.azimuth_deg + fov.h_fov_deg / 2.f) &&
+         p_pol.z >=
+             wrapAngleToPlusMinus180(fov.azimuth_deg - fov.h_fov_deg / 2.f) &&
+         p_pol.e <= fov.elevation_deg + fov.v_fov_deg / 2.f &&
+         p_pol.e >= fov.elevation_deg - fov.v_fov_deg / 2.f;
 }
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
@@ -83,8 +83,8 @@ Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res) {
 
 void wrapPolar(PolarPoint& p_pol) {
   // first wrap the angles to +-180 degrees
-  wrapAngleToPlusMinus180(p_pol.e);
-  wrapAngleToPlusMinus180(p_pol.z);
+  p_pol.e = wrapAngleToPlusMinus180(p_pol.e);
+  p_pol.z = wrapAngleToPlusMinus180(p_pol.z);
 
   // elevation valid [-90,90)
   // when abs(elevation) > 90, wrap elevation angle
@@ -142,16 +142,16 @@ float getPitchFromQuaternion(const Eigen::Quaternionf q) {
   return pitch * RAD_TO_DEG;
 }
 
-void wrapAngleToPlusMinusPI(float& angle) {
-  angle = angle - 2.0f * M_PI_F * std::floor(angle / (2.0f * M_PI_F) + 0.5f);
+float wrapAngleToPlusMinusPI(float angle) {
+  return angle - 2.0f * M_PI_F * std::floor(angle / (2.0f * M_PI_F) + 0.5f);
 }
 
-void wrapAngleToPlusMinus180(float& angle) {
-  angle = angle - 360.f * std::floor(angle / 360.f + 0.5f);
+float wrapAngleToPlusMinus180(float angle) {
+  return angle - 360.f * std::floor(angle / 360.f + 0.5f);
 }
 
 double getAngularVelocity(float desired_yaw, float curr_yaw) {
-  wrapAngleToPlusMinusPI(desired_yaw);
+  desired_yaw = wrapAngleToPlusMinusPI(desired_yaw);
   float yaw_vel1 = desired_yaw - curr_yaw;
   float yaw_vel2;
   // finds the yaw vel for the other yaw direction

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -8,21 +8,21 @@ using namespace avoidance;
 TEST(Common, pointInsideFOV) {
   // GIVEN: three points and a regular FOV
   FOV fov(34.0f, 12.0f, 90.0f, 60.0f);
-  PolarPoint p_outside_yaw(-1.0f, 126.0f, 2.0f);
-  PolarPoint p_outside_pitch(-60.0f, 30.0f, 2.0f);
-  PolarPoint p_inside_pitch_sign(-41.0f, 0.0f, 2.0f);
+  PolarPoint p_outside_azimuth(-1.0f, 126.0f, 2.0f);
+  PolarPoint p_outside_elevation(-60.0f, 30.0f, 2.0f);
+  PolarPoint p_inside_elevation_sign(41.0f, 0.0f, 2.0f);
   PolarPoint p_inside_fov(5.0f, 25.0f, 2.0f);
 
   // WHEN: we check whether they are inside the FOV
-  bool outside_yaw = pointInsideFOV(fov, p_outside_yaw);
-  bool outside_pitch = pointInsideFOV(fov, p_outside_pitch);
-  bool inside_pitch_sign = pointInsideFOV(fov, p_inside_pitch_sign);
+  bool outside_azimuth = pointInsideFOV(fov, p_outside_azimuth);
+  bool outside_elevation = pointInsideFOV(fov, p_outside_elevation);
+  bool inside_elevation_sign = pointInsideFOV(fov, p_inside_elevation_sign);
   bool inside = pointInsideFOV(fov, p_inside_fov);
 
   // THEN: they should lie in the expected region
-  EXPECT_FALSE(outside_yaw);
-  EXPECT_FALSE(outside_pitch);
-  EXPECT_TRUE(inside_pitch_sign);
+  EXPECT_FALSE(outside_azimuth);
+  EXPECT_FALSE(outside_elevation);
+  EXPECT_TRUE(inside_elevation_sign);
   EXPECT_TRUE(inside);
 }
 
@@ -344,12 +344,12 @@ TEST(Common, wrapAngle) {
   float angle6 = std::numeric_limits<float>::infinity();
 
   // WHEN: it is wrapped to the space (-PI; PI] space
-  wrapAngleToPlusMinusPI(angle1);
-  wrapAngleToPlusMinusPI(angle2);
-  wrapAngleToPlusMinusPI(angle3);
-  wrapAngleToPlusMinusPI(angle4);
-  wrapAngleToPlusMinusPI(angle5);
-  wrapAngleToPlusMinusPI(angle6);
+  angle1 = wrapAngleToPlusMinusPI(angle1);
+  angle2 = wrapAngleToPlusMinusPI(angle2);
+  angle3 = wrapAngleToPlusMinusPI(angle3);
+  angle4 = wrapAngleToPlusMinusPI(angle4);
+  angle5 = wrapAngleToPlusMinusPI(angle5);
+  angle6 = wrapAngleToPlusMinusPI(angle6);
 
   // THEN: the output angles shoudl be ..
   EXPECT_FLOAT_EQ(0.f, angle1);

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -77,8 +77,6 @@ class LocalPlanner {
   int n_expanded_nodes_;
   int min_num_points_per_cell_ = 3;
 
-  float curr_yaw_fcu_frame_deg_, curr_yaw_histogram_frame_deg_;
-  float curr_pitch_fcu_frame_deg_;
   ros::Time integral_time_old_;
   float no_progress_slope_;
   float new_yaw_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -35,7 +35,7 @@ namespace avoidance {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const FOV& fov, const Eigen::Vector3f& position,
+    Box histogram_box, FOV& fov, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell);
 

--- a/local_planner/launch/rs_depthcloud.launch
+++ b/local_planner/launch/rs_depthcloud.launch
@@ -38,7 +38,7 @@ Processing enabled by this node:
 -->
 
 <launch>
-  <arg name="tf_prefix"           default=""/> 
+  <arg name="tf_prefix"           default=""/>
   <arg name="namespace"           default="camera"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
 
@@ -71,7 +71,7 @@ Processing enabled by this node:
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="true"/>
   <arg name="align_depth"         default="false"/>
-  
+
   <!-- rgbd_launch specific arguments -->
 
   <!--<arg name="depth_scale" value="0.25" description="scaling factor for image_proc/resize"/>-->
@@ -140,9 +140,9 @@ Processing enabled by this node:
 
      <node pkg="nodelet" type="nodelet" name="points_xyz_sw_registered"
             args="load depth_image_proc/point_cloud_xyz $(arg manager) $(arg bond)" respawn="$(arg respawn)">
-        <remap from="camera_info"             to="$(arg depth)/camera_info" />
-        <remap from="image_rect" to="$(arg depth)/image_rect_raw" />
-        <remap from="points"     to="$(arg depth)/points" />
+        <remap from="camera_info"             to="depth/camera_info" />
+        <remap from="image_rect" to="depth/image_rect_raw" />
+        <remap from="points"     to="depth/points" />
       </node>
 
 

--- a/local_planner/launch/rs_depthcloud.launch
+++ b/local_planner/launch/rs_depthcloud.launch
@@ -38,7 +38,7 @@ Processing enabled by this node:
 -->
 
 <launch>
-  <arg name="tf_prefix"           default=""/>
+  <arg name="tf_prefix"           default=""/> 
   <arg name="namespace"           default="camera"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
 
@@ -71,7 +71,7 @@ Processing enabled by this node:
   <arg name="enable_pointcloud"   default="false"/>
   <arg name="enable_sync"         default="true"/>
   <arg name="align_depth"         default="false"/>
-
+  
   <!-- rgbd_launch specific arguments -->
 
   <!--<arg name="depth_scale" value="0.25" description="scaling factor for image_proc/resize"/>-->
@@ -140,9 +140,9 @@ Processing enabled by this node:
 
      <node pkg="nodelet" type="nodelet" name="points_xyz_sw_registered"
             args="load depth_image_proc/point_cloud_xyz $(arg manager) $(arg bond)" respawn="$(arg respawn)">
-        <remap from="camera_info"             to="depth/camera_info" />
-        <remap from="image_rect" to="depth/image_rect_raw" />
-        <remap from="points"     to="depth/points" />
+        <remap from="camera_info"             to="$(arg depth)/camera_info" />
+        <remap from="image_rect" to="$(arg depth)/image_rect_raw" />
+        <remap from="points"     to="$(arg depth)/points" />
       </node>
 
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -16,8 +16,10 @@ LocalPlanner::~LocalPlanner() {}
 void LocalPlanner::setPose(const Eigen::Vector3f& pos,
                            const Eigen::Quaternionf& q) {
   position_ = pos;
-  fov_.azimuth_deg = -getYawFromQuaternion(q) + 90.0f;
-  wrapAngleToPlusMinus180(fov_.azimuth_deg);
+
+  // Azimuth angle in histogram convention is different from FCU convention!
+  // Azimuth is flipped and rotated 90 degrees, elevation is just flipped
+  fov_.azimuth_deg = wrapAngleToPlusMinus180(-getYawFromQuaternion(q) + 90.0f);
   fov_.elevation_deg = -getPitchFromQuaternion(q);
   star_planner_->setPose(position_, fov_.azimuth_deg);
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -95,7 +95,6 @@ void LocalPlanner::runPlanner() {
   processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
-  std::cout << "fov: " << fov_.h_fov_deg << std::endl;
   last_pointcloud_process_time_ = ros::Time::now();
 
   determineStrategy();

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -85,7 +85,7 @@ void LocalPlanner::runPlanner() {
            static_cast<int>(original_cloud_vector_.size()));
 
   // calculate Field of View
-  fov_.yaw_deg = curr_yaw_histogram_frame_deg_;
+  fov_.yaw_deg = curr_yaw_fcu_frame_deg_;
   fov_.pitch_deg = curr_pitch_fcu_frame_deg_;
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
@@ -95,6 +95,7 @@ void LocalPlanner::runPlanner() {
   processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
+  std::cout << "fov: " << fov_.h_fov_deg << std::endl;
   last_pointcloud_process_time_ = ros::Time::now();
 
   determineStrategy();

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -564,8 +564,9 @@ void LocalPlannerNode::cameraInfoCallback(
       2.0 * atan(static_cast<double>(msg->height) / (2.0 * msg->K[4])) * 180.0 /
       M_PI);
 
-  local_planner_->setFOV(h_fov, v_fov);
-  wp_generator_->setFOV(h_fov, v_fov);
+  // make sure to underestimate FOV to avoid blind spots!
+  local_planner_->setFOV(h_fov - 15.0f, v_fov - 15.0f);
+  wp_generator_->setFOV(h_fov - 15.0f, v_fov - 15.0f);
 }
 
 void LocalPlannerNode::dynamicReconfigureCallback(

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -93,14 +93,14 @@ void LocalPlannerVisualization::publishFOV(const Eigen::Vector3f& drone_pos,
                                            const float max_range) const {
   // pitch angle must be counted negative: zero pitch is level, positive pitch
   // is leaning down. Whereas a positive elevation angle is counted upwards
-  PolarPoint p1(-fov.pitch_deg - fov.v_fov_deg / 2.f,
-                -fov.yaw_deg + 90.0f + fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p2(-fov.pitch_deg + fov.v_fov_deg / 2.f,
-                -fov.yaw_deg + 90.0f + fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p3(-fov.pitch_deg + fov.v_fov_deg / 2.f,
-                -fov.yaw_deg + 90.0f - fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p4(-fov.pitch_deg - fov.v_fov_deg / 2.f,
-                -fov.yaw_deg + 90.0f - fov.h_fov_deg / 2.f, max_range);
+  PolarPoint p1(fov.elevation_deg - fov.v_fov_deg / 2.f,
+                fov.azimuth_deg + fov.h_fov_deg / 2.f, max_range);
+  PolarPoint p2(fov.elevation_deg + fov.v_fov_deg / 2.f,
+                fov.azimuth_deg + fov.h_fov_deg / 2.f, max_range);
+  PolarPoint p3(fov.elevation_deg + fov.v_fov_deg / 2.f,
+                fov.azimuth_deg - fov.h_fov_deg / 2.f, max_range);
+  PolarPoint p4(fov.elevation_deg - fov.v_fov_deg / 2.f,
+                fov.azimuth_deg - fov.h_fov_deg / 2.f, max_range);
 
   visualization_msgs::Marker m;
   m.header.frame_id = "local_origin";

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -94,13 +94,13 @@ void LocalPlannerVisualization::publishFOV(const Eigen::Vector3f& drone_pos,
   // pitch angle must be counted negative: zero pitch is level, positive pitch
   // is leaning down. Whereas a positive elevation angle is counted upwards
   PolarPoint p1(-fov.pitch_deg - fov.v_fov_deg / 2.f,
-                fov.yaw_deg + fov.h_fov_deg / 2.f, max_range);
+                -fov.yaw_deg + 90.0f + fov.h_fov_deg / 2.f, max_range);
   PolarPoint p2(-fov.pitch_deg + fov.v_fov_deg / 2.f,
-                fov.yaw_deg + fov.h_fov_deg / 2.f, max_range);
+                -fov.yaw_deg + 90.0f + fov.h_fov_deg / 2.f, max_range);
   PolarPoint p3(-fov.pitch_deg + fov.v_fov_deg / 2.f,
-                fov.yaw_deg - fov.h_fov_deg / 2.f, max_range);
+                -fov.yaw_deg + 90.0f - fov.h_fov_deg / 2.f, max_range);
   PolarPoint p4(-fov.pitch_deg - fov.v_fov_deg / 2.f,
-                fov.yaw_deg - fov.h_fov_deg / 2.f, max_range);
+                -fov.yaw_deg + 90.0f - fov.h_fov_deg / 2.f, max_range);
 
   visualization_msgs::Marker m;
   m.header.frame_id = "local_origin";

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -91,8 +91,6 @@ void LocalPlannerVisualization::visualizePlannerData(
 void LocalPlannerVisualization::publishFOV(const Eigen::Vector3f& drone_pos,
                                            const FOV& fov,
                                            const float max_range) const {
-  // pitch angle must be counted negative: zero pitch is level, positive pitch
-  // is leaning down. Whereas a positive elevation angle is counted upwards
   PolarPoint p1(fov.elevation_deg - fov.v_fov_deg / 2.f,
                 fov.azimuth_deg + fov.h_fov_deg / 2.f, max_range);
   PolarPoint p2(fov.elevation_deg + fov.v_fov_deg / 2.f,

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -53,9 +53,9 @@ void processPointcloud(
             fov_yaw_upper_boundary =
                 std::max(fov_yaw_upper_boundary, -p_pol.z + 90.f);
             fov_pitch_lower_boundary =
-                std::min(fov_pitch_lower_boundary, p_pol.e);
+                std::min(fov_pitch_lower_boundary, -p_pol.e);
             fov_pitch_upper_boundary =
-                std::max(fov_pitch_upper_boundary, p_pol.e);
+                std::max(fov_pitch_upper_boundary, -p_pol.e);
 
             // subsampling the cloud
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
@@ -88,13 +88,15 @@ void processPointcloud(
       distance = (position - toEigen(xyzi)).norm();
       if (distance < histogram_box.radius_) {
         PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
+        PolarPoint p_pol_fcu_frame(-p_pol.e, -p_pol.z+90.f, p_pol.r);
+
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
 
         // only remember point if it's in a cell not previously populated by
         // complete_cloud, as well as outside FOV and 'young' enough
         if (histogram_points_counter(p_ind.y(), p_ind.x()) <
                 min_num_points_per_cell &&
-            xyzi.intensity < max_age && !pointInsideFOV(fov, p_pol)) {
+            xyzi.intensity < max_age && !pointInsideFOV(fov, p_pol_fcu_frame)) {
           final_cloud.points.push_back(
               toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -88,7 +88,7 @@ void processPointcloud(
       distance = (position - toEigen(xyzi)).norm();
       if (distance < histogram_box.radius_) {
         PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
-        PolarPoint p_pol_fcu_frame(-p_pol.e, -p_pol.z+90.f, p_pol.r);
+        PolarPoint p_pol_fcu_frame(-p_pol.e, -p_pol.z + 90.f, p_pol.r);
 
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
 

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -24,12 +24,12 @@ void processPointcloud(
 
   float distance;
 
-  float fov_yaw_lower_boundary = fov.azimuth_deg - fov.h_fov_deg / 2.0f;
-  float fov_yaw_upper_boundary = fov.azimuth_deg + fov.h_fov_deg / 2.0f;
-  float fov_pitch_lower_boundary = fov.elevation_deg - fov.v_fov_deg / 2.0f;
-  float fov_pitch_upper_boundary = fov.elevation_deg + fov.v_fov_deg / 2.0f;
-  wrapAngleToPlusMinus180(fov_yaw_lower_boundary);
-  wrapAngleToPlusMinus180(fov_yaw_upper_boundary);
+  float fov_azimuth_lower_boundary =
+      wrapAngleToPlusMinus180(fov.azimuth_deg - fov.h_fov_deg / 2.0f);
+  float fov_azimuth_upper_boundary =
+      wrapAngleToPlusMinus180(fov.azimuth_deg + fov.h_fov_deg / 2.0f);
+  float fov_elevation_lower_boundary = fov.elevation_deg - fov.v_fov_deg / 2.0f;
+  float fov_elevation_upper_boundary = fov.elevation_deg + fov.v_fov_deg / 2.0f;
 
   // counter to keep track of how many points lie in a given cell
   Eigen::MatrixXi histogram_points_counter(180 / (ALPHA_RES / 2),
@@ -46,14 +46,14 @@ void processPointcloud(
               distance < histogram_box.radius_) {
             // Keep track of the FOV
             PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
-            // To get yaw in local frame instead of histogram frame, add 90
-            // degrees
-            fov_yaw_lower_boundary = std::min(fov_yaw_lower_boundary, p_pol.z);
-            fov_yaw_upper_boundary = std::max(fov_yaw_upper_boundary, p_pol.z);
-            fov_pitch_lower_boundary =
-                std::min(fov_pitch_lower_boundary, p_pol.e);
-            fov_pitch_upper_boundary =
-                std::max(fov_pitch_upper_boundary, p_pol.e);
+            fov_azimuth_lower_boundary =
+                std::min(fov_azimuth_lower_boundary, p_pol.z);
+            fov_azimuth_upper_boundary =
+                std::max(fov_azimuth_upper_boundary, p_pol.z);
+            fov_elevation_lower_boundary =
+                std::min(fov_elevation_lower_boundary, p_pol.e);
+            fov_elevation_upper_boundary =
+                std::max(fov_elevation_upper_boundary, p_pol.e);
 
             // subsampling the cloud
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
@@ -72,11 +72,13 @@ void processPointcloud(
   // margin to avoid creating a blind spot due to latency and fast yaw movements
   fov.h_fov_deg = std::max(
       fov.h_fov_deg,
-      std::min(360.0f - (fov_yaw_upper_boundary - fov_yaw_lower_boundary),
-               fov_yaw_upper_boundary - fov_yaw_lower_boundary) -
+      std::min(
+          360.0f - (fov_azimuth_upper_boundary - fov_azimuth_lower_boundary),
+          fov_azimuth_upper_boundary - fov_azimuth_lower_boundary) -
           15.0f);
-  fov.v_fov_deg = std::max(fov.v_fov_deg, fov_pitch_upper_boundary -
-                                              fov_pitch_lower_boundary - 15.0f);
+  fov.v_fov_deg =
+      std::max(fov.v_fov_deg, fov_elevation_upper_boundary -
+                                  fov_elevation_lower_boundary - 15.0f);
 
   // combine with old cloud
   for (const pcl::PointXYZI& xyzi : old_cloud) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -13,7 +13,7 @@ namespace avoidance {
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const FOV& fov, const Eigen::Vector3f& position,
+    Box histogram_box, FOV& fov, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell) {
   pcl::PointCloud<pcl::PointXYZI> old_cloud;
@@ -23,6 +23,12 @@ void processPointcloud(
   final_cloud.points.reserve((2 * GRID_LENGTH_Z) * (2 * GRID_LENGTH_E));
 
   float distance;
+  // todo: wrapping
+  float fov_yaw_lower_boundary = fov.yaw_deg - fov.h_fov_deg / 2;
+  float fov_yaw_upper_boundary = fov.yaw_deg + fov.h_fov_deg / 2;
+  float fov_pitch_lower_boundary = fov.pitch_deg - fov.v_fov_deg / 2;
+  float fov_pitch_upper_boundary = fov.pitch_deg - fov.v_fov_deg / 2;
+
 
   // counter to keep track of how many points lie in a given cell
   Eigen::MatrixXi histogram_points_counter(180 / (ALPHA_RES / 2),
@@ -37,8 +43,16 @@ void processPointcloud(
           distance = (position - toEigen(xyz)).norm();
           if (distance > min_realsense_dist &&
               distance < histogram_box.radius_) {
-            // subsampling the cloud
+
+            // Keep track of the FOV
             PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
+           fov_yaw_lower_boundary = std::min(fov_yaw_lower_boundary, p_pol.z);
+           fov_yaw_upper_boundary = std::max(fov_yaw_upper_boundary, p_pol.z);
+           fov_pitch_lower_boundary = std::min(fov_pitch_lower_boundary, p_pol.e);
+           fov_pitch_upper_boundary = std::max(fov_pitch_upper_boundary, p_pol.e);
+
+           // subsampling the cloud
+
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
             histogram_points_counter(p_ind.y(), p_ind.x())++;
             if (histogram_points_counter(p_ind.y(), p_ind.x()) ==
@@ -50,6 +64,10 @@ void processPointcloud(
       }
     }
   }
+  // Update the FOV
+  fov.h_fov_deg = std::max(fov.h_fov_deg, fov_yaw_upper_boundary - fov_yaw_lower_boundary);
+  fov.v_fov_deg = std::max(fov.v_fov_deg, fov_pitch_upper_boundary - fov_pitch_lower_boundary);
+
 
   // combine with old cloud
   for (const pcl::PointXYZI& xyzi : old_cloud) {

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -232,18 +232,18 @@ void WaypointGenerator::nextSmoothYaw(float dt) {
 
   const float desired_yaw_velocity = 0.0f;
 
-  float yaw_diff = std::isfinite(desired_setpoint_yaw_rad)
-                       ? desired_setpoint_yaw_rad - setpoint_yaw_rad_
-                       : 0.0f;
+  float yaw_diff =
+      wrapAngleToPlusMinusPI(std::isfinite(desired_setpoint_yaw_rad)
+                                 ? desired_setpoint_yaw_rad - setpoint_yaw_rad_
+                                 : 0.0f);
 
-  wrapAngleToPlusMinusPI(yaw_diff);
   const float p = yaw_diff * P_constant_xy;
   const float d =
       (desired_yaw_velocity - setpoint_yaw_velocity_) * D_constant_xy;
 
   setpoint_yaw_velocity_ += (p + d) * dt;
   setpoint_yaw_rad_ += setpoint_yaw_velocity_ * dt;
-  wrapAngleToPlusMinusPI(setpoint_yaw_rad_);
+  setpoint_yaw_rad_ = wrapAngleToPlusMinusPI(setpoint_yaw_rad_);
 }
 
 void WaypointGenerator::adaptSpeed() {

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -118,14 +118,14 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   FOV FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
   FOV_zero.h_fov_deg = 0.0f;
   FOV_zero.v_fov_deg = 0.0f;
-  FOV_zero.yaw_deg = 1.0f;
-  FOV_zero.pitch_deg = 1.0f;
+  FOV_zero.azimuth_deg = 1.0f;
+  FOV_zero.elevation_deg = 1.0f;
 
   FOV FOV_regular;
   FOV_regular.h_fov_deg = 85.0f;
   FOV_regular.v_fov_deg = 65.0f;
-  FOV_regular.yaw_deg = 90.0f;  // in histogram frame!
-  FOV_regular.pitch_deg = 1.0f;
+  FOV_regular.azimuth_deg = 90.0f;  // in histogram frame!
+  FOV_regular.elevation_deg = 1.0f;
 
   // WHEN: we filter the PointCloud with different values max_age
   processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,


### PR DESCRIPTION
This PR works on top of #358 and computes the FOV dynamically based on the point cloud.

At the same time, an error margin is subtracted in order to always underestimate it. This is needed because delay in the system (current yaw estimation and most recent point cloud during fast yaw maneuvers) can yield to overestimating the FOV.

Overestimating the FOV, even just a few degrees leads to the memory bug described in #357 