### PR TITLE
Add gazebo_model_path to launchfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,6 @@ In the following section we guide you trough installing and running a Gazebo sim
 
    # Setup some more Gazebo-related environment variables
    . ~/Firmware/Tools/setup_gazebo.bash ~/Firmware ~/Firmware/build/px4_sitl_default
-
-   # Add the models from the avoidance module to GAZEBO_MODEL_PATH
-   export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/avoidance/sim/models
    ```
 
 1. Add the Firmware directory to ROS_PACKAGE_PATH so that ROS can start PX4.

--- a/avoidance/launch/avoidance_sitl_mavros.launch
+++ b/avoidance/launch/avoidance_sitl_mavros.launch
@@ -11,6 +11,8 @@
     <arg name="tgt_component" default="1" />
 
     <param name="use_sim_time" value="true" />
+    <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find avoidance)/sim/models"/>
+    <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find avoidance)/sim/models"/>
 
     <!-- Launch rqt_reconfigure -->
     <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />


### PR DESCRIPTION
This PR adds the environment variable `GAZEBO_MODEL_PATH` and `GAZEBO_RESOURCE_PATH` to the launchfile, which eliminates the need to specify the environment as 
```
export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/avoidance/sim/models
```

For the lazy people