### PR TITLE
Add cmake flags for compilation with disabled sim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ script:
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner --no-deps -v -i --catkin-make-args tests
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
-  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --gen-suppressions=all $f || status=1; done && exit $status
+  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ script:
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner --no-deps -v -i --catkin-make-args tests
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
-  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status
+  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --gen-suppressions=all $f || status=1; done && exit $status

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   - cd src/avoidance
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
   - ./check_code_format.sh
-  - catkin build avoidance local_planner global_planner --no-deps -v -i --catkin-make-args tests
+  - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
+  - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner --no-deps -v -i --catkin-make-args tests
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
   - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status
-  - catkin build avoidance local_planner global_planner --no-deps -v -i --catkin-make-args DISABLE_SIMULATION

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -23,6 +23,11 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL 1.7 REQUIRED)
 find_package(octomap REQUIRED)
 
+if(DISABLE_SIMULATION)
+  message(STATUS "Building avoidance without Gazebo Simulation")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_SIMULATION")
+endif()
+
 ################################################
 ## Gazebo Simulation
 ################################################

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -21,6 +21,11 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(PCL 1.7 REQUIRED)
 
+if(DISABLE_SIMULATION)
+  message(STATUS "Building avoidance without Gazebo Simulation")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDISABLE_SIMULATION")
+endif()
+
 ################################################
 ## Gazebo Simulation
 ################################################

--- a/local_planner/test/valgrind_suppressions.sup
+++ b/local_planner/test/valgrind_suppressions.sup
@@ -18,3 +18,23 @@
    fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
    fun:_ZN7testing4Test3RunEv
 }
+{
+   ROS-related memory leak
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.2.5
+   fun:_ZN5boost6thread21start_thread_noexceptEv
+   fun:_ZN3ros14ROSOutAppenderC1Ev
+   fun:_ZN3ros5startEv
+   fun:_ZN3ros10NodeHandle9constructERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb
+   fun:_ZN3ros10NodeHandleC1ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKSt3mapIS6_S6_St4lessIS6_ESaISt4pairIS7_S6_EEE
+   fun:_ZN35LocalPlannerNodeTests_failsafe_Test8TestBodyEv
+   fun:HandleSehExceptionsInMethodIfSupported<testing::Test, void>
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+}


### PR DESCRIPTION
This commit adds a check in the cmake files for the DISABLE_SIMULATION
flag, which was previously broken

Output when compiling with
```
catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON
catkin build
```

![image](https://user-images.githubusercontent.com/14265408/57908588-ade31c00-7880-11e9-957d-7c0bcaa26b61.png)


@Jaeyoung-Lim Are you able to build with `-DDISABLE_SIMULATION` without this fix?