### PR TITLE
Plan to sensor horizon at all times

### DIFF
--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -31,6 +31,5 @@ gen.add("children_per_node_",    int_t,    0, "Branching factor of the search tr
 gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 10,  0, 200)
 gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)
 gen.add("tree_discount_factor_",    double_t,    0, "Discount factor in tree cost function", 0.8,  0, 1)
-gen.add("max_path_length_",    double_t,    0, "Maximum length of planned paths", 3,  0, 15)
 
 exit(gen.generate(PACKAGE, "avoidance", "LocalPlannerNode"))

--- a/local_planner/cfg/vehicle.yaml
+++ b/local_planner/cfg/vehicle.yaml
@@ -17,7 +17,6 @@ dictitems:
         state: []
       heading_cost_param_: 0.5
       id: 0
-      max_path_length_: 3.0
       max_point_age_s_: 20.0
       min_num_points_per_cell_: 25 # Tune to your sensor requirements!
       min_realsense_dist_: 0.2
@@ -40,7 +39,6 @@ dictitems:
       use_vel_setpoints_: false
     state: []
   heading_cost_param_: 0.5
-  max_path_length_: 3.0
   max_point_age_s_: 20.0
   min_num_points_per_cell_: 25 # Tune to your sensor requirements!
   min_realsense_dist_: 0.2

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -44,8 +44,7 @@ float StarPlanner::treeCostFunction(int node_number) const {
   PolarPoint goal_pol = cartesianToPolarHistogram(goal_, origin_position);
 
   float target_cost = indexAngleDifference(z, goal_pol.z) +
-                      10.0f * indexAngleDifference(e, goal_pol.e);     // include effective direction?
-  float turning_cost = 5.0f * indexAngleDifference(z, tree_[0].yaw_);  // maybe include pitching cost?
+                      10.0f * indexAngleDifference(e, goal_pol.e);  // include effective direction?
 
   float last_e = tree_[origin].last_e_;
   float last_z = tree_[origin].last_z_;
@@ -64,7 +63,7 @@ float StarPlanner::treeCostFunction(int node_number) const {
   }
 
   return std::pow(tree_discount_factor_, static_cast<float>(tree_[node_number].depth_)) *
-         (target_cost + smooth_cost + smooth_cost_to_old_tree + turning_cost);
+         (target_cost + smooth_cost + smooth_cost_to_old_tree);
 }
 
 float StarPlanner::treeHeuristicFunction(int node_number) const {

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -16,7 +16,7 @@ void StarPlanner::dynamicReconfigureSetStarParams(const avoidance::LocalPlannerN
   n_expanded_nodes_ = config.n_expanded_nodes_;
   tree_node_distance_ = static_cast<float>(config.tree_node_distance_);
   tree_discount_factor_ = static_cast<float>(config.tree_discount_factor_);
-  max_path_length_ = static_cast<float>(config.max_path_length_);
+  max_path_length_ = static_cast<float>(config.box_radius_);
   smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
 }
 


### PR DESCRIPTION
This commit removes the 'max_tree_length' parameter, replacing its
logic with the box_size. This way we always plan to the maximum
of the sensor range, which is a logical thing to do.

To throttle the planning effort the number of nodes expanded during
A* search is much more suitable, and that logic remains untouched.