### PR TITLE
Export liblocal_planner.so for other projects

### DIFF
--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -106,6 +106,7 @@ generate_dynamic_reconfigure_options(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
+  LIBRARIES local_planner
   CATKIN_DEPENDS roscpp rospy std_msgs mavros_msgs geometry_msgs sensor_msgs message_runtime tf avoidance
 #  DEPENDS system_lib
 )


### PR DESCRIPTION
This patch introduces a minor change to local_planner's CMakeLists.txt,
which allows other cmake projects to use the library as an external
project. Without this change, compiling against local_planner introduces
the following errors (to begin with):

undefined reference to `avoidance::LocalPlanner::LocalPlanner()'
undefined reference to `avoidance::LocalPlanner::~LocalPlanner()'