### PR TITLE
Fix gazebo model path broken by #378

### DIFF
--- a/avoidance/launch/avoidance_sitl_mavros.launch
+++ b/avoidance/launch/avoidance_sitl_mavros.launch
@@ -11,8 +11,9 @@
     <arg name="tgt_component" default="1" />
 
     <param name="use_sim_time" value="true" />
-    <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find avoidance)/sim/models"/>
-    <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find avoidance)/sim/models"/>
+
+    <env name="GAZEBO_MODEL_PATH" value="$(env GAZEBO_MODEL_PATH):$(find avoidance)/sim/models"/>
+    <env name="GAZEBO_RESOURCE_PATH" value="$(env GAZEBO_RESOURCE_PATH):$(find avoidance)/sim/models"/>
 
     <!-- Launch rqt_reconfigure -->
     <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />


### PR DESCRIPTION
This commit slightly changes the syntax of how the gazebo model
path is set in the launch file. On my machine this was necessary.