### PR TITLE
[GlobalPlanner] Move replanning to a loop from events

### DIFF
--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -309,8 +309,6 @@ void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
     ROS_INFO("  Path is bad, planning a new path \n");
     if (global_planner_.goal_pos_.is_temporary_) {
       popNextGoal();  // Throw away temporary goal
-    } else {
-      planPath();  // Plan a whole new path
     }
   }
 }

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -110,7 +110,6 @@ void GlobalPlannerNode::setNewGoal(const GoalCell& goal) {
   ROS_INFO("========== Set goal : %s ==========", goal.asString().c_str());
   global_planner_.setGoal(goal);
   publishGoal(goal);
-  planPath();
 }
 
 // Sets the next waypoint to be the current goal
@@ -390,9 +389,7 @@ void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
   }
 
   // If the current cell is blocked, try finding a path again
-  if (global_planner_.current_cell_blocked_) {
-    planPath();
-  }
+  planPath();
 
   // Print and publish info
   if (is_in_goal && !waypoints_.empty()) {

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -380,7 +380,6 @@ void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
     popNextGoal();
   }
 
-  // If the current cell is blocked, try finding a path again
   planPath();
 
   // Print and publish info

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -123,7 +123,6 @@ void GlobalPlannerNode::popNextGoal() {
     // Goal is blocked but there is no other goal in waypoints_, just stop
     ROS_INFO("  STOP  ");
     global_planner_.stop();
-    publishPath();
   }
 }
 
@@ -136,10 +135,6 @@ void GlobalPlannerNode::planPath() {
   }
 
   bool found_path = global_planner_.getGlobalPath();
-
-  // Publish even though no path is found
-  publishExploredCells();
-  publishPath();
 
   if (!found_path) {
     // TODO: popNextGoal(), instead of checking if goal_is_blocked in
@@ -298,7 +293,6 @@ void GlobalPlannerNode::laserSensorCallback(const sensor_msgs::LaserScan& msg) {
         // Don't complain about crashing on take-off
         ROS_INFO("CRASH!!! Distance to obstacle: %2.2f\n\n\n", range);
         global_planner_.goBack();
-        publishPath();
       }
     }
   }
@@ -400,6 +394,9 @@ void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
              pathLength(actual_path_),
              pathEnergy(actual_path_, global_planner_.up_cost_));
   }
+
+  publishPath();
+  publishExploredCells();
 }
 
 // Publish the position of goal
@@ -473,7 +470,6 @@ void GlobalPlannerNode::publishExploredCells() {
 // Prints information about the point, mostly the risk of the containing cell
 void GlobalPlannerNode::printPointInfo(double x, double y, double z) {
   // Update explored cells
-  publishExploredCells();
   printPointStats(&global_planner_, x, y, z);
 }
 


### PR DESCRIPTION
This PR moves replanning of the global planner into a fixed loop(1Hz), and makes the planner to always replan, rather than only plan when the current cell is blocked / or the path is invalid.

Previously, the replanning was only done on events(when certain topics arrive) which led to collisions when a replanning was necessary, but a sufficient event to trigger the event was missing.

This is largely because the path searching is done by assuming priors, which fails when the assumption is different with the environment. There is no mechanism to guarantee safety inbetween