### PR TITLE
[GlobalPlanner] Add support for multicamera in global_planner

### DIFF
--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -43,6 +43,10 @@
 
 namespace global_planner {
 
+struct cameraData {
+  ros::Subscriber pointcloud_sub_;
+};
+
 class GlobalPlannerNode {
  public:
   // TODO: Deque instead of vector
@@ -65,7 +69,6 @@ class GlobalPlannerNode {
   ros::Subscriber clicked_point_sub_;
   ros::Subscriber move_base_simple_sub_;
   ros::Subscriber laser_sensor_sub_;
-  ros::Subscriber depth_camera_sub_;
   ros::Subscriber fcu_input_sub_;
 
   // Publishers
@@ -78,6 +81,7 @@ class GlobalPlannerNode {
   ros::Publisher mavros_obstacle_free_path_pub_;
   ros::Publisher mavros_waypoint_publisher_;
   ros::Publisher current_waypoint_publisher_;
+  ros::Publisher pointcloud_pub_;
 
   ros::Time start_time_;
   ros::Time last_wp_time_;
@@ -100,6 +104,7 @@ class GlobalPlannerNode {
 
   std::vector<geometry_msgs::PoseStamped> last_clicked_points;
   std::vector<geometry_msgs::PoseStamped> path_;
+  std::vector<cameraData> cameras_;
 
   int num_octomap_msg_ = 0;
   int num_pos_msg_ = 0;
@@ -122,6 +127,7 @@ class GlobalPlannerNode {
   std::unique_ptr<avoidance::WorldVisualizer> world_visualizer_;
 #endif
   void readParams();
+  void initializeCameraSubscribers(std::vector<std::string>& camera_topics);
   void receivePath(const nav_msgs::Path& msg);
   void setNewGoal(const GoalCell& goal);
   void popNextGoal();

--- a/global_planner/launch/global_planner_depth-camera.launch
+++ b/global_planner/launch/global_planner_depth-camera.launch
@@ -2,7 +2,7 @@
 
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
-    <arg name="pointcloud_topics" default="/camera/depth/points"/>
+    <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -13,7 +13,6 @@
         <param name="start_pos_z" value="$(arg start_pos_z)" />
         <param name="world_name" value="$(find avoidance)/sim/worlds/$(arg world_file_name).yaml" />
         <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
-        <!-- <remap from="/camera/depth/points" to="$(arg point_cloud_topic)" /> -->
     </node>
 
     <!-- OctoMap Server -->

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -1,5 +1,5 @@
 <launch>
-    <arg name="point_cloud_topic" default="/camera/depth/points"/>
+    <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
@@ -12,7 +12,8 @@
         <param name="start_pos_y" value="$(arg start_pos_y)" />
         <param name="start_pos_z" value="$(arg start_pos_z)" />
         <param name="world_name" value="$(find avoidance)/sim/worlds/$(arg world_file_name).yaml" />
-        <remap from="/camera/depth/points" to="$(arg point_cloud_topic)" />
+        <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
+        <!-- <remap from="/camera/depth/points" to="$(arg point_cloud_topic)" /> -->
     </node>
 
     <!-- OctoMap Server -->
@@ -35,6 +36,6 @@
         <param name="height_map" value="false" />
         <param name="publish_free_space" value="false" />
         <!-- data source to integrate (PointCloud2) -->
-        <remap from="cloud_in" to="$(arg point_cloud_topic)" />
+        <!-- <remap from="cloud_in" to="$(arg point_cloud_topic)" /> -->
     </node>
 </launch>

--- a/global_planner/launch/global_planner_sitl_3cam.launch
+++ b/global_planner/launch/global_planner_sitl_3cam.launch
@@ -1,0 +1,39 @@
+<launch>
+
+    <arg name="world_file_name"    default="simple_obstacle" />
+    <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
+    <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
+    <arg name="start_pos_x" default="0.5" />
+    <arg name="start_pos_y" default="0.5" />
+    <arg name="start_pos_z" default="3.5" />
+
+    <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
+    <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
+          args="0 0 0 0 0 0 world local_origin 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_camera"
+          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
+          args="0 0 0 -1.57 0 -1.57 fcu front_camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_right_camera"
+          args="0 0 0 -3.14 0 -1.57 fcu right_camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_left_camera"
+          args="0 0 0 0 0 -1.57 fcu left_camera_link 10"/>
+
+    <!-- Launch PX4 and mavros -->
+    <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
+        <arg name="model" value="iris_depth_camera_3" />
+        <arg name="world_path" value="$(arg world_path)" />
+    </include>
+
+    <!-- Launch global planner -->
+   <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
+        <arg name="start_pos_x" value="$(arg start_pos_x)" />
+        <arg name="start_pos_y" value="$(arg start_pos_y)" />
+        <arg name="start_pos_z" value="$(arg start_pos_z)" />
+        <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
+    </include>
+
+    <!-- RViz -->
+    <node pkg="rviz" type="rviz" output="screen" name="rviz" respawn="true"
+          args="-d $(find global_planner)/resource/global_planner.rviz" />
+</launch>

--- a/global_planner/launch/global_planner_stereo.launch
+++ b/global_planner/launch/global_planner_stereo.launch
@@ -9,8 +9,6 @@
     <!-- Ros transformation -->
     <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
           args="0 0 0 0 0 0 world local_origin 10"/>
-    <node pkg="tf" type="static_transform_publisher" name="tf_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
 
   <!-- Launch PX4 and mavros -->
   <include file="$(find avoidance)/launch/avoidance_sitl_stereo.launch" >

--- a/global_planner/launch/global_planner_stereo.launch
+++ b/global_planner/launch/global_planner_stereo.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
-    <arg name="pointcloud_topics" default="/stereo/points2" />
+    <arg name="pointcloud_topics" default="[/stereo/points2]" />
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
@@ -21,10 +21,10 @@
 
     <!-- Global planner -->
     <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
-        <arg name="point_cloud_topic" value="$(arg pointcloud_topics)" />
         <arg name="start_pos_x" value="$(arg start_pos_x)" />
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />
+        <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
     </include>
 
     <!-- RViz -->

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -58,7 +58,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh,
   current_waypoint_publisher_ =
       nh_.advertise<geometry_msgs::PoseStamped>("/current_setpoint", 10);
   pointcloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2>("/cloud_in", 10);
- 
+
   actual_path_.header.frame_id = "/world";
   listener_.waitForTransform("/fcu", "/world", ros::Time(0),
                              ros::Duration(3.0));
@@ -109,17 +109,15 @@ void GlobalPlannerNode::readParams() {
       GoalCell(start_pos_.x, start_pos_.y, start_pos_.z);
 }
 
-void GlobalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& camera_topics){
+void GlobalPlannerNode::initializeCameraSubscribers(
+    std::vector<std::string>& camera_topics) {
   cameras_.resize(camera_topics.size());
 
-  for(size_t i = 0; i < camera_topics.size(); i++){
+  for (size_t i = 0; i < camera_topics.size(); i++) {
     cameras_[i].pointcloud_sub_ = nh_.subscribe(
-        camera_topics[i], 1,
-        &GlobalPlannerNode::depthCameraCallback, this);
+        camera_topics[i], 1, &GlobalPlannerNode::depthCameraCallback, this);
   }
-
 }
-
 
 // Sets a new goal, plans a path to it and publishes some info
 void GlobalPlannerNode::setNewGoal(const GoalCell& goal) {

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -36,8 +36,6 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh,
                     &GlobalPlannerNode::moveBaseSimpleCallback, this);
   laser_sensor_sub_ =
       nh_.subscribe("/scan", 1, &GlobalPlannerNode::laserSensorCallback, this);
-  depth_camera_sub_ = nh_.subscribe(
-      "/camera/depth/points", 1, &GlobalPlannerNode::depthCameraCallback, this);
   fcu_input_sub_ =
       nh_.subscribe("/mavros/trajectory/desired", 1,
                     &GlobalPlannerNode::fcuInputGoalCallback, this);
@@ -59,7 +57,8 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh,
       "/mavros/trajectory/generated", 10);
   current_waypoint_publisher_ =
       nh_.advertise<geometry_msgs::PoseStamped>("/current_setpoint", 10);
-
+  pointcloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2>("/cloud_in", 10);
+ 
   actual_path_.header.frame_id = "/world";
   listener_.waitForTransform("/fcu", "/world", ros::Time(0),
                              ros::Duration(3.0));
@@ -98,12 +97,29 @@ GlobalPlannerNode::~GlobalPlannerNode() {}
 
 // Read Ros parameters
 void GlobalPlannerNode::readParams() {
+  std::vector<std::string> camera_topics;
+
   nh_.param<double>("start_pos_x", start_pos_.x, 0.5);
   nh_.param<double>("start_pos_y", start_pos_.y, 0.5);
   nh_.param<double>("start_pos_z", start_pos_.z, 3.5);
+  nh_.getParam("pointcloud_topics", camera_topics);
+
+  initializeCameraSubscribers(camera_topics);
   global_planner_.goal_pos_ =
       GoalCell(start_pos_.x, start_pos_.y, start_pos_.z);
 }
+
+void GlobalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& camera_topics){
+  cameras_.resize(camera_topics.size());
+
+  for(size_t i = 0; i < camera_topics.size(); i++){
+    cameras_[i].pointcloud_sub_ = nh_.subscribe(
+        camera_topics[i], 1,
+        &GlobalPlannerNode::depthCameraCallback, this);
+  }
+
+}
+
 
 // Sets a new goal, plans a path to it and publishes some info
 void GlobalPlannerNode::setNewGoal(const GoalCell& goal) {
@@ -337,6 +353,7 @@ void GlobalPlannerNode::depthCameraCallback(
         global_planner_.occupied_.insert(occupied_cell);
       }
     }
+    pointcloud_pub_.publish(msg);
   } catch (tf::TransformException const& ex) {
     ROS_DEBUG("%s", ex.what());
     ROS_WARN("Transformation not available (/world to /camera_link");


### PR DESCRIPTION
This PR adds support for multicamera to `global_planner` with mostly the same interface with the local_planner. The pointcloud is republished from global_planner so that it can be consumed in a single topic to construct the Octomap.

This has been tested in SITL, with the `iris_depth_camera_3` model.

To launch the 3camera model, 
```
roslaunch global_planner global_planner_sitl_3cam.launch
```

![Screenshot from 2019-06-11 13-21-42](https://user-images.githubusercontent.com/5248102/59293903-8402f680-8c80-11e9-8cef-9e64f936f924.png)
