### PR TITLE
send range message if unknown whether colprev is enabled

### DIFF
--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -643,7 +643,8 @@ void LocalPlannerNode::dynamicReconfigureCallback(
 }
 
 void LocalPlannerNode::publishLaserScan() const {
-  if (local_planner_->px4_.param_mpc_col_prev_d > 0) {
+  // inverted logic to make sure values like NAN default to sending the message
+  if (!(local_planner_->px4_.param_mpc_col_prev_d < 0)) {
     sensor_msgs::LaserScan distance_data_to_fcu;
     local_planner_->getObstacleDistanceData(distance_data_to_fcu);
     mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);


### PR DESCRIPTION
the PX4 parameter server takes quite some time to get the MPC_COL_PREV_D param. At the beginning the parameter is therefore NAN for about 30s. Therefore, during this time the range message was not sent and the drone often crashed into the tree with col prev at the first try. This PR makes sure that if we know nothing about the parameter, we send the range message. Only if we know it is disabled the message is not sent.