### PR TITLE
Safe Landing Planner: correctly init spiral

### DIFF
--- a/safe_landing_planner/src/nodes/waypoint_generator_node.cpp
+++ b/safe_landing_planner/src/nodes/waypoint_generator_node.cpp
@@ -362,6 +362,8 @@ void WaypointGeneratorNode::updateSLPState() {
     std::fill(can_land_hysteresis_.begin(), can_land_hysteresis_.end(), 0.f);
     slp_state_ = SLPState::goTo;
     explorarion_is_active_ = false;
+    n_explored_pattern_ = -1;
+    factor_exploration_ = 1.f;
     ROS_INFO("[WGN] Not a land waypoint");
   }
 


### PR DESCRIPTION
Properly reset spiral index and width when not in land mode