### PR TITLE
[GlobalPlanner] Lower replanning rate

### DIFF
--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -8,7 +8,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh,
       nh_private_(nh_private),
       avoidance_node_(nh, nh_private),
       cmdloop_dt_(0.1),
-      plannerloop_dt_(1.0) {
+      plannerloop_dt_(2.0) {
   // Set up Dynamic Reconfigure Server
   dynamic_reconfigure::Server<
       global_planner::GlobalPlannerNodeConfig>::CallbackType f;


### PR DESCRIPTION
This is a temporary fix for the segmentation faults that were being observed in the global_planner.

Lowering the planner loop seems to solve the problem for now