### PR TITLE
Yet another GAZEBO_MODEL_PATH fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ In the following section we guide you trough installing and running a Gazebo sim
    ```bash
    export ROS_PACKAGE_PATH=${ROS_PACKAGE_PATH}:~/Firmware
    ```
+1. Finally, set the GAZEBO_MODEL_PATH in your bashrc:
+```bash
+echo export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:~/catkin_ws/src/avoidance/avoidance/sim/models:~/catkin_ws/src/avoidance/avoidance/sim/worlds >> ~/.bashrc
+```
 
 You should now be ready to run the simulation using local or global planner.
 

--- a/avoidance/launch/avoidance_sitl_mavros.launch
+++ b/avoidance/launch/avoidance_sitl_mavros.launch
@@ -12,9 +12,6 @@
 
     <param name="use_sim_time" value="true" />
 
-    <env name="GAZEBO_MODEL_PATH" value="$(env GAZEBO_MODEL_PATH):$(find avoidance)/sim/models"/>
-    <env name="GAZEBO_RESOURCE_PATH" value="$(env GAZEBO_RESOURCE_PATH):$(find avoidance)/sim/models"/>
-
     <!-- Launch rqt_reconfigure -->
     <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />
 


### PR DESCRIPTION
Ok, let's figure this out now. 

I think setting GAZEBO_MODEL_PATH in the bashrc is the most portable thing and will work on everyone's machine.

Can you please test @Jaeyoung-Lim, so I don't break your setup once again? (Sorry...)

Also, let me know if the Readme is not clear enough about the installation

Addresses #383 #391 