### PR TITLE
Update ROS key due to upstream key change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
   - sudo apt-get update -qq
   - sudo apt-get install -y build-essential git valgrind
   - sudo apt-get install -y python-rosinstall python-rosinstall-generator python-wstool python-catkin-tools


### PR DESCRIPTION
https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454

This is a blocker for https://github.com/PX4/avoidance/pull/402