### PR TITLE
Add robot radius for path searching in global_planner

### DIFF
--- a/global_planner/include/global_planner/cell.h
+++ b/global_planner/include/global_planner/cell.h
@@ -42,7 +42,7 @@ class Cell {
   double angle() const;
 
   Cell getNeighborFromYaw(double yaw) const;
-  std::vector<Cell> getFlowNeighbors() const;
+  std::vector<Cell> getFlowNeighbors(int radius) const;
   std::vector<Cell> getDiagonalNeighbors() const;
   std::vector<Cell> getNeighbors() const;
 

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -150,9 +150,10 @@ class GlobalPlanner {
   void goBack();
   void stop();
   void setRobotRadius(double radius);
-  private:
-    double robot_radius_;
-    double octree_resolution_;
+
+ private:
+  double robot_radius_;
+  double octree_resolution_;
 };
 
 }  // namespace global_planner

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -149,6 +149,10 @@ class GlobalPlanner {
   bool getGlobalPath();
   void goBack();
   void stop();
+  void setRobotRadius(double radius);
+  private:
+    double robot_radius_;
+    double octree_resolution_;
 };
 
 }  // namespace global_planner

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -13,7 +13,7 @@
         <param name="start_pos_z" value="$(arg start_pos_z)" />
         <param name="world_name" value="$(find avoidance)/sim/worlds/$(arg world_file_name).yaml" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
-        <param name="robot_radius" value="1.0" />        
+        <param name="robot_radius" value="0.5" />        
     </node>
 
     <!-- OctoMap Server -->

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -13,6 +13,7 @@
         <param name="start_pos_z" value="$(arg start_pos_z)" />
         <param name="world_name" value="$(find avoidance)/sim/worlds/$(arg world_file_name).yaml" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
+        <param name="robot_radius" value="1.0" />        
     </node>
 
     <!-- OctoMap Server -->

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -72,11 +72,12 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 // Returns the neighbors of the Cell whose risk influences the Cell
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
-  for(int x = -radius; x < radius; x++){
-    for(int y = -radius; x < radius; x++){
-      for(int z = -radius; x < radius; x++){
-        cells.push_back(Cell(std::tuple<int, int, int>(xIndex() + x, yIndex() + y, zIndex() + z)));
-      }   
+  for (int x = -radius; x < radius; x++) {
+    for (int y = -radius; x < radius; x++) {
+      for (int z = -radius; x < radius; x++) {
+        cells.push_back(Cell(std::tuple<int, int, int>(
+            xIndex() + x, yIndex() + y, zIndex() + z)));
+      }
     }
   }
   return cells;

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -73,9 +73,11 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
   for (int x = -radius; x <= radius; x++) {
-    int y_radius = static_cast<int>(std::ceil(std::sqrt(std::pow(double(radius), 2) - std::pow(double(x),2))));
+    int y_radius = static_cast<int>(std::ceil(
+        std::sqrt(std::pow(double(radius), 2) - std::pow(double(x), 2))));
     for (int y = -y_radius; y <= y_radius; y++) {
-      int z_radius = static_cast<int>(std::ceil(std::sqrt(std::pow(double(y_radius), 2) - std::pow(double(y),2))));
+      int z_radius = static_cast<int>(std::ceil(
+          std::sqrt(std::pow(double(y_radius), 2) - std::pow(double(y), 2))));
       for (int z = -z_radius; z <= z_radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -73,8 +73,10 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
   for (int x = -radius; x <= radius; x++) {
-    for (int y = -radius; y <= radius; y++) {
-      for (int z = -radius; z <= radius; z++) {
+    int y_radius = static_cast<int>(std::ceil(std::sqrt(std::pow(double(radius), 2) - std::pow(double(x),2))));
+    for (int y = -y_radius; y <= y_radius; y++) {
+      int z_radius = static_cast<int>(std::ceil(std::sqrt(std::pow(double(y_radius), 2) - std::pow(double(y),2))));
+      for (int z = -z_radius; z <= z_radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));
       }

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -72,14 +72,15 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 // Returns the neighbors of the Cell whose risk influences the Cell
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
-  auto ceilDistance = [](int radius, int x) {
-    return static_cast<int>(std::ceil(
-        std::sqrt(std::pow(double(radius), 2) - std::pow(double(x), 2))));
+  auto ceilDistance = [](int radius, int x, int y) {
+    auto sqr = [](int i) { return double(i * i); };
+    return static_cast<int>(
+        std::ceil(std::sqrt(sqr(radius) - sqr(x) - sqr(y))));
   };
   for (int x = -radius; x <= radius; x++) {
-    int y_radius = ceilDistance(radius, x);
+    int y_radius = ceilDistance(radius, x, 0);
     for (int y = -y_radius; y <= y_radius; y++) {
-      int z_radius = ceilDistance(y_radius, y);
+      int z_radius = ceilDistance(radius, x, y);
       for (int z = -z_radius; z <= z_radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -79,7 +79,7 @@ std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   for (int x = -radius; x <= radius; x++) {
     int y_radius = ceilDistance(radius, x);
     for (int y = -y_radius; y <= y_radius; y++) {
-      int z_radius = ceilDistance(radius, y);
+      int z_radius = ceilDistance(y_radius, y);
       for (int z = -z_radius; z <= z_radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -72,12 +72,14 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 // Returns the neighbors of the Cell whose risk influences the Cell
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
-  for (int x = -radius; x <= radius; x++) {
-    int y_radius = static_cast<int>(std::ceil(
+  auto ceilDistance = [](int radius, int x) {
+    return static_cast<int>(std::ceil(
         std::sqrt(std::pow(double(radius), 2) - std::pow(double(x), 2))));
+  };
+  for (int x = -radius; x <= radius; x++) {
+    int y_radius = ceilDistance(radius, x);
     for (int y = -y_radius; y <= y_radius; y++) {
-      int z_radius = static_cast<int>(std::ceil(
-          std::sqrt(std::pow(double(y_radius), 2) - std::pow(double(y), 2))));
+      int z_radius = ceilDistance(radius, y);
       for (int z = -z_radius; z <= z_radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -72,9 +72,9 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 // Returns the neighbors of the Cell whose risk influences the Cell
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
-  for (int x = -radius; x < radius; x++) {
-    for (int y = -radius; y < radius; y++) {
-      for (int z = -radius; z < radius; z++) {
+  for (int x = -radius; x <= radius; x++) {
+    for (int y = -radius; y <= radius; y++) {
+      for (int z = -radius; z <= radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));
       }

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -70,14 +70,16 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 }
 
 // Returns the neighbors of the Cell whose risk influences the Cell
-std::vector<Cell> Cell::getFlowNeighbors() const {
-  return std::vector<Cell>{
-      Cell(std::tuple<int, int, int>(xIndex() + 1, yIndex(), zIndex())),
-      Cell(std::tuple<int, int, int>(xIndex() - 1, yIndex(), zIndex())),
-      Cell(std::tuple<int, int, int>(xIndex(), yIndex() + 1, zIndex())),
-      Cell(std::tuple<int, int, int>(xIndex(), yIndex() - 1, zIndex())),
-      Cell(std::tuple<int, int, int>(xIndex(), yIndex(), zIndex() + 1)),
-      Cell(std::tuple<int, int, int>(xIndex(), yIndex(), zIndex() - 1))};
+std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
+  std::vector<Cell> cells;
+  for(int x = -radius; x < radius; x++){
+    for(int y = -radius; x < radius; x++){
+      for(int z = -radius; x < radius; x++){
+        cells.push_back(Cell(std::tuple<int, int, int>(xIndex() + x, yIndex() + y, zIndex() + z)));
+      }   
+    }
+  }
+  return cells;
 }
 
 // Returns the neighbors of the Cell that are diagonal to the cell in the

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -73,8 +73,8 @@ Cell Cell::getNeighborFromYaw(double yaw) const {
 std::vector<Cell> Cell::getFlowNeighbors(int radius) const {
   std::vector<Cell> cells;
   for (int x = -radius; x < radius; x++) {
-    for (int y = -radius; x < radius; x++) {
-      for (int z = -radius; x < radius; x++) {
+    for (int y = -radius; y < radius; y++) {
+      for (int z = -radius; z < radius; z++) {
         cells.push_back(Cell(std::tuple<int, int, int>(
             xIndex() + x, yIndex() + y, zIndex() + z)));
       }

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -570,9 +570,6 @@ void GlobalPlanner::stop() {
   setPath({curr_pos_});
 }
 
-void GlobalPlanner::setRobotRadius(double radius){
-  robot_radius_ = radius;
-}
-
+void GlobalPlanner::setRobotRadius(double radius) { robot_radius_ = radius; }
 
 }  // namespace global_planner

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -192,7 +192,7 @@ double GlobalPlanner::getRisk(const Cell& cell) {
   }
 
   double risk = getSingleCellRisk(cell);
-  int radius = int(robot_radius_ / octree_resolution_);
+  int radius = static_cast<int>(std::ceil(robot_radius_ / octree_resolution_));
   for (const Cell& neighbor : cell.getFlowNeighbors(radius)) {
     risk += neighbor_risk_flow_ * getSingleCellRisk(neighbor);
   }

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -71,6 +71,7 @@ bool GlobalPlanner::updateFullOctomap(const octomap_msgs::Octomap& msg) {
     delete octree_;
   }
   octree_ = dynamic_cast<octomap::OcTree*>(tree);
+  octree_resolution_ = octree_->getResolution();
 
   // Check if the risk of the current path has increased
   if (!curr_path_.empty()) {
@@ -191,7 +192,8 @@ double GlobalPlanner::getRisk(const Cell& cell) {
   }
 
   double risk = getSingleCellRisk(cell);
-  for (const Cell& neighbor : cell.getFlowNeighbors()) {
+  int radius = int(robot_radius_ / octree_resolution_);
+  for (const Cell& neighbor : cell.getFlowNeighbors(radius)) {
     risk += neighbor_risk_flow_ * getSingleCellRisk(neighbor);
   }
 
@@ -567,5 +569,10 @@ void GlobalPlanner::stop() {
   setGoal(GoalCell(curr_pos_));
   setPath({curr_pos_});
 }
+
+void GlobalPlanner::setRobotRadius(double radius){
+  robot_radius_ = radius;
+}
+
 
 }  // namespace global_planner

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -107,6 +107,9 @@ void GlobalPlannerNode::readParams() {
   initializeCameraSubscribers(camera_topics);
   global_planner_.goal_pos_ =
       GoalCell(start_pos_.x, start_pos_.y, start_pos_.z);
+  double robot_radius;
+  nh_.param<double>("robot_radius", robot_radius, 0.5);
+  global_planner_.setRobotRadius(robot_radius);
 }
 
 void GlobalPlannerNode::initializeCameraSubscribers(


### PR DESCRIPTION
Prior to this PR, the path found from the global_planner would tend to plan paths that are too close to the obstacle, or the paths would go through extremely narrow paths which the drone will not be able to traverse.

This PR adds a robot radius to consider when calculating the list of neighbors in global planner.

The radius can be defined from a parameter as the following in the `global_planner_node`
```
    <node name="global_planner_node" pkg="global_planner" type="global_planner_node" output="screen"
       ...
        <param name="robot_radius" value="1.0" />        
    </node>
```

Tested in SITL, and the behavior seems reasonable (plans around further away with larger robot_radius)
