### PR TITLE
Add libsensors_monitor for launchfile generation

### DIFF
--- a/safe_landing_planner/tools/generate_launchfile.sh
+++ b/safe_landing_planner/tools/generate_launchfile.sh
@@ -109,6 +109,11 @@ EOM
 echo "Adding vehicle paramters: $VEHICLE_CONFIG_WPG"
 fi
 
+cat >> launch/safe_landing_planner_launch.launch <<- EOM
+  <!-- Monitor cpu temperature -->
+  <node name="libsensors_monitor" pkg="libsensors_monitor" type="libsensors_monitor"/>
+EOM
+
 
 cat >> launch/safe_landing_planner_launch.launch <<- EOM
     <!-- Launch avoidance -->

--- a/tools/generate_launchfile.sh
+++ b/tools/generate_launchfile.sh
@@ -126,6 +126,11 @@ EOM
 fi
 
 cat >> local_planner/launch/avoidance.launch <<- EOM
+  <!-- Monitor cpu temperature -->
+  <node name="libsensors_monitor" pkg="libsensors_monitor" type="libsensors_monitor"/>
+EOM
+
+cat >> local_planner/launch/avoidance.launch <<- EOM
 </launch>
 EOM
 


### PR DESCRIPTION
This PR adds the libsensors_monitors package to the generated launchfile. 

[libsensors_monitor](http://wiki.ros.org/libsensors_monitor) is a package used to monitor temperature information on the companion computer.