### PR TITLE
Global planner launchfile unification / depth camera model

### DIFF
--- a/avoidance/launch/avoidance_sitl_stereo.launch
+++ b/avoidance/launch/avoidance_sitl_stereo.launch
@@ -1,0 +1,28 @@
+<launch>
+  <arg name="model" default="iris_depth_camera"/>
+  <arg name="world_file_name"    default="simple_obstacle" />
+  <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
+  <arg name="pointcloud_topics" default="[/stereo/points2]"/>
+
+  <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
+  <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
+          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+
+  <!-- Launch PX4 and mavros -->
+  <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
+    <arg name="model" value="iris_stereo_camera" />
+    <arg name="world_path" value="$(arg world_path)" />
+  </include>
+
+  <!-- Launch stereo_image_proc node which runs OpenCV's block matching  -->
+  <node ns="stereo" pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
+    <param name="stereo_algorithm" type="double" value="1.0" />
+    <param name="correlation_window_size" type="double" value="19.0" />
+    <param name="disparity_range" type="double" value="32.0" />
+    <param name="uniqueness_ratio" type="double" value="40.0" />
+    <param name="speckle_size" type="double" value="1000.0" />
+    <param name="speckle_range" type="double" value="2.0" />
+  </node>
+
+</launch>
+

--- a/avoidance/launch/avoidance_sitl_stereo.launch
+++ b/avoidance/launch/avoidance_sitl_stereo.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="model" default="iris_depth_camera"/>
+  <arg name="model" default="iris_stereo_camera"/>
   <arg name="world_file_name"    default="simple_obstacle" />
   <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
   <arg name="pointcloud_topics" default="[/stereo/points2]"/>

--- a/global_planner/launch/global_planner_depth-camera.launch
+++ b/global_planner/launch/global_planner_depth-camera.launch
@@ -1,33 +1,35 @@
 <launch>
+
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
-    <arg name="pointcloud_topics" default="/stereo/points2" />
+    <arg name="pointcloud_topics" default="/camera/depth/points"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
 
+    <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
     <!-- Ros transformation -->
     <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
           args="0 0 0 0 0 0 world local_origin 10"/>
-    <node pkg="tf" type="static_transform_publisher" name="tf_camera"
+    <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
 
-  <!-- Launch PX4 and mavros -->
-  <include file="$(find avoidance)/launch/avoidance_sitl_stereo.launch" >
-    <arg name="model" value="iris_stereo_camera" />
-    <arg name="world_path" value="$(arg world_path)" />
-    <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
-  </include>
+    <!-- Launch PX4 and mavros -->
+    <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
+        <arg name="model" value="iris_depth_camera" />
+        <arg name="world_path" value="$(arg world_path)" />
+    </include>
 
+
+    <!-- Launch local planner -->
     <!-- Global planner -->
     <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
         <arg name="point_cloud_topic" value="$(arg pointcloud_topics)" />
         <arg name="start_pos_x" value="$(arg start_pos_x)" />
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />
-    </include>
+    </include>>
 
-    <!-- RViz -->
     <node pkg="rviz" type="rviz" output="screen" name="rviz" respawn="true"
           args="-d $(find global_planner)/resource/global_planner.rviz" />
 </launch>

--- a/global_planner/launch/global_planner_stereo.launch
+++ b/global_planner/launch/global_planner_stereo.launch
@@ -1,40 +1,28 @@
 <launch>
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
-    <arg name="use_three_point_msg" default="false" />
-    <arg name="mavros_transformation" default="0" />
-    <arg name="point_cloud_topic" default="/stereo/points2" />
+    <arg name="pointcloud_topics" default="/stereo/points2" />
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
-
     <param name="use_sim_time" value="true" />
 
     <!-- Ros transformation -->
     <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
-          args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
+          args="0 0 0 0 0 0 world local_origin 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
 
-    <!-- Launch PX4 and mavros -->
-    <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
-        <arg name="model" value="iris_stereo_camera" />
-        <arg name="world_path" value="$(arg world_path)" />
-    </include>
-
-    <!-- Launch stereo_image_proc node which runs OpenCV's block matching  -->
-    <node ns="stereo" pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
-        <param name="stereo_algorithm" type="double" value="1.0" />
-        <param name="correlation_window_size" type="double" value="19.0" />
-        <param name="disparity_range" type="double" value="32.0" />
-        <param name="uniqueness_ratio" type="double" value="40.0" />
-        <param name="speckle_size" type="double" value="1000.0" />
-        <param name="speckle_range" type="double" value="2.0" />
-    </node>
+  <!-- Launch PX4 and mavros -->
+  <include file="$(find avoidance)/launch/avoidance_sitl_stereo.launch" >
+    <arg name="model" value="iris_stereo_camera" />
+    <arg name="world_path" value="$(arg world_path)" />
+    <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
+  </include>
 
     <!-- Global planner -->
     <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
-        <arg name="point_cloud_topic" value="$(arg point_cloud_topic)" />
+        <arg name="point_cloud_topic" value="$(arg pointcloud_topics)" />
         <arg name="start_pos_x" value="$(arg start_pos_x)" />
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />

--- a/local_planner/launch/local_planner_stereo.launch
+++ b/local_planner/launch/local_planner_stereo.launch
@@ -4,25 +4,13 @@
   <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
   <arg name="pointcloud_topics" default="[/stereo/points2]"/>
 
-  <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
-  <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
-
   <!-- Launch PX4 and mavros -->
-  <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
+  <include file="$(find avoidance)/launch/avoidance_sitl_stereo.launch" >
     <arg name="model" value="iris_stereo_camera" />
     <arg name="world_path" value="$(arg world_path)" />
+    <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
   </include>
 
-  <!-- Launch stereo_image_proc node which runs OpenCV's block matching  -->
-  <node ns="stereo" pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
-    <param name="stereo_algorithm" type="double" value="1.0" />
-    <param name="correlation_window_size" type="double" value="19.0" />
-    <param name="disparity_range" type="double" value="32.0" />
-    <param name="uniqueness_ratio" type="double" value="40.0" />
-    <param name="speckle_size" type="double" value="1000.0" />
-    <param name="speckle_range" type="double" value="2.0" />
-  </node>
 
   <!-- Load custom console configuration -->
   <env name="ROSCONSOLE_CONFIG_FILE" value="$(find local_planner)/resource/custom_rosconsole.conf"/>


### PR DESCRIPTION
This PR enables a depth camera model in global_planner with a launchfile `global_planner_depth-camera.launch` as discussed in #390 @mrivi 

In order to share as much code as possible between local and global_planner, a `avoidance_sitl_stereo.launch` file was added that is both used by local and global planner