### PR TITLE
Make depth image at 30Hz then downsample

### DIFF
--- a/local_planner/launch/rs_depthcloud.launch
+++ b/local_planner/launch/rs_depthcloud.launch
@@ -33,13 +33,13 @@ limitations under the License.
 
   <arg name="depth_width"       value="640"/>
   <arg name="depth_height"      value="480"/>
-  <arg name="depth_fps"         default="15"/>
+  <arg name="depth_fps"         default="30"/>
 
   <arg name="color_width"       value="640"/>
   <arg name="color_height"      value="480"/>
   <arg name="color_fps"         value="15"/>
 
-  <arg name="infra_fps"         value="15"/>
+  <arg name="infra_fps"         value="30"/>
 
   <arg name="initial_reset"             default="false"/>
 
@@ -75,7 +75,7 @@ limitations under the License.
       <node pkg="nodelet" type="nodelet" name="points_xyz_sw_registered"
             args="load depth_image_proc/point_cloud_xyz $(arg manager) true" respawn="true">
         <remap from="camera_info"             to="depth/camera_info" />
-        <remap from="image_rect" to="depth/image_rect_raw" />
+        <remap from="image_rect" to="depth/image_rect_raw_drop_pc" />
         <remap from="points"     to="depth/points" />
       </node>
 

--- a/local_planner/resource/stereo_calib.json
+++ b/local_planner/resource/stereo_calib.json
@@ -72,7 +72,7 @@
     "param-usersm": "1",
     "param-zunits": "1000",
     "stream-depth-format": "Z16",
-    "stream-fps": "15",
+    "stream-fps": "30",
     "stream-height": "480",
     "stream-width": "640"
 }

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -62,15 +62,17 @@ for camera in $CAMERA_CONFIGS; do
 				<arg name="namespace"             value="$1" />
 				<arg name="tf_prefix"             value="$1" />
 				<arg name="serial_no"             value="$3"/>
-				<arg name="depth_fps"             value="$DEPTH_CAMERA_FRAME_RATE"/>
 			</include>
 
       <!-- launch node to throttle depth images for logging -->
       <node name="drop_$1_depth" pkg="topic_tools" type="drop" output="screen"
-        args="/$1/depth/image_rect_raw 29 30">
+        args="/$1/depth/image_rect_raw 59 60">
       </node>
       <node name="drop_$1_ir" pkg="topic_tools" type="drop" output="screen"
-        args="/$1/infra1/image_rect_raw 29 30">
+        args="/$1/infra1/image_rect_raw 59 60">
+      </node>
+      <node name="drop_$1_depth_pc" pkg="topic_tools" type="drop" output="screen"
+        args="/$1/depth/image_rect_raw 1 2 /$1/depth/image_rect_raw_drop_pc">
       </node>
 		EOM
 
@@ -100,7 +102,7 @@ if [ ! -z $VEHICLE_CONFIG ]; then
 cat >> local_planner/launch/avoidance.launch <<- EOM
     <node name="dynparam" pkg="dynamic_reconfigure" type="dynparam" args="load local_planner_node $VEHICLE_CONFIG" />
 EOM
-echo "Adding vehicle paramters: $VEHICLE_CONFIG"
+echo "Adding vehicle parameters: $VEHICLE_CONFIG"
 fi
 
 cat >> local_planner/launch/avoidance.launch <<- EOM
@@ -128,6 +130,3 @@ fi
 cat >> local_planner/launch/avoidance.launch <<- EOM
 </launch>
 EOM
-
-# Set the frame rate in the JSON file as well
-sed -i '/stream-fps/c\    \"stream-fps\": \"'$DEPTH_CAMERA_FRAME_RATE'\",' local_planner/resource/stereo_calib.json


### PR DESCRIPTION
This commit changes the auto-generation of the launch file, as well
as the realsense launch file to generate a depth image at 30Hz, then
downsample it to 15Hz before sending to the nodelet. Doing so
fixes a realsense-related bug that breaks auto-exposure on USB2.0