### PR TITLE
Compute FOV in camera frame

### DIFF
--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -1,6 +1,8 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include "avoidance/histogram.h"  // needed for ALPHA_RES
+
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <Eigen/Core>
@@ -77,7 +79,7 @@ bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
 /**
 * @brief      compute in which FOV the current point lies
 * @param[in]  vector of FOV defining the field of view of the drone
-* @param[in]  polar point of the current orienation in question
+* @param[in]  polar point of the current orientation in question
 * @param[out] index pointing to the camera in the FOV struct which contains the
 *             current point
 * @returns    boolean value if the point in question is in exactly one FOV
@@ -108,8 +110,6 @@ bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol, int
 *            go
 * @returns   a scale [0, 1] depending on whether the point in question can be
 *            seen from here
-* @TODO:     currently this is binary depending on whether its inside or outside
-*            in the near future I want to scale this correctly
 **/
 float scaleToFOV(const std::vector<FOV>& fov, const PolarPoint& p_pol);
 

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -83,6 +83,34 @@ bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol);
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
 
 /**
+* @brief      compute in which FOV the current point lies
+* @param[in]  vector of FOV defining the field of view of the drone
+* @param[in]  polar point of the current orienation in question
+* @param[out] index pointing to the camera in the FOV struct which contains the
+*             current point
+* @returns    boolean value if the point in question is in exactly one FOV
+* @warning    This function returns false and sets the index to -1 if there is
+*             no or more than one camera which sees the current point
+**/
+bool isInWhichFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
+                  int& idx);
+
+/**
+* @brief      determine whether the given point lies on the edge of the field
+*             of view or between two adjacent cameras
+* @param[in]  vector of FOV defining the field of view of the drone
+* @param[in]  polar point of the current orientation in question
+* @param[out] index of the camera in the FOV vector, indicating which FOV edge
+*             it is on, if any. -1 if none
+* @returns    boolean indicating whether the current point is on the edge of the
+*             field of view
+* @warning    This function returns false and sets the index to -1 if the point
+*             is not on the edge of the fov
+**/
+bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
+                   int& idx);
+
+/**
 * @brief     function returning a scale value depending on where a polar point
 *            is relative to the field of view
 * @param[in] vector of FOV structs defining the field of view

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -207,13 +207,16 @@ void transformVelocityToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry
 void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
 
 /**
-* @brief           This is a refactored version of the PCL library function to
-*                  remove NAN values from the point cloud and compute the FOV
+* @brief           This is a refactored version of the PCL library function
+*                  "removeNaNFromPointCloud" to remove NAN values from the
+*                  point cloud and compute the FOV
 * @note            It operates in-place and iterates through the cloud once
 * @param[in, out]  cloud The point cloud to be filtered in the camera frame
 * @param[in, out]  fov of the camera
+* @note            the FOV is only adjusted if the current cloud indicates a
+*                  bigger FOV than previously thought
 **/
-void removeNaNFromPointCloud(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov);
+void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov);
 
 }  // namespace avoidance
 

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -51,18 +51,11 @@ struct PolarPoint {
 * field of view of the sensor
 */
 struct FOV {
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  FOV() : azimuth_deg(0.f), elevation_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
-  FOV(float y, float p, float h, float v) : azimuth_deg(y), elevation_deg(p), h_fov_deg(h), v_fov_deg(v){};
-  float azimuth_deg;
-  float elevation_deg;
-=======
   FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
   FOV(float y, float p, float h, float v)
       : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
   float yaw_deg;
   float pitch_deg;
->>>>>>> Allow discontinuous FOV
   float h_fov_deg;
   float v_fov_deg;
 };
@@ -81,34 +74,6 @@ const float RAD_TO_DEG = 180.0f / M_PI_F;
 **/
 bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol);
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
-
-/**
-* @brief      compute in which FOV the current point lies
-* @param[in]  vector of FOV defining the field of view of the drone
-* @param[in]  polar point of the current orienation in question
-* @param[out] index pointing to the camera in the FOV struct which contains the
-*             current point
-* @returns    boolean value if the point in question is in exactly one FOV
-* @warning    This function returns false and sets the index to -1 if there is
-*             no or more than one camera which sees the current point
-**/
-bool isInWhichFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
-                  int& idx);
-
-/**
-* @brief      determine whether the given point lies on the edge of the field
-*             of view or between two adjacent cameras
-* @param[in]  vector of FOV defining the field of view of the drone
-* @param[in]  polar point of the current orientation in question
-* @param[out] index of the camera in the FOV vector, indicating which FOV edge
-*             it is on, if any. -1 if none
-* @returns    boolean indicating whether the current point is on the edge of the
-*             field of view
-* @warning    This function returns false and sets the index to -1 if the point
-*             is not on the edge of the fov
-**/
-bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
-                   int& idx);
 
 /**
 * @brief     function returning a scale value depending on where a polar point
@@ -154,13 +119,9 @@ Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol,
 *            incoming polar point. This means the pitch is positive for forward
 *            pitching of a quadrotor and the yaw is positive for CCW yaw motion
 **/
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-Eigen::Vector3f polarToCartesian(const PolarPoint& p_pol, const Eigen::Vector3f& pos);
-=======
 Eigen::Vector3f polarFCUToCartesian(const PolarPoint& p_pol,
                                     const Eigen::Vector3f& pos);
 
->>>>>>> Allow discontinuous FOV
 float indexAngleDifference(float a, float b);
 
 /**
@@ -204,11 +165,6 @@ PolarPoint cartesianToPolarHistogram(float x, float y, float z,
 PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos,
                                const Eigen::Vector3f& origin);
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-PolarPoint cartesianToPolar(const Eigen::Vector3f& pos, const Eigen::Vector3f& origin);
-PolarPoint cartesianToPolar(float x, float y, float z, const Eigen::Vector3f& pos);
-=======
->>>>>>> Allow discontinuous FOV
 /**
 * @brief     compute polar point to histogram index
 * @param[in] p_pol with elevation, azimuth angle and radius

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -51,10 +51,18 @@ struct PolarPoint {
 * field of view of the sensor
 */
 struct FOV {
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   FOV() : azimuth_deg(0.f), elevation_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
   FOV(float y, float p, float h, float v) : azimuth_deg(y), elevation_deg(p), h_fov_deg(h), v_fov_deg(v){};
   float azimuth_deg;
   float elevation_deg;
+=======
+  FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
+  FOV(float y, float p, float h, float v)
+      : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
+  float yaw_deg;
+  float pitch_deg;
+>>>>>>> Allow discontinuous FOV
   float h_fov_deg;
   float v_fov_deg;
 };
@@ -67,11 +75,25 @@ const float RAD_TO_DEG = 180.0f / M_PI_F;
 
 /**
 * @brief      determines whether point is inside FOV
-* @param[in]  FOV, struct defining current field of view
+* @param[in]  vector of FOV structs defining current field of view
 * @param[in]  p_pol, polar representation of the point in question
 * @return     whether point is inside the FOV
 **/
+bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol);
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
+
+/**
+* @brief     function returning a scale value depending on where a polar point
+*            is relative to the field of view
+* @param[in] vector of FOV structs defining the field of view
+* @param[in] polar point in the fcu frame pointing in the direction we wish to
+*            go
+* @returns   a scale [0, 1] depending on whether the point in question can be
+*            seen from here
+* @TODO:     currently this is binary depending on whether its inside or outside
+*            in the near future I want to scale this correctly
+**/
+float scaleToFOV(const std::vector<FOV>& fov, const PolarPoint& p_pol);
 
 /**
 * @brief     calculates the distance between two polar points
@@ -82,14 +104,37 @@ bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2);
 
 /**
-* @brief     Convertes a polar point to a cartesian point and add it to a
-*cartesian position
-* @param[in] p_pol polar point to be converted to cartesian point
-* @param[in] pos given cartesian position, from which to convert the polar point
+* @brief     Converts a polar point in histogram convention to a cartesian point
+*            and add it to a cartesian position
+* @param[in] polar point in histogram convention to be converted
+* @param[in] cartesian position, from which to convert the polar point
 * @returns   point in cartesian CS
+* @warning   The histogram convention means zero-azimuth is the positive y axis
+*            with increasing azimuth in CW direction, while the elevation angle
+*            increases for "upward looking" (contrary to pitch in FCU!)
 **/
+Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol,
+                                          const Eigen::Vector3f& pos);
+
+/**
+* @brief     Converts a polar point in fcu convention to a cartesian point and
+*            add it to a cartesian position
+* @param[in] polar point to be converted to cartesian point
+* @param[in] given cartesian position, from which to convert the polar point
+* @returns   point in cartesian coordinates
+* @warning   The returned point is computed assuming the FCU convention on the
+*            incoming polar point. This means the pitch is positive for forward
+*            pitching of a quadrotor and the yaw is positive for CCW yaw motion
+**/
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 Eigen::Vector3f polarToCartesian(const PolarPoint& p_pol, const Eigen::Vector3f& pos);
+=======
+Eigen::Vector3f polarFCUToCartesian(const PolarPoint& p_pol,
+                                    const Eigen::Vector3f& pos);
+
+>>>>>>> Allow discontinuous FOV
 float indexAngleDifference(float a, float b);
+
 /**
 * @brief     compute point in the histogram to a polar point
 * @param[in] e evelation index in the histogram
@@ -101,7 +146,8 @@ float indexAngleDifference(float a, float b);
 PolarPoint histogramIndexToPolar(int e, int z, int res, float radius);
 
 /**
-* @brief     Compute a cartesian point to polar CS
+* @brief     Compute polar vector in histogram convention between two cartesian
+*            points
 * @param[in] position Position of the location to which to compute the bearing
 *            angles to.
 * @param[in] origin Origin from which to compute the bearing vectors.
@@ -111,9 +157,30 @@ PolarPoint histogramIndexToPolar(int e, int z, int res, float radius);
 * @returns   azimuth Angle in float degrees from the positive y-axis (-180, 180]
 *            and elevation angle degrees (-90, 90]
 **/
+PolarPoint cartesianToPolarHistogram(const Eigen::Vector3f& pos,
+                                     const Eigen::Vector3f& origin);
+PolarPoint cartesianToPolarHistogram(float x, float y, float z,
+                                     const Eigen::Vector3f& pos);
 
+/**
+* @brief     Compute the polar vector in FCU convention between two cartesian
+*            points
+* @param[in] endpoint of the polar vector
+* @param[in] origin of the polar vector
+* @returns   polar point in FCU convention that points from the given origin to
+*            the given point
+* @warning   the output adheres to the FCU convention: positive yaw is measured
+*            CCW from the positive x-axis, and positve pitch is measured CCW
+*            from the positve x-axis. (Positive pitch is pitching forward)
+**/
+PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos,
+                               const Eigen::Vector3f& origin);
+
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 PolarPoint cartesianToPolar(const Eigen::Vector3f& pos, const Eigen::Vector3f& origin);
 PolarPoint cartesianToPolar(float x, float y, float z, const Eigen::Vector3f& pos);
+=======
+>>>>>>> Allow discontinuous FOV
 /**
 * @brief     compute polar point to histogram index
 * @param[in] p_pol with elevation, azimuth angle and radius
@@ -131,6 +198,7 @@ Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res);
 *            azimuth angle [-180,180)
 **/
 void wrapPolar(PolarPoint& p_pol);
+
 /**
 * @brief     Compute the yaw angle between current position and point
 * @returns   angle between two points in rad

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -161,9 +161,12 @@ PolarPoint cartesianToPolarHistogram(float x, float y, float z,
 * @warning   the output adheres to the FCU convention: positive yaw is measured
 *            CCW from the positive x-axis, and positve pitch is measured CCW
 *            from the positve x-axis. (Positive pitch is pitching forward)
+* @note      An overloaded function taking a pcl::PointXYZ assumes the origin
+*            (0, 0, 0)
 **/
 PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos,
                                const Eigen::Vector3f& origin);
+PolarPoint cartesianToPolarFCU(const pcl::PointXYZ& p);
 
 /**
 * @brief     compute polar point to histogram index
@@ -264,11 +267,22 @@ void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
 *                  point cloud and compute the FOV
 * @note            It operates in-place and iterates through the cloud once
 * @param[in, out]  cloud The point cloud to be filtered in the camera frame
-* @param[in, out]  fov of the camera
+* @returns         a cloud containing the eight corners of the box containing
+*                  all the points, in the same frame as the given point cloud
+**/
+pcl::PointCloud<pcl::PointXYZ> removeNaNAndGetMaxima(
+    pcl::PointCloud<pcl::PointXYZ>& cloud);
+
+/**
+* @brief           Compute the FOV given a box of 8 points defining a box
+* @param[in]       FOV to be updated
+* @param[in]       point cloud containing 8 points which define a cube that
+*                  contains all the points in a point cloud in the FCU frame
 * @note            the FOV is only adjusted if the current cloud indicates a
 *                  bigger FOV than previously thought
 **/
-void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov);
+void updateFOVFromMaxima(FOV& fov,
+                         const pcl::PointCloud<pcl::PointXYZ>& maxima);
 
 }  // namespace avoidance
 

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -52,8 +52,7 @@ struct PolarPoint {
 */
 struct FOV {
   FOV() : yaw_deg(0.f), pitch_deg(0.f), h_fov_deg(0.f), v_fov_deg(0.f){};
-  FOV(float y, float p, float h, float v)
-      : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
+  FOV(float y, float p, float h, float v) : yaw_deg(y), pitch_deg(p), h_fov_deg(h), v_fov_deg(v){};
   float yaw_deg;
   float pitch_deg;
   float h_fov_deg;
@@ -74,6 +73,32 @@ const float RAD_TO_DEG = 180.0f / M_PI_F;
 **/
 bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol);
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol);
+
+/**
+* @brief      compute in which FOV the current point lies
+* @param[in]  vector of FOV defining the field of view of the drone
+* @param[in]  polar point of the current orienation in question
+* @param[out] index pointing to the camera in the FOV struct which contains the
+*             current point
+* @returns    boolean value if the point in question is in exactly one FOV
+* @warning    This function returns false and sets the index to -1 if there is
+*             no or more than one camera which sees the current point
+**/
+bool isInWhichFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol, int& idx);
+
+/**
+* @brief      determine whether the given point lies on the edge of the field
+*             of view or between two adjacent cameras
+* @param[in]  vector of FOV defining the field of view of the drone
+* @param[in]  polar point of the current orientation in question
+* @param[out] index of the camera in the FOV vector, indicating which FOV edge
+*             it is on, if any. -1 if none
+* @returns    boolean indicating whether the current point is on the edge of the
+*             field of view
+* @warning    This function returns false and sets the index to -1 if the point
+*             is not on the edge of the fov
+**/
+bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol, int& idx);
 
 /**
 * @brief     function returning a scale value depending on where a polar point
@@ -106,8 +131,7 @@ float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2);
 *            with increasing azimuth in CW direction, while the elevation angle
 *            increases for "upward looking" (contrary to pitch in FCU!)
 **/
-Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol,
-                                          const Eigen::Vector3f& pos);
+Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol, const Eigen::Vector3f& pos);
 
 /**
 * @brief     Converts a polar point in fcu convention to a cartesian point and
@@ -119,8 +143,7 @@ Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol,
 *            incoming polar point. This means the pitch is positive for forward
 *            pitching of a quadrotor and the yaw is positive for CCW yaw motion
 **/
-Eigen::Vector3f polarFCUToCartesian(const PolarPoint& p_pol,
-                                    const Eigen::Vector3f& pos);
+Eigen::Vector3f polarFCUToCartesian(const PolarPoint& p_pol, const Eigen::Vector3f& pos);
 
 float indexAngleDifference(float a, float b);
 
@@ -146,10 +169,8 @@ PolarPoint histogramIndexToPolar(int e, int z, int res, float radius);
 * @returns   azimuth Angle in float degrees from the positive y-axis (-180, 180]
 *            and elevation angle degrees (-90, 90]
 **/
-PolarPoint cartesianToPolarHistogram(const Eigen::Vector3f& pos,
-                                     const Eigen::Vector3f& origin);
-PolarPoint cartesianToPolarHistogram(float x, float y, float z,
-                                     const Eigen::Vector3f& pos);
+PolarPoint cartesianToPolarHistogram(const Eigen::Vector3f& pos, const Eigen::Vector3f& origin);
+PolarPoint cartesianToPolarHistogram(float x, float y, float z, const Eigen::Vector3f& pos);
 
 /**
 * @brief     Compute the polar vector in FCU convention between two cartesian
@@ -164,8 +185,7 @@ PolarPoint cartesianToPolarHistogram(float x, float y, float z,
 * @note      An overloaded function taking a pcl::PointXYZ assumes the origin
 *            (0, 0, 0)
 **/
-PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos,
-                               const Eigen::Vector3f& origin);
+PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos, const Eigen::Vector3f& origin);
 PolarPoint cartesianToPolarFCU(const pcl::PointXYZ& p);
 
 /**
@@ -270,8 +290,7 @@ void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
 * @returns         a cloud containing the eight corners of the box containing
 *                  all the points, in the same frame as the given point cloud
 **/
-pcl::PointCloud<pcl::PointXYZ> removeNaNAndGetMaxima(
-    pcl::PointCloud<pcl::PointXYZ>& cloud);
+pcl::PointCloud<pcl::PointXYZ> removeNaNAndGetMaxima(pcl::PointCloud<pcl::PointXYZ>& cloud);
 
 /**
 * @brief           Compute the FOV given a box of 8 points defining a box
@@ -281,8 +300,7 @@ pcl::PointCloud<pcl::PointXYZ> removeNaNAndGetMaxima(
 * @note            the FOV is only adjusted if the current cloud indicates a
 *                  bigger FOV than previously thought
 **/
-void updateFOVFromMaxima(FOV& fov,
-                         const pcl::PointCloud<pcl::PointXYZ>& maxima);
+void updateFOVFromMaxima(FOV& fov, const pcl::PointCloud<pcl::PointXYZ>& maxima);
 
 }  // namespace avoidance
 

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -1,6 +1,7 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -204,6 +205,16 @@ void transformVelocityToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry
 * @param      point, setpoint to be filled with NAN
 **/
 void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point);
-}
+
+/**
+* @brief           This is a refactored version of the PCL library function to
+*                  remove NAN values from the point cloud and compute the FOV
+* @note            It operates in-place and iterates through the cloud once
+* @param[in, out]  cloud The point cloud to be filtered in the camera frame
+* @param[in, out]  fov of the camera
+**/
+void removeNaNFromPointCloud(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov);
+
+}  // namespace avoidance
 
 #endif  // COMMON_H

--- a/avoidance/sim/models/iris_depth_camera_3/iris_depth_camera.sdf
+++ b/avoidance/sim/models/iris_depth_camera_3/iris_depth_camera.sdf
@@ -76,7 +76,7 @@
 
 
   <model name="left_camera">
-    <pose>0.05 0.05 -0.03 0 0 1.57</pose>
+    <pose>0.05 0.05 -0.03 0 0 1.0472</pose>
     <link name="link">
       <inertial>
         <pose>0.01 0.025 0.025 0 0 0</pose>
@@ -147,7 +147,7 @@
     </joint>
 
   <model name="right_camera">
-    <pose>0.05 -0.05 -0.03 0 0 -1.57</pose>
+    <pose>0.05 -0.05 -0.03 0 0 -1.0472</pose>
     <link name="link">
       <inertial>
         <pose>0.01 0.025 0.025 0 0 0</pose>

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -17,11 +17,6 @@ bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol) {
 }
 
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  return p_pol.z <= wrapAngleToPlusMinus180(fov.azimuth_deg + fov.h_fov_deg / 2.f) &&
-         p_pol.z >= wrapAngleToPlusMinus180(fov.azimuth_deg - fov.h_fov_deg / 2.f) &&
-         p_pol.e <= fov.elevation_deg + fov.v_fov_deg / 2.f && p_pol.e >= fov.elevation_deg - fov.v_fov_deg / 2.f;
-=======
   return p_pol.z <=
              wrapAngleToPlusMinus180(fov.yaw_deg + fov.h_fov_deg / 2.f) &&
          p_pol.z >=
@@ -30,70 +25,16 @@ bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
          p_pol.e >= fov.pitch_deg - fov.v_fov_deg / 2.f;
 }
 
-bool isInWhichFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
-                  int& idx) {
-  bool retval = false;
-  idx = -1;
-  for (int i = 0; i < fov_vec.size(); ++i) {
-    if (pointInsideFOV(fov_vec[i], p_pol)) {
-      if (retval) {  // if it's been found before, return false!
-        idx = -1;
-        return false;
-      }
-      idx = i;
-      retval = true;
-    }
-  }
-  return retval;
-}
-
-bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
-                   int& idx) {
-  idx = -1;
-  bool retval = false;
-  if (isInWhichFOV(fov_vec, p_pol, idx)) {
-    PolarPoint just_outside = p_pol;
-    // todo: check for pitch!
-    if (wrapAngleToPlusMinus180(p_pol.z - fov_vec[idx].yaw_deg) >
-        0.0f) {  // to the right
-      just_outside.z = wrapAngleToPlusMinus180(
-          fov_vec[idx].yaw_deg + fov_vec[idx].h_fov_deg / 2.0f + 1.0f);
-    } else {  // to the left
-      just_outside.z = wrapAngleToPlusMinus180(
-          fov_vec[idx].yaw_deg - fov_vec[idx].h_fov_deg / 2.0f - 1.0f);
-    }
-
-    retval = !pointInsideFOV(fov_vec, just_outside);
-    if (!retval) {
-      idx = -1;
-    }
-  }
-  return retval;
-}
-
 float scaleToFOV(const std::vector<FOV>& fov, const PolarPoint& p_pol) {
-  int i;
-  if (isOnEdgeOfFOV(fov, p_pol, i)) {
-    float angle_diff_deg = std::abs(fov[i].yaw_deg - p_pol.z);
-    angle_diff_deg = std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
-    angle_diff_deg =
-        std::min(fov[i].h_fov_deg / 2.0f, angle_diff_deg);  // Clamp at h_FOV/2
-    return 1.0f - 2.0f * angle_diff_deg / fov[i].h_fov_deg;
-  }
   return pointInsideFOV(fov, p_pol) ? 1.f : 0.f;  // todo: scale properly
->>>>>>> Allow discontinuous FOV
 }
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
   return sqrt((p1.e - p2.e) * (p1.e - p2.e) + (p1.z - p2.z) * (p1.z - p2.z));
 }
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-Eigen::Vector3f polarToCartesian(const PolarPoint& p_pol, const Eigen::Vector3f& pos) {
-=======
 Eigen::Vector3f polarHistogramToCartesian(const PolarPoint& p_pol,
                                           const Eigen::Vector3f& pos) {
->>>>>>> Allow discontinuous FOV
   Eigen::Vector3f p;
   p.x() = pos.x() + p_pol.r * std::cos(p_pol.e * DEG_TO_RAD) * std::sin(p_pol.z * DEG_TO_RAD);
   p.y() = pos.y() + p_pol.r * std::cos(p_pol.e * DEG_TO_RAD) * std::cos(p_pol.z * DEG_TO_RAD);
@@ -126,19 +67,12 @@ PolarPoint histogramIndexToPolar(int e, int z, int res, float radius) {
   return p_pol;
 }
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-PolarPoint cartesianToPolar(const Eigen::Vector3f& pos, const Eigen::Vector3f& origin) {
-  return cartesianToPolar(pos.x(), pos.y(), pos.z(), origin);
-}
-PolarPoint cartesianToPolar(float x, float y, float z, const Eigen::Vector3f& pos) {
-=======
 PolarPoint cartesianToPolarHistogram(const Eigen::Vector3f& pos,
                                      const Eigen::Vector3f& origin) {
   return cartesianToPolarHistogram(pos.x(), pos.y(), pos.z(), origin);
 }
 PolarPoint cartesianToPolarHistogram(float x, float y, float z,
                                      const Eigen::Vector3f& pos) {
->>>>>>> Allow discontinuous FOV
   PolarPoint p_pol(0.0f, 0.0f, 0.0f);
   float den = (Eigen::Vector2f(x, y) - pos.topRows<2>()).norm();
   p_pol.e = std::atan2(z - pos.z(), den) * RAD_TO_DEG;          //(-90.+90)

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -326,10 +326,18 @@ void removeNaNFromPointCloud(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
         !std::isfinite(cloud.points[i].y) || !std::isfinite(cloud.points[i].z))
       continue;
     cloud.points[j] = cloud.points[i];  // safe, because i is always ahead of j
-    h_max = std::max(h_max, cloud.points[i].x / cloud.points[i].z);
-    v_max = std::max(v_max, cloud.points[i].y / cloud.points[i].z);
-    h_min = std::min(h_min, cloud.points[i].x / cloud.points[i].z);
-    v_min = std::min(v_min, cloud.points[i].y / cloud.points[i].z);
+    h_max = h_max * cloud.points[i].z > cloud.points[i].x
+                ? h_max
+                : cloud.points[i].x / cloud.points[i].z;
+    v_max = v_max * cloud.points[i].z > cloud.points[i].y
+                ? v_max
+                : cloud.points[i].y / cloud.points[i].z;
+    h_min = h_min * cloud.points[i].z < cloud.points[i].x
+                ? h_min
+                : cloud.points[i].x / cloud.points[i].z;
+    v_min = v_min * cloud.points[i].z < cloud.points[i].y
+                ? v_min
+                : cloud.points[i].y / cloud.points[i].z;
     j++;
   }
   if (j != cloud.points.size()) {

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -30,7 +30,56 @@ bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
          p_pol.e >= fov.pitch_deg - fov.v_fov_deg / 2.f;
 }
 
+bool isInWhichFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
+                  int& idx) {
+  bool retval = false;
+  idx = -1;
+  for (int i = 0; i < fov_vec.size(); ++i) {
+    if (pointInsideFOV(fov_vec[i], p_pol)) {
+      if (retval) {  // if it's been found before, return false!
+        idx = -1;
+        return false;
+      }
+      idx = i;
+      retval = true;
+    }
+  }
+  return retval;
+}
+
+bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol,
+                   int& idx) {
+  idx = -1;
+  bool retval = false;
+  if (isInWhichFOV(fov_vec, p_pol, idx)) {
+    PolarPoint just_outside = p_pol;
+    // todo: check for pitch!
+    if (wrapAngleToPlusMinus180(p_pol.z - fov_vec[idx].yaw_deg) >
+        0.0f) {  // to the right
+      just_outside.z = wrapAngleToPlusMinus180(
+          fov_vec[idx].yaw_deg + fov_vec[idx].h_fov_deg / 2.0f + 1.0f);
+    } else {  // to the left
+      just_outside.z = wrapAngleToPlusMinus180(
+          fov_vec[idx].yaw_deg - fov_vec[idx].h_fov_deg / 2.0f - 1.0f);
+    }
+
+    retval = !pointInsideFOV(fov_vec, just_outside);
+    if (!retval) {
+      idx = -1;
+    }
+  }
+  return retval;
+}
+
 float scaleToFOV(const std::vector<FOV>& fov, const PolarPoint& p_pol) {
+  int i;
+  if (isOnEdgeOfFOV(fov, p_pol, i)) {
+    float angle_diff_deg = std::abs(fov[i].yaw_deg - p_pol.z);
+    angle_diff_deg = std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
+    angle_diff_deg =
+        std::min(fov[i].h_fov_deg / 2.0f, angle_diff_deg);  // Clamp at h_FOV/2
+    return 1.0f - 2.0f * angle_diff_deg / fov[i].h_fov_deg;
+  }
   return pointInsideFOV(fov, p_pol) ? 1.f : 0.f;  // todo: scale properly
 >>>>>>> Allow discontinuous FOV
 }

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -99,6 +99,11 @@ PolarPoint cartesianToPolarFCU(const Eigen::Vector3f& pos,
   return p;
 }
 
+PolarPoint cartesianToPolarFCU(const pcl::PointXYZ& p) {
+  return cartesianToPolarFCU(Eigen::Vector3f(p.x, p.y, p.z),
+                             Eigen::Vector3f(0.0f, 0.0f, 0.0f));
+}
+
 Eigen::Vector2i polarToHistogramIndex(const PolarPoint& p_pol, int res) {
   Eigen::Vector2i ev2(0, 0);
   PolarPoint p_wrapped = p_pol;
@@ -368,27 +373,49 @@ void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point) {
 }
 
 // This function is a refactor of the original in the pcl library
-void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
+pcl::PointCloud<pcl::PointXYZ> removeNaNAndGetMaxima(
+    pcl::PointCloud<pcl::PointXYZ>& cloud) {
   // Filter out NANs and keep track of outermost points for FOV
   size_t j = 0;
-  float h_max = -9999.f, v_max = -9999.f, h_min = 9999.f, v_min = 9999.f;
+  float x_max = -9999.f, y_max = -9999.f, z_max = -9999.f, x_min = 9999.f,
+        y_min = 9999.f, z_min = 9999.f;
+  int i_x_max = -1, i_x_min = -1, i_y_max = -1, i_y_min = -1, i_z_max = -1,
+      i_z_min = -1;
   for (size_t i = 0; i < cloud.points.size(); ++i) {
     if (!std::isfinite(cloud.points[i].x) ||
         !std::isfinite(cloud.points[i].y) || !std::isfinite(cloud.points[i].z))
       continue;
     cloud.points[j] = cloud.points[i];  // safe, because i is always ahead of j
 
-    if (h_max * cloud.points[i].z < cloud.points[i].x)
-      h_max = cloud.points[i].x / cloud.points[i].z;
+    if (cloud.points[j].x > x_max) {
+      x_max = cloud.points[j].x;
+      i_x_max = j;
+    }
 
-    if (v_max * cloud.points[i].z < cloud.points[i].y)
-      v_max = cloud.points[i].y / cloud.points[i].z;
+    if (cloud.points[j].y > y_max) {
+      y_max = cloud.points[j].y;
+      i_y_max = j;
+    }
 
-    if (h_min * cloud.points[i].z > cloud.points[i].x)
-      h_min = cloud.points[i].x / cloud.points[i].z;
+    if (cloud.points[j].z > z_max) {
+      z_max = cloud.points[j].z;
+      i_z_max = j;
+    }
 
-    if (v_min * cloud.points[i].z > cloud.points[i].y)
-      v_min = cloud.points[i].y / cloud.points[i].z;
+    if (cloud.points[j].x < x_min) {
+      x_min = cloud.points[j].x;
+      i_x_min = j;
+    }
+
+    if (cloud.points[j].y < y_min) {
+      y_min = cloud.points[j].y;
+      i_y_min = j;
+    }
+
+    if (cloud.points[j].z < z_min) {
+      z_min = cloud.points[j].z;
+      i_z_min = j;
+    }
 
     j++;
   }
@@ -402,11 +429,53 @@ void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
 
   // Removing bad points => dense (note: 'dense' doesn't mean 'organized')
   cloud.is_dense = true;
-  fov.h_fov_deg =
-      std::max(fov.h_fov_deg,
-               RAD_TO_DEG * static_cast<float>(atan(h_max) - atan(h_min)));
-  fov.v_fov_deg =
-      std::max(fov.v_fov_deg,
-               RAD_TO_DEG * static_cast<float>(atan(v_max) - atan(v_min)));
+  pcl::PointCloud<pcl::PointXYZ> maxima;
+  maxima.header.frame_id = cloud.header.frame_id;
+  if (i_x_max >= 0) maxima.push_back(cloud.points[i_x_max]);
+  if (i_y_max >= 0) maxima.push_back(cloud.points[i_y_max]);
+  if (i_z_max >= 0) maxima.push_back(cloud.points[i_z_max]);
+  if (i_x_min >= 0) maxima.push_back(cloud.points[i_x_min]);
+  if (i_y_min >= 0) maxima.push_back(cloud.points[i_y_min]);
+  if (i_z_min >= 0) maxima.push_back(cloud.points[i_z_min]);
+
+  return maxima;
 }
+
+void updateFOVFromMaxima(FOV& fov,
+                         const pcl::PointCloud<pcl::PointXYZ>& maxima) {
+  float h_min = 9999.f, h_max = -9999.f, v_min = 9999.f, v_max = -9999.f;
+
+  for (auto p : maxima) {
+    PolarPoint p_pol_fcu = cartesianToPolarFCU(p);
+    p_pol_fcu.z += 180.0f;  // move azimuth to [0, 360]
+    p_pol_fcu.e += 90.0f;   // move elevation to [0, 180]
+    h_min = std::min(p_pol_fcu.z, h_min);
+    h_max = std::max(p_pol_fcu.z, h_max);
+    v_min = std::min(p_pol_fcu.e, v_min);
+    v_max = std::max(p_pol_fcu.e, v_max);
+  }
+
+  float h_diff = std::min(h_max - h_min, 360.0f - h_max + h_min);
+  float v_diff = std::min(v_max - v_min, 360.0f - v_max + v_min);
+
+  if (h_diff > fov.h_fov_deg) {
+    fov.h_fov_deg = h_diff;
+
+    // Note: the wrapping here assumes the FOV < 180 degrees!
+    if (h_diff >= h_max - h_min) {
+      fov.yaw_deg = wrapAngleToPlusMinus180(
+          (h_max + h_min) / 2.0 - 180.0f);  // center of camera in [-180, 180]
+    } else {
+      fov.yaw_deg = wrapAngleToPlusMinus180((h_max + h_min) / 2.0);
+    }
+  }
+
+  // Note: no wrapping in elevation! If the camera sees the zenith or nadir,
+  // we are in trouble anyways! (aka. horizontal FOV = 360 degrees)
+  if (v_diff > fov.v_fov_deg) {
+    fov.v_fov_deg = v_diff;
+    fov.pitch_deg = (v_max + v_min) / 2.0f - 90.0f;
+  }
 }
+
+}  // namespace avoidance

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -315,4 +315,38 @@ void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point) {
   point.yaw = NAN;
   point.yaw_rate = NAN;
 }
+
+// This function is a refactor of the original in the pcl library
+void removeNaNFromPointCloud(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
+  // Filter out NANs and keep track of outermost points for FOV
+  size_t j = 0;
+  float h_max = -9999.f, v_max = -9999.f, h_min = 9999.f, v_min = 9999.f;
+  for (size_t i = 0; i < cloud.points.size(); ++i) {
+    if (!std::isfinite(cloud.points[i].x) ||
+        !std::isfinite(cloud.points[i].y) || !std::isfinite(cloud.points[i].z))
+      continue;
+    cloud.points[j] = cloud.points[i];  // safe, because i is always ahead of j
+    h_max = std::max(h_max, cloud.points[i].x / cloud.points[i].z);
+    v_max = std::max(v_max, cloud.points[i].y / cloud.points[i].z);
+    h_min = std::min(h_min, cloud.points[i].x / cloud.points[i].z);
+    v_min = std::min(v_min, cloud.points[i].y / cloud.points[i].z);
+    j++;
+  }
+  if (j != cloud.points.size()) {
+    // Resize to the correct size
+    cloud.points.resize(j);
+  }
+
+  cloud.height = 1;
+  cloud.width = static_cast<uint32_t>(j);
+
+  // Removing bad points => dense (note: 'dense' doesn't mean 'organized')
+  cloud.is_dense = true;
+  fov.h_fov_deg =
+      std::max(fov.h_fov_deg,
+               RAD_TO_DEG * static_cast<float>(atan(h_max) - atan(h_min)));
+  fov.v_fov_deg =
+      std::max(fov.v_fov_deg,
+               RAD_TO_DEG * static_cast<float>(atan(v_max) - atan(v_min)));
+}
 }

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -317,7 +317,7 @@ void fillUnusedTrajectoryPoint(mavros_msgs::PositionTarget& point) {
 }
 
 // This function is a refactor of the original in the pcl library
-void removeNaNFromPointCloud(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
+void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
   // Filter out NANs and keep track of outermost points for FOV
   size_t j = 0;
   float h_max = -9999.f, v_max = -9999.f, h_min = 9999.f, v_min = 9999.f;

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -9,11 +9,12 @@
 namespace avoidance {
 
 bool pointInsideFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol) {
-  bool retval = false;
   for (auto fov : fov_vec) {
-    retval |= pointInsideFOV(fov, p_pol);
+    if (pointInsideFOV(fov, p_pol)) {
+      return true;
+    }
   }
-  return retval;
+  return false;
 }
 
 bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
@@ -26,7 +27,15 @@ bool pointInsideFOV(const FOV& fov, const PolarPoint& p_pol) {
 }
 
 float scaleToFOV(const std::vector<FOV>& fov, const PolarPoint& p_pol) {
-  return pointInsideFOV(fov, p_pol) ? 1.f : 0.f;  // todo: scale properly
+  int i;
+  if (isOnEdgeOfFOV(fov, p_pol, i)) {
+    float angle_diff_deg = std::abs(fov[i].yaw_deg - p_pol.z);
+    angle_diff_deg = std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
+    angle_diff_deg =
+        std::min(fov[i].h_fov_deg / 2.0f, angle_diff_deg);  // Clamp at h_FOV/2
+    return 1.0f - 2.0f * angle_diff_deg / fov[i].h_fov_deg;
+  }
+  return pointInsideFOV(fov, p_pol) ? 1.f : 0.f;
 }
 
 float distance2DPolar(const PolarPoint& p1, const PolarPoint& p2) {
@@ -368,18 +377,19 @@ void removeNaNAndGetFOV(pcl::PointCloud<pcl::PointXYZ>& cloud, FOV& fov) {
         !std::isfinite(cloud.points[i].y) || !std::isfinite(cloud.points[i].z))
       continue;
     cloud.points[j] = cloud.points[i];  // safe, because i is always ahead of j
-    h_max = h_max * cloud.points[i].z > cloud.points[i].x
-                ? h_max
-                : cloud.points[i].x / cloud.points[i].z;
-    v_max = v_max * cloud.points[i].z > cloud.points[i].y
-                ? v_max
-                : cloud.points[i].y / cloud.points[i].z;
-    h_min = h_min * cloud.points[i].z < cloud.points[i].x
-                ? h_min
-                : cloud.points[i].x / cloud.points[i].z;
-    v_min = v_min * cloud.points[i].z < cloud.points[i].y
-                ? v_min
-                : cloud.points[i].y / cloud.points[i].z;
+
+    if (h_max * cloud.points[i].z < cloud.points[i].x)
+      h_max = cloud.points[i].x / cloud.points[i].z;
+
+    if (v_max * cloud.points[i].z < cloud.points[i].y)
+      v_max = cloud.points[i].y / cloud.points[i].z;
+
+    if (h_min * cloud.points[i].z > cloud.points[i].x)
+      h_min = cloud.points[i].x / cloud.points[i].z;
+
+    if (v_min * cloud.points[i].z > cloud.points[i].y)
+      v_min = cloud.points[i].y / cloud.points[i].z;
+
     j++;
   }
   if (j != cloud.points.size()) {

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -45,10 +45,13 @@ bool isOnEdgeOfFOV(const std::vector<FOV>& fov_vec, const PolarPoint& p_pol, int
   if (isInWhichFOV(fov_vec, p_pol, idx)) {
     PolarPoint just_outside = p_pol;
     // todo: check for pitch!
-    if (wrapAngleToPlusMinus180(p_pol.z - fov_vec[idx].yaw_deg) > 0.0f) {  // to the right
-      just_outside.z = wrapAngleToPlusMinus180(fov_vec[idx].yaw_deg + fov_vec[idx].h_fov_deg / 2.0f + 1.0f);
-    } else {  // to the left
-      just_outside.z = wrapAngleToPlusMinus180(fov_vec[idx].yaw_deg - fov_vec[idx].h_fov_deg / 2.0f - 1.0f);
+    if (wrapAngleToPlusMinus180(p_pol.z - fov_vec[idx].yaw_deg) > 0.0f) {
+      // check half-resolution degrees outside the current fov
+      just_outside.z =
+          wrapAngleToPlusMinus180(fov_vec[idx].yaw_deg + fov_vec[idx].h_fov_deg / 2.0f + (ALPHA_RES / 2.0f));
+    } else {  // half-resolution degrees to the left
+      just_outside.z =
+          wrapAngleToPlusMinus180(fov_vec[idx].yaw_deg - fov_vec[idx].h_fov_deg / 2.0f - (ALPHA_RES / 2.0f));
     }
 
     retval = !pointInsideFOV(fov_vec, just_outside);
@@ -478,7 +481,7 @@ void updateFOVFromMaxima(FOV& fov, const pcl::PointCloud<pcl::PointXYZ>& maxima)
   if (h_diff > fov.h_fov_deg) {
     fov.h_fov_deg = h_diff;
 
-    // Note: the wrapping here assumes the FOV < 180 degrees!
+    // Note: the wrapping here assumes the FOV of one camera is < 180 degrees!
     if (h_diff >= h_max - h_min) {
       fov.yaw_deg = wrapAngleToPlusMinus180((h_max + h_min) / 2.0 - 180.0f);  // center of camera in [-180, 180]
     } else {

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -437,12 +437,12 @@ TEST(Common, wrapPolar) {
   EXPECT_FLOAT_EQ(-120.f, p_pol_6.z);
 }
 
-TEST(Common, removeNaNAndGetFOV) {
+TEST(Common, removeNaNAndGetMaxima) {
   // GIVEN: two point clouds, one including NANs, one without
   pcl::PointCloud<pcl::PointXYZ> pc_no_nan, pc_with_nan;
-  for (float x = -40.f; x < 40.f; x += 1.f) {
-    for (float y = -40.f; y < 40.f; y += 1.f) {
-      pcl::PointXYZ p(x, y, 40.f);
+  for (float x = -40.f; x <= 40.f; x += 1.f) {
+    for (float y = -30.f; y <= 30.f; y += 1.f) {
+      pcl::PointXYZ p(x, y, 15.f);
       pc_no_nan.push_back(p);
       pc_with_nan.push_back(p);
       pc_with_nan.push_back(pcl::PointXYZ(NAN, x, y));  // garbage point
@@ -452,23 +452,47 @@ TEST(Common, removeNaNAndGetFOV) {
   pc_no_nan.is_dense = true;
 
   // WHEN: we filter these clouds
-  FOV fov_no_nan, fov_with_nan;
-  FOV fov_larger(0.f, 0.f, 95.f, 95.f);
-  removeNaNAndGetFOV(pc_no_nan, fov_no_nan);
-  removeNaNAndGetFOV(pc_with_nan, fov_with_nan);
-  removeNaNAndGetFOV(pc_with_nan, fov_larger);
+  pcl::PointCloud<pcl::PointXYZ> maxima_no_nan, maxima_with_nan;
+  maxima_no_nan = removeNaNAndGetMaxima(pc_no_nan);
+  maxima_with_nan = removeNaNAndGetMaxima(pc_with_nan);
 
   // THEN: we expect the clouds to not contain NANs, be dense and reflect
-  // the FOV given by the cloud unless the previous FOV was bigger
+  // the maxima and minima
   EXPECT_EQ(pc_no_nan.size(), pc_with_nan.size());
   EXPECT_TRUE(pc_no_nan.is_dense);
   EXPECT_TRUE(pc_with_nan.is_dense);
-  EXPECT_NEAR(90.f, fov_no_nan.h_fov_deg, 1.f);
-  EXPECT_NEAR(90.f, fov_no_nan.v_fov_deg, 1.f);
-  EXPECT_NEAR(90.f, fov_with_nan.h_fov_deg, 1.f);
-  EXPECT_NEAR(90.f, fov_with_nan.v_fov_deg, 1.f);
-  EXPECT_FLOAT_EQ(95.f, fov_larger.h_fov_deg);
-  EXPECT_FLOAT_EQ(95.f, fov_larger.v_fov_deg);
+  float min_x = 999.f, min_y = 999.f, min_z = 999.f, max_x = -999.f,
+        max_y = -999.f, max_z = -999.f;
+
+  for (auto p : maxima_no_nan) {
+    min_x = std::min(p.x, min_x);
+    min_y = std::min(p.y, min_y);
+    min_z = std::min(p.z, min_z);
+    max_x = std::max(p.x, max_x);
+    max_y = std::max(p.y, max_y);
+    max_z = std::max(p.z, max_z);
+  }
+  EXPECT_NEAR(-40.f, min_x, 1.0f);
+  EXPECT_NEAR(-30.f, min_y, 1.0f);
+  EXPECT_NEAR(15.f, min_z, 1.0f);
+  EXPECT_NEAR(40.f, max_x, 1.0f);
+  EXPECT_NEAR(30.f, max_y, 1.0f);
+  EXPECT_NEAR(15.f, max_z, 1.0f);
+
+  for (auto p : maxima_with_nan) {
+    min_x = std::min(p.x, min_x);
+    min_y = std::min(p.y, min_y);
+    min_z = std::min(p.z, min_z);
+    max_x = std::max(p.x, max_x);
+    max_y = std::max(p.y, max_y);
+    max_z = std::max(p.z, max_z);
+  }
+  EXPECT_NEAR(-40.f, min_x, 1.0f);
+  EXPECT_NEAR(-30.f, min_y, 1.0f);
+  EXPECT_NEAR(15.f, min_z, 1.0f);
+  EXPECT_NEAR(40.f, max_x, 1.0f);
+  EXPECT_NEAR(30.f, max_y, 1.0f);
+  EXPECT_NEAR(15.f, min_z, 1.0f);
 }
 
 TEST(Common, isInWhichFOV) {
@@ -630,4 +654,88 @@ TEST(Common, scaleToFOV) {
   EXPECT_GT(1.0f, right_cam_3);
   EXPECT_FLOAT_EQ(1.0f, overlap);
   EXPECT_FLOAT_EQ(0.0f, outside);
+}
+
+TEST(Common, updateFOVFromMaxima) {
+  // GIVEN: different point clouds indicating various FOV
+  pcl::PointCloud<pcl::PointXYZ> front_h60_v45, right_h90_v30, back_h78_v45,
+      front_elevated, empty, one, zenith, nadir;
+  FOV fov_front_h60_v45, fov_right_h90_v30, fov_back_h78_v45,
+      fov_front_elevated, fov_empty, fov_one, fov_zenith, fov_nadir;
+  front_h60_v45.push_back(pcl::PointXYZ(1.0f, 0.57735026f, 0.47829262f));
+  front_h60_v45.push_back(pcl::PointXYZ(1.0f, -0.57735026f, -0.47829262f));
+  right_h90_v30.push_back(pcl::PointXYZ(1.0f, -1.0f, -0.37893738196));
+  right_h90_v30.push_back(pcl::PointXYZ(-1.0f, -1.0f, 0.37893738196));
+  back_h78_v45.push_back(pcl::PointXYZ(-1.0f, -0.80978403319f, 0.5329932637f));
+  back_h78_v45.push_back(pcl::PointXYZ(-1.0f, 0.80978403319f, -0.5329932637f));
+  front_elevated.push_back(pcl::PointXYZ(1.0f, 1.0f, 1.0f));
+  front_elevated.push_back(pcl::PointXYZ(1.0f, -1.0f, 2.0f));
+  one.push_back(pcl::PointXYZ(1.0f, 1.0f, 1.0f));
+  zenith.push_back(pcl::PointXYZ(1.0f, 1.0f, 3.0f));
+  zenith.push_back(pcl::PointXYZ(1.0f, -1.0f, 3.0f));
+  zenith.push_back(pcl::PointXYZ(-1.0f, 1.0f, 3.0f));
+  zenith.push_back(pcl::PointXYZ(-1.0f, -1.0f, 3.0f));
+  nadir.push_back(pcl::PointXYZ(1.0f, 1.0f, -3.0f));
+  nadir.push_back(pcl::PointXYZ(1.0f, -1.0f, -3.0f));
+  nadir.push_back(pcl::PointXYZ(-1.0f, 1.0f, -3.0f));
+  nadir.push_back(pcl::PointXYZ(-1.0f, -1.0f, -3.0f));
+
+  // WHEN: we call the updateFOVFromMaxima
+  updateFOVFromMaxima(fov_front_h60_v45, front_h60_v45);
+
+  // WHEN: we make subsequent calls with smaller or empty point clouds
+  updateFOVFromMaxima(fov_front_h60_v45, empty);
+
+  // WHEN: we test different fov point clouds
+  updateFOVFromMaxima(fov_right_h90_v30, right_h90_v30);
+  updateFOVFromMaxima(fov_back_h78_v45, back_h78_v45);
+  EXPECT_NO_THROW(updateFOVFromMaxima(fov_empty, empty));
+  updateFOVFromMaxima(fov_front_elevated, front_elevated);
+  EXPECT_NO_THROW(updateFOVFromMaxima(fov_one, one));
+  EXPECT_NO_THROW(updateFOVFromMaxima(fov_zenith, zenith));
+  EXPECT_NO_THROW(updateFOVFromMaxima(fov_nadir, nadir));
+
+  // THEN: we expect the corresponding field of view
+  EXPECT_NEAR(60.0f, fov_front_h60_v45.h_fov_deg, 1.0f);
+  EXPECT_NEAR(45.0f, fov_front_h60_v45.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_front_h60_v45.yaw_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_front_h60_v45.pitch_deg, 1.0f);
+
+  EXPECT_NEAR(90.0f, fov_right_h90_v30.h_fov_deg, 1.0f);
+  EXPECT_NEAR(30.0f, fov_right_h90_v30.v_fov_deg, 1.0f);
+  EXPECT_NEAR(-90.0f, fov_right_h90_v30.yaw_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_right_h90_v30.pitch_deg, 1.0f);
+
+  // THEN: the backward-looking can have yaw of + or - 180
+  EXPECT_NEAR(78.0f, fov_back_h78_v45.h_fov_deg, 1.0f);
+  EXPECT_NEAR(45.0f, fov_back_h78_v45.v_fov_deg, 1.0f);
+  EXPECT_TRUE(180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON ||
+              -180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON);
+  EXPECT_NEAR(0.0f, fov_back_h78_v45.pitch_deg, 1.0f);
+
+  EXPECT_NEAR(0.0f, fov_empty.h_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_empty.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_empty.yaw_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_empty.pitch_deg, 1.0f);
+
+  EXPECT_NEAR(90.0f, fov_front_elevated.h_fov_deg, 1.0f);
+  EXPECT_NEAR(19.47121f, fov_front_elevated.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_front_elevated.yaw_deg, 1.0f);
+  EXPECT_NEAR(-45.0f, fov_front_elevated.pitch_deg, 1.0f);
+
+  EXPECT_NEAR(0.0f, fov_one.h_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_one.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_one.yaw_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_one.pitch_deg, 1.0f);
+/** these can currently not work, as long as it doesn't throw
+  EXPECT_NEAR(360.0f, fov_zenith.h_fov_deg, 1.0f);
+  EXPECT_NEAR(36.8698976f, fov_zenith.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_zenith.yaw_deg, 1.0f);
+  EXPECT_NEAR(90.0f, fov_zenith.pitch_deg, 1.0f);
+
+  EXPECT_NEAR(360.0f, fov_nadir.h_fov_deg, 1.0f);
+  EXPECT_NEAR(36.8698976f, fov_nadir.v_fov_deg, 1.0f);
+  EXPECT_NEAR(0.0f, fov_nadir.yaw_deg, 1.0f);
+  EXPECT_NEAR(-90.0f, fov_nadir.pitch_deg, 1.0f);
+  **/
 }

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -436,7 +436,7 @@ TEST(Common, wrapPolar) {
   EXPECT_FLOAT_EQ(-120.f, p_pol_6.z);
 }
 
-TEST(Common, removeNaNFromPointCloud) {
+TEST(Common, removeNaNAndGetFOV) {
   // GIVEN: two point clouds, one including NANs, one without
   pcl::PointCloud<pcl::PointXYZ> pc_no_nan, pc_with_nan;
   for (float x = -40.f; x < 40.f; x += 1.f) {
@@ -452,8 +452,8 @@ TEST(Common, removeNaNFromPointCloud) {
 
   // WHEN: we filter these clouds
   FOV fov_no_nan, fov_with_nan;
-  removeNaNFromPointCloud(pc_no_nan, fov_no_nan);
-  removeNaNFromPointCloud(pc_with_nan, fov_with_nan);
+  removeNaNAndGetFOV(pc_no_nan, fov_no_nan);
+  removeNaNAndGetFOV(pc_with_nan, fov_with_nan);
 
   // THEN: we expect the clouds to not contain NANs, be dense and reflect
   // the FOV given by the cloud

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -136,8 +136,7 @@ TEST(Common, elevationAnglefromCartesian) {
   const float angle_q2 = cartesianToPolarHistogram(point_q2, origin).e;
   const float angle_q3 = cartesianToPolarHistogram(point_q3, origin).e;
   const float angle_q4 = cartesianToPolarHistogram(point_q4, origin).e;
-  const float angle_non_zero_origin =
-      cartesianToPolarHistogram(point_q4, point_q2).e;
+  const float angle_non_zero_origin = cartesianToPolarHistogram(point_q4, point_q2).e;
 
   // THEN: angle should be ..
   EXPECT_FLOAT_EQ(0.f, angle_front);
@@ -461,8 +460,7 @@ TEST(Common, removeNaNAndGetMaxima) {
   EXPECT_EQ(pc_no_nan.size(), pc_with_nan.size());
   EXPECT_TRUE(pc_no_nan.is_dense);
   EXPECT_TRUE(pc_with_nan.is_dense);
-  float min_x = 999.f, min_y = 999.f, min_z = 999.f, max_x = -999.f,
-        max_y = -999.f, max_z = -999.f;
+  float min_x = 999.f, min_y = 999.f, min_z = 999.f, max_x = -999.f, max_y = -999.f, max_z = -999.f;
 
   for (auto p : maxima_no_nan) {
     min_x = std::min(p.x, min_x);
@@ -505,16 +503,13 @@ TEST(Common, isInWhichFOV) {
   -180                             -30   0     +30                          +180
   **/
   std::vector<FOV> fov;
-  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));  // camera one: forward-facing
-  fov.push_back(FOV(35.0f, -1.0f, 15.0f,
-                    30.0f));  // camera two: right-facing with overlaps with 1
+  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));     // camera one: forward-facing
+  fov.push_back(FOV(35.0f, -1.0f, 15.0f, 30.0f));   // camera two: right-facing with overlaps with 1
   fov.push_back(FOV(-100.0f, 3.0f, 20.0f, 30.0f));  // camera three: left facing
 
   // WHEN: we sample points inside, outside and in the overlapping region
-  int idx_inside_camera_1, idx_inside_camera_2, idx_inside_camera_3,
-      idx_outside, idx_overlap = 0;
-  bool retval_inside_1, retval_inside_2, retval_inside_3, retval_outside,
-      retval_overlap = false;
+  int idx_inside_camera_1, idx_inside_camera_2, idx_inside_camera_3, idx_outside, idx_overlap = 0;
+  bool retval_inside_1, retval_inside_2, retval_inside_3, retval_outside, retval_overlap = false;
   PolarPoint sample_inside_1(0.0f, -25.0f, 1.0f);
   PolarPoint sample_inside_2(0.0f, 36.0f, 1.0f);
   PolarPoint sample_inside_3(0.0f, -90.0f, 1.0f);
@@ -549,17 +544,15 @@ TEST(Common, isOnEdgeOfFOV) {
   -180                             -30   0     +30                          +180
   **/
   std::vector<FOV> fov;
-  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));  // camera one: forward-facing
-  fov.push_back(FOV(35.0f, -1.0f, 15.0f,
-                    30.0f));  // camera two: right-facing with overlaps with 1
+  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));     // camera one: forward-facing
+  fov.push_back(FOV(35.0f, -1.0f, 15.0f, 30.0f));   // camera two: right-facing with overlaps with 1
   fov.push_back(FOV(-100.0f, 3.0f, 20.0f, 30.0f));  // camera three: left facing
 
   // WHEN: we sample points outside, inside but on edge, inside but not on edge,
   // inside in overlapping region
-  bool left_cam_1, right_cam_1, left_cam_2, right_cam_2, left_cam_3,
-      right_cam_3, overlap, outside = false;
-  int idx_left_cam_1, idx_right_cam_1, idx_left_cam_2, idx_right_cam_2,
-      idx_left_cam_3, idx_right_cam_3, idx_overlap, idx_outside;
+  bool left_cam_1, right_cam_1, left_cam_2, right_cam_2, left_cam_3, right_cam_3, overlap, outside = false;
+  int idx_left_cam_1, idx_right_cam_1, idx_left_cam_2, idx_right_cam_2, idx_left_cam_3, idx_right_cam_3, idx_overlap,
+      idx_outside;
   PolarPoint sample_left_cam_1(0.0f, -25.0f, 1.0f);
   PolarPoint sample_right_cam_1(0.0f, 0.2f, 1.0f);
   PolarPoint sample_left_cam_2(0.0f, 34.0f, 1.0f);
@@ -607,17 +600,16 @@ TEST(Common, scaleToFOV) {
   -180                             -30   0     +30                          +180
   **/
   std::vector<FOV> fov;
-  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));  // camera one: forward-facing
-  fov.push_back(FOV(35.0f, -1.0f, 15.0f,
-                    30.0f));  // camera two: right-facing with overlaps with 1
+  fov.push_back(FOV(0.0f, 0.0f, 60.0f, 40.0f));     // camera one: forward-facing
+  fov.push_back(FOV(35.0f, -1.0f, 15.0f, 30.0f));   // camera two: right-facing with overlaps with 1
   fov.push_back(FOV(-100.0f, 3.0f, 20.0f, 30.0f));  // camera three: left facing
 
   // WHEN: we sample points outside, inside but on edge, inside but not on edge,
   // inside in overlapping region
-  float left_cam_1, left_2_cam_1, right_cam_1, left_cam_2, right_cam_2,
-      left_cam_3, right_cam_3, overlap, outside = false;
-  int idx_left_cam_1, idx_right_cam_1, idx_left_cam_2, idx_right_cam_2,
-      idx_left_cam_3, idx_right_cam_3, idx_overlap, idx_outside;
+  float left_cam_1, left_2_cam_1, right_cam_1, left_cam_2, right_cam_2, left_cam_3, right_cam_3, overlap,
+      outside = false;
+  int idx_left_cam_1, idx_right_cam_1, idx_left_cam_2, idx_right_cam_2, idx_left_cam_3, idx_right_cam_3, idx_overlap,
+      idx_outside;
   PolarPoint sample_left_cam_1(0.0f, -25.0f, 1.0f);
   PolarPoint sample2_left_cam_1(0.0f, -26.0f, 1.0f);
   PolarPoint sample_right_cam_1(0.0f, 0.2f, 1.0f);
@@ -658,10 +650,9 @@ TEST(Common, scaleToFOV) {
 
 TEST(Common, updateFOVFromMaxima) {
   // GIVEN: different point clouds indicating various FOV
-  pcl::PointCloud<pcl::PointXYZ> front_h60_v45, right_h90_v30, back_h78_v45,
-      front_elevated, empty, one, zenith, nadir;
-  FOV fov_front_h60_v45, fov_right_h90_v30, fov_back_h78_v45,
-      fov_front_elevated, fov_empty, fov_one, fov_zenith, fov_nadir;
+  pcl::PointCloud<pcl::PointXYZ> front_h60_v45, right_h90_v30, back_h78_v45, front_elevated, empty, one, zenith, nadir;
+  FOV fov_front_h60_v45, fov_right_h90_v30, fov_back_h78_v45, fov_front_elevated, fov_empty, fov_one, fov_zenith,
+      fov_nadir;
   front_h60_v45.push_back(pcl::PointXYZ(1.0f, 0.57735026f, 0.47829262f));
   front_h60_v45.push_back(pcl::PointXYZ(1.0f, -0.57735026f, -0.47829262f));
   right_h90_v30.push_back(pcl::PointXYZ(1.0f, -1.0f, -0.37893738196));
@@ -709,8 +700,7 @@ TEST(Common, updateFOVFromMaxima) {
   // THEN: the backward-looking can have yaw of + or - 180
   EXPECT_NEAR(78.0f, fov_back_h78_v45.h_fov_deg, 1.0f);
   EXPECT_NEAR(45.0f, fov_back_h78_v45.v_fov_deg, 1.0f);
-  EXPECT_TRUE(180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON ||
-              -180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON);
+  EXPECT_TRUE(180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON || -180.0f - fov_back_h78_v45.yaw_deg <= FLT_EPSILON);
   EXPECT_NEAR(0.0f, fov_back_h78_v45.pitch_deg, 1.0f);
 
   EXPECT_NEAR(0.0f, fov_empty.h_fov_deg, 1.0f);
@@ -727,15 +717,15 @@ TEST(Common, updateFOVFromMaxima) {
   EXPECT_NEAR(0.0f, fov_one.v_fov_deg, 1.0f);
   EXPECT_NEAR(0.0f, fov_one.yaw_deg, 1.0f);
   EXPECT_NEAR(0.0f, fov_one.pitch_deg, 1.0f);
-/** these can currently not work, as long as it doesn't throw
-  EXPECT_NEAR(360.0f, fov_zenith.h_fov_deg, 1.0f);
-  EXPECT_NEAR(36.8698976f, fov_zenith.v_fov_deg, 1.0f);
-  EXPECT_NEAR(0.0f, fov_zenith.yaw_deg, 1.0f);
-  EXPECT_NEAR(90.0f, fov_zenith.pitch_deg, 1.0f);
+  /** these can currently not work, as long as it doesn't throw
+    EXPECT_NEAR(360.0f, fov_zenith.h_fov_deg, 1.0f);
+    EXPECT_NEAR(36.8698976f, fov_zenith.v_fov_deg, 1.0f);
+    EXPECT_NEAR(0.0f, fov_zenith.yaw_deg, 1.0f);
+    EXPECT_NEAR(90.0f, fov_zenith.pitch_deg, 1.0f);
 
-  EXPECT_NEAR(360.0f, fov_nadir.h_fov_deg, 1.0f);
-  EXPECT_NEAR(36.8698976f, fov_nadir.v_fov_deg, 1.0f);
-  EXPECT_NEAR(0.0f, fov_nadir.yaw_deg, 1.0f);
-  EXPECT_NEAR(-90.0f, fov_nadir.pitch_deg, 1.0f);
-  **/
+    EXPECT_NEAR(360.0f, fov_nadir.h_fov_deg, 1.0f);
+    EXPECT_NEAR(36.8698976f, fov_nadir.v_fov_deg, 1.0f);
+    EXPECT_NEAR(0.0f, fov_nadir.yaw_deg, 1.0f);
+    EXPECT_NEAR(-90.0f, fov_nadir.pitch_deg, 1.0f);
+    **/
 }

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -88,16 +88,16 @@ TEST(Common, azimuthAnglefromCartesian) {
   const Eigen::Vector3f origin(0.0f, 0.0f, 0.0f);
 
   // WHEN: calculating the azimuth angle between the two points
-  float angle_right = cartesianToPolar(point_right, origin).z;
-  float angle_up = cartesianToPolar(point_up, origin).z;
-  float angle_left = cartesianToPolar(point_left, origin).z;
-  float angle_down = cartesianToPolar(point_down, origin).z;
-  float angle_undetermined = cartesianToPolar(origin, origin).z;
-  float angle_q1 = cartesianToPolar(point_q1, origin).z;
-  float angle_q2 = cartesianToPolar(point_q2, origin).z;
-  float angle_q3 = cartesianToPolar(point_q3, origin).z;
-  float angle_q4 = cartesianToPolar(point_q4, origin).z;
-  float angle_non_zero_origin = cartesianToPolar(point_q1, point_q2).z;
+  float angle_right = cartesianToPolarHistogram(point_right, origin).z;
+  float angle_up = cartesianToPolarHistogram(point_up, origin).z;
+  float angle_left = cartesianToPolarHistogram(point_left, origin).z;
+  float angle_down = cartesianToPolarHistogram(point_down, origin).z;
+  float angle_undetermined = cartesianToPolarHistogram(origin, origin).z;
+  float angle_q1 = cartesianToPolarHistogram(point_q1, origin).z;
+  float angle_q2 = cartesianToPolarHistogram(point_q2, origin).z;
+  float angle_q3 = cartesianToPolarHistogram(point_q3, origin).z;
+  float angle_q4 = cartesianToPolarHistogram(point_q4, origin).z;
+  float angle_non_zero_origin = cartesianToPolarHistogram(point_q1, point_q2).z;
 
   // THEN:  angle should be ..
   EXPECT_FLOAT_EQ(90.f, angle_right);
@@ -126,17 +126,18 @@ TEST(Common, elevationAnglefromCartesian) {
   const Eigen::Vector3f origin(0.0f, 0.0f, 0.0f);
 
   // WHEN: we get the elevation angle between the two points
-  const float angle_front = cartesianToPolar(point_front, origin).e;
-  const float angle_up = cartesianToPolar(point_up, origin).e;
-  const float angle_behind = cartesianToPolar(point_behind, origin).e;
-  const float angle_down = cartesianToPolar(point_down, origin).e;
-  const float angle_undetermined = cartesianToPolar(origin, origin).e;
-  const float angle_q1 = cartesianToPolar(point_q1, origin).e;
-  const float angle_30 = cartesianToPolar(point_30, origin).e;
-  const float angle_q2 = cartesianToPolar(point_q2, origin).e;
-  const float angle_q3 = cartesianToPolar(point_q3, origin).e;
-  const float angle_q4 = cartesianToPolar(point_q4, origin).e;
-  const float angle_non_zero_origin = cartesianToPolar(point_q4, point_q2).e;
+  const float angle_front = cartesianToPolarHistogram(point_front, origin).e;
+  const float angle_up = cartesianToPolarHistogram(point_up, origin).e;
+  const float angle_behind = cartesianToPolarHistogram(point_behind, origin).e;
+  const float angle_down = cartesianToPolarHistogram(point_down, origin).e;
+  const float angle_undetermined = cartesianToPolarHistogram(origin, origin).e;
+  const float angle_q1 = cartesianToPolarHistogram(point_q1, origin).e;
+  const float angle_30 = cartesianToPolarHistogram(point_30, origin).e;
+  const float angle_q2 = cartesianToPolarHistogram(point_q2, origin).e;
+  const float angle_q3 = cartesianToPolarHistogram(point_q3, origin).e;
+  const float angle_q4 = cartesianToPolarHistogram(point_q4, origin).e;
+  const float angle_non_zero_origin =
+      cartesianToPolarHistogram(point_q4, point_q2).e;
 
   // THEN: angle should be ..
   EXPECT_FLOAT_EQ(0.f, angle_front);
@@ -201,7 +202,7 @@ TEST(Common, polarToHistogramIndex) {
   EXPECT_EQ(29, index_9.x());
 }
 
-TEST(Common, polarToCartesian) {
+TEST(Common, polarHistogramToCartesian) {
   // GIVEN: the elevation angle, azimuth angle, a radius and the position
   std::vector<float> e = {-90.f, -90.f, 90.f, 0.f, 45.f};    //[-90, 90]
   std::vector<float> z = {-180.f, -90.f, 179.f, 0.f, 45.f};  //[-180, 180]
@@ -223,12 +224,12 @@ TEST(Common, polarToCartesian) {
 
   for (int i = 0; i < n; i++) {
     PolarPoint p_pol(e[i], z[3], radius[0]);
-    pos_out.push_back(polarToCartesian(p_pol, pos));
+    pos_out.push_back(polarHistogramToCartesian(p_pol, pos));
   }
 
   for (int i = 0; i < n; i++) {
     PolarPoint p_pol(e[i], z[i], radius[1]);
-    pos_out.push_back(polarToCartesian(p_pol, pos));
+    pos_out.push_back(polarHistogramToCartesian(p_pol, pos));
   }
 
   // THEN: the cartesian coordinates are
@@ -270,9 +271,9 @@ TEST(Common, PolarToCatesianToPolar) {
   for (float e = -90.f; e <= 90.f; e = e + 3.f) {
     for (float z = -180.f; z <= 180.f; z = z + 6.f) {
       PolarPoint p_pol(e, z, radius);
-      Eigen::Vector3f p_cartesian = polarToCartesian(p_pol, pos);
+      Eigen::Vector3f p_cartesian = polarHistogramToCartesian(p_pol, pos);
 
-      PolarPoint p_pol_new = cartesianToPolar(p_cartesian, pos);
+      PolarPoint p_pol_new = cartesianToPolarHistogram(p_cartesian, pos);
 
       // THEN: the resulting polar positions are expected to be the same as
       // before the conversion
@@ -293,7 +294,7 @@ TEST(Common, PolarToCatesianToPolar) {
   }
 }
 
-TEST(Common, cartesianTopolarToCartesian) {
+TEST(Common, cartesianTopolarHistogramToCartesian) {
   // GIVEN: a current position
   Eigen::Vector3f pos(0.81f, 5.17f, 3.84f);
 
@@ -303,9 +304,9 @@ TEST(Common, cartesianTopolarToCartesian) {
     for (float y = -5.f; y <= 5.f; y = y + 0.6f) {
       for (float z = -5.f; z <= 5.f; z = z + 0.4f) {
         Eigen::Vector3f origin(x, y, z);
-        PolarPoint p_pol = cartesianToPolar(origin, pos);
+        PolarPoint p_pol = cartesianToPolarHistogram(origin, pos);
         // p_pol.r = (origin - pos).norm();
-        Eigen::Vector3f p_cartesian = polarToCartesian(p_pol, pos);
+        Eigen::Vector3f p_cartesian = polarHistogramToCartesian(p_pol, pos);
 
         // THEN: the resulting cartesian positions are expected to be the same
         // as

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -475,7 +475,7 @@ TEST(Common, isInWhichFOV) {
   // GIVEN: a three-camera setup with two overlapping FOV and one alone
   /**
             cam 3                     cam1    cam 2
-                                             |--|--\
+                                             |--|--|
           |---|---|                |-----|-----|
   |--------------------------------------|------------------------------------|
   -180                             -30   0     +30                          +180
@@ -519,7 +519,7 @@ TEST(Common, isOnEdgeOfFOV) {
   // GIVEN: a three-camera setup with two overlapping FOV and one alone
   /**
             cam 3                     cam1    cam 2
-                                             |--|--\
+                                             |--|--|
           |---|---|                |-----|-----|
   |--------------------------------------|------------------------------------|
   -180                             -30   0     +30                          +180
@@ -577,7 +577,7 @@ TEST(Common, scaleToFOV) {
   // GIVEN: a three-camera setup with two overlapping FOV and one alone
   /**
             cam 3                     cam1    cam 2
-                                             |--|--\
+                                             |--|--|
           |---|---|                |-----|-----|
   |--------------------------------------|------------------------------------|
   -180                             -30   0     +30                          +180

--- a/avoidance/test/test_common.cpp
+++ b/avoidance/test/test_common.cpp
@@ -452,11 +452,13 @@ TEST(Common, removeNaNAndGetFOV) {
 
   // WHEN: we filter these clouds
   FOV fov_no_nan, fov_with_nan;
+  FOV fov_larger(0.f, 0.f, 95.f, 95.f);
   removeNaNAndGetFOV(pc_no_nan, fov_no_nan);
   removeNaNAndGetFOV(pc_with_nan, fov_with_nan);
+  removeNaNAndGetFOV(pc_with_nan, fov_larger);
 
   // THEN: we expect the clouds to not contain NANs, be dense and reflect
-  // the FOV given by the cloud
+  // the FOV given by the cloud unless the previous FOV was bigger
   EXPECT_EQ(pc_no_nan.size(), pc_with_nan.size());
   EXPECT_TRUE(pc_no_nan.is_dense);
   EXPECT_TRUE(pc_with_nan.is_dense);
@@ -464,4 +466,6 @@ TEST(Common, removeNaNAndGetFOV) {
   EXPECT_NEAR(90.f, fov_no_nan.v_fov_deg, 1.f);
   EXPECT_NEAR(90.f, fov_with_nan.h_fov_deg, 1.f);
   EXPECT_NEAR(90.f, fov_with_nan.v_fov_deg, 1.f);
+  EXPECT_FLOAT_EQ(95.f, fov_larger.h_fov_deg);
+  EXPECT_FLOAT_EQ(95.f, fov_larger.v_fov_deg);
 }

--- a/local_planner/include/local_planner/box.h
+++ b/local_planner/include/local_planner/box.h
@@ -25,7 +25,7 @@ class Box {
   * @param[in] z, z-coordinate of the point
   * @returns   true, if the point is within the bounding box
   **/
-  inline bool isPointWithinBox(const float& x, const float& y, const float& z) {
+  inline bool isPointWithinBox(const float& x, const float& y, const float& z) const {
     return x < xmax_ && x > xmin_ && y < ymax_ && y > ymin_ && z < zmax_ && z > zmin_;
   }
 

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -188,12 +188,8 @@ class LocalPlanner {
   /**
   * @brief     Getters for the FOV
   */
-  float getHFOV(int i) {
-    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].h_fov_deg : 0.f;
-  }
-  float getVFOV(int i) {
-    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].v_fov_deg : 0.f;
-  }
+  float getHFOV(int i) { return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].h_fov_deg : 0.f; }
+  float getVFOV(int i) { return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].v_fov_deg : 0.f; }
   const std::vector<FOV>& getFOV() const { return fov_fcu_frame_; }
 
   /**

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -194,10 +194,7 @@ class LocalPlanner {
   float getVFOV(int i) {
     return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].v_fov_deg : 0.f;
   }
-  FOV getFOV(int i) const {
-    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i] : FOV();
-  }
-  std::vector<FOV> getFOV() const { return fov_fcu_frame_; }
+  const std::vector<FOV>& getFOV() const { return fov_fcu_frame_; }
 
   /**
   * @brief     getter method for current goal

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -83,8 +83,10 @@ class LocalPlanner {
   float min_realsense_dist_ = 0.2f;
   float smoothing_margin_degrees_ = 30.f;
   float max_point_age_s_ = 10;
+  float yaw_fcu_frame_deg_ = 0.0f;
+  float pitch_fcu_frame_deg_ = 0.0f;
 
-  FOV fov_;
+  std::vector<FOV> fov_fcu_frame_;
 
   waypoint_choice waypoint_type_ = hover;
   ros::Time last_path_time_;
@@ -169,24 +171,33 @@ class LocalPlanner {
   * @param[in] q, vehicle orientation message coming from the FCU
   **/
   void setPose(const Eigen::Vector3f& pos, const Eigen::Quaternionf& q);
+
   /**
   * @brief     setter method for mission goal
   * @param[in] mgs, goal message coming from the FCU
   **/
   void setGoal(const Eigen::Vector3f& goal);
+
   /**
   * @brief     setter method for field of view
-  * @param[in] horizontal angle in degrees of the sensor data
-  * @param[in] vertical angle in degrees of the sensor data
+  * @param[in] index of the camera
+  * @param[in] field of view structure of the camera
   */
-  void setFOV(float h_FOV_deg, float v_FOV_deg);
+  void setFOV(int i, const FOV& fov);
 
   /**
   * @brief     Getters for the FOV
   */
-  float getHFOV() { return fov_.h_fov_deg; }
-  float getVFOV() { return fov_.v_fov_deg; }
-  FOV getFOV() const { return fov_; }
+  float getHFOV(int i) {
+    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].h_fov_deg : 0.f;
+  }
+  float getVFOV(int i) {
+    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i].v_fov_deg : 0.f;
+  }
+  FOV getFOV(int i) const {
+    return i < fov_fcu_frame_.size() ? fov_fcu_frame_[i] : FOV();
+  }
+  std::vector<FOV> getFOV() const { return fov_fcu_frame_; }
 
   /**
   * @brief     getter method for current goal

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -57,7 +57,7 @@ struct cameraData {
   ros::Subscriber pointcloud_sub_;
   sensor_msgs::PointCloud2 newest_cloud_msg_;
 
-  FOV fov_camera_frame_;
+  FOV fov_fcu_frame_;
 
   std::unique_ptr<std::mutex> cloud_msg_mutex_;
   std::unique_ptr<std::mutex> transformed_cloud_mutex_;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <geometry_msgs/Point.h>
+#include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <mavros_msgs/Altitude.h>

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -11,7 +11,6 @@
 #endif
 
 #include <geometry_msgs/Point.h>
-#include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/PoseArray.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <mavros_msgs/Altitude.h>

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -55,8 +55,9 @@ class WaypointGenerator;
 struct cameraData {
   std::string topic_;
   ros::Subscriber pointcloud_sub_;
-  ros::Subscriber camera_info_sub_;
   sensor_msgs::PointCloud2 newest_cloud_msg_;
+
+  FOV fov_camera_frame_;
 
   std::unique_ptr<std::mutex> cloud_msg_mutex_;
   std::unique_ptr<std::mutex> transformed_cloud_mutex_;

--- a/local_planner/include/local_planner/local_planner_visualization.h
+++ b/local_planner/include/local_planner/local_planner_visualization.h
@@ -135,7 +135,7 @@ class LocalPlannerVisualization {
   **/
   void publishOfftrackPoints(Eigen::Vector3f& closest_pt, Eigen::Vector3f& deg60_pt);
 
-  void publishFOV(const std::vector<FOV>& fov, const float max_range) const;
+  void publishFOV(const std::vector<FOV>& fov, float max_range) const;
 
  private:
   ros::Publisher local_pointcloud_pub_;

--- a/local_planner/include/local_planner/local_planner_visualization.h
+++ b/local_planner/include/local_planner/local_planner_visualization.h
@@ -135,11 +135,7 @@ class LocalPlannerVisualization {
   **/
   void publishOfftrackPoints(Eigen::Vector3f& closest_pt, Eigen::Vector3f& deg60_pt);
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  void publishFOV(const Eigen::Vector3f& drone_pos, const FOV& fov, const float max_range) const;
-=======
   void publishFOV(const std::vector<FOV>& fov, const float max_range) const;
->>>>>>> Allow discontinuous FOV
 
  private:
   ros::Publisher local_pointcloud_pub_;

--- a/local_planner/include/local_planner/local_planner_visualization.h
+++ b/local_planner/include/local_planner/local_planner_visualization.h
@@ -135,7 +135,11 @@ class LocalPlannerVisualization {
   **/
   void publishOfftrackPoints(Eigen::Vector3f& closest_pt, Eigen::Vector3f& deg60_pt);
 
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   void publishFOV(const Eigen::Vector3f& drone_pos, const FOV& fov, const float max_range) const;
+=======
+  void publishFOV(const std::vector<FOV>& fov, const float max_range) const;
+>>>>>>> Allow discontinuous FOV
 
  private:
   ros::Publisher local_pointcloud_pub_;

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -32,10 +32,20 @@ namespace avoidance {
 *             be kept, less points are discarded as noise (careful: 0 is not
 *             a valid input here)
 **/
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                        const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box, FOV& fov,
                        const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
                        int min_num_points_per_cell);
+=======
+void processPointcloud(
+    pcl::PointCloud<pcl::PointXYZI>& final_cloud,
+    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
+    Box histogram_box, const std::vector<FOV>& fov, float yaw_fcu_frame_deg,
+    float pitch_fcu_frame_deg, const Eigen::Vector3f& position,
+    float min_realsense_dist, int max_age, float elapsed_s,
+    int min_num_points_per_cell);
+>>>>>>> Allow discontinuous FOV
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around
@@ -67,10 +77,21 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] cost_matrix
 * @param[out] image of the cost matrix for visualization
 **/
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                    const float yaw_angle_histogram_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed, const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data);
+=======
+void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
+                   const Eigen::Vector3f& position,
+                   const float yaw_fcu_frame_deg,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed,
+                   const float smoothing_margin_degrees,
+                   Eigen::MatrixXf& cost_matrix,
+                   std::vector<uint8_t>& image_data);
+>>>>>>> Allow discontinuous FOV
 
 /**
 * @brief      get the index in the data vector of a color image
@@ -111,9 +132,17 @@ void getBestCandidatesFromCostMatrix(const Eigen::MatrixXf& matrix, unsigned int
 * @param[out] distance_cost, cost component due to proximity to obstacles
 * @param[out] other_costs, cost component due to goal and smoothness
 **/
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params, float& distance_cost,
+=======
+void costFunction(float e_angle, float z_angle, float obstacle_distance,
+                  const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                  float yaw_fcu_frame_deg,
+                  const Eigen::Vector3f& last_sent_waypoint,
+                  costParameters cost_params, float& distance_cost,
+>>>>>>> Allow discontinuous FOV
                   float& other_costs);
 
 /**

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -32,13 +32,11 @@ namespace avoidance {
 *             be kept, less points are discarded as noise (careful: 0 is not
 *             a valid input here)
 **/
-void processPointcloud(
-    pcl::PointCloud<pcl::PointXYZI>& final_cloud,
-    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const std::vector<FOV>& fov, float yaw_fcu_frame_deg,
-    float pitch_fcu_frame_deg, const Eigen::Vector3f& position,
-    float min_realsense_dist, int max_age, float elapsed_s,
-    int min_num_points_per_cell);
+void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
+                       const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box,
+                       const std::vector<FOV>& fov, float yaw_fcu_frame_deg, float pitch_fcu_frame_deg,
+                       const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
+                       int min_num_points_per_cell);
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around
@@ -70,11 +68,9 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] cost_matrix
 * @param[out] image of the cost matrix for visualization
 **/
-void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position, float yaw_fcu_frame_deg,
-                   const Eigen::Vector3f& last_sent_waypoint,
-                   costParameters cost_params, bool only_yawed,
-                   float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
+void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                   float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params,
+                   bool only_yawed, float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
                    std::vector<uint8_t>& image_data);
 
 /**
@@ -116,12 +112,9 @@ void getBestCandidatesFromCostMatrix(const Eigen::MatrixXf& matrix, unsigned int
 * @param[out] distance_cost, cost component due to proximity to obstacles
 * @param[out] other_costs, cost component due to goal and smoothness
 **/
-void costFunction(float e_angle, float z_angle, float obstacle_distance,
-                  const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  float yaw_fcu_frame_deg,
-                  const Eigen::Vector3f& last_sent_waypoint,
-                  costParameters cost_params, float& distance_cost,
-                  float& other_costs);
+void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
+                  const Eigen::Vector3f& position, float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
+                  costParameters cost_params, float& distance_cost, float& other_costs);
 
 /**
 * @brief      max-median filtes the cost matrix

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -33,7 +33,7 @@ namespace avoidance {
 *             a valid input here)
 **/
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
-                       const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box,
+                       const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, const Box& histogram_box,
                        const std::vector<FOV>& fov, float yaw_fcu_frame_deg, float pitch_fcu_frame_deg,
                        const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
                        int min_num_points_per_cell);
@@ -52,7 +52,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
 * @brief      compresses the histogram such that for each azimuth the minimum
 *             distance at the elevation inside the FOV is saved
 * @param[out] new_hist, compressed elevation histogram
-* @param[int] input_hist, original histogram
+* @param[in] input_hist, original histogram
 **/
 void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist);
 /**
@@ -69,9 +69,9 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] image of the cost matrix for visualization
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                   float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params,
-                   bool only_yawed, float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
-                   std::vector<uint8_t>& image_data);
+                   float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
+                   const costParameters& cost_params, bool only_yawed, float smoothing_margin_degrees,
+                   Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data);
 
 /**
 * @brief      get the index in the data vector of a color image
@@ -114,7 +114,7 @@ void getBestCandidatesFromCostMatrix(const Eigen::MatrixXf& matrix, unsigned int
 **/
 void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
                   const Eigen::Vector3f& position, float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                  costParameters cost_params, float& distance_cost, float& other_costs);
+                  const costParameters& cost_params, float& distance_cost, float& other_costs);
 
 /**
 * @brief      max-median filtes the cost matrix
@@ -144,7 +144,7 @@ Eigen::ArrayXf getConicKernel(int radius);
 * @brief      helper method to output on the console the histogram
 * @param[in]  histogram, polar histogram
 **/
-void printHistogram(Histogram& histogram);
+void printHistogram(const Histogram& histogram);
 
 /**
 * @brief      finds the minimum cost direction in the tree

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -71,12 +71,10 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] image of the cost matrix for visualization
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position,
-                   const float yaw_fcu_frame_deg,
+                   const Eigen::Vector3f& position, float yaw_fcu_frame_deg,
                    const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed,
-                   const float smoothing_margin_degrees,
-                   Eigen::MatrixXf& cost_matrix,
+                   float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
                    std::vector<uint8_t>& image_data);
 
 /**

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -32,12 +32,6 @@ namespace avoidance {
 *             be kept, less points are discarded as noise (careful: 0 is not
 *             a valid input here)
 **/
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
-                       const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box, FOV& fov,
-                       const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
-                       int min_num_points_per_cell);
-=======
 void processPointcloud(
     pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
@@ -45,7 +39,6 @@ void processPointcloud(
     float pitch_fcu_frame_deg, const Eigen::Vector3f& position,
     float min_realsense_dist, int max_age, float elapsed_s,
     int min_num_points_per_cell);
->>>>>>> Allow discontinuous FOV
 
 /**
 * @brief      calculates a histogram from the current frame pointcloud around
@@ -77,12 +70,6 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] cost_matrix
 * @param[out] image of the cost matrix for visualization
 **/
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                   const float yaw_angle_histogram_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                   costParameters cost_params, bool only_yawed, const float smoothing_margin_degrees,
-                   Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data);
-=======
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const Eigen::Vector3f& position,
                    const float yaw_fcu_frame_deg,
@@ -91,7 +78,6 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
                    const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix,
                    std::vector<uint8_t>& image_data);
->>>>>>> Allow discontinuous FOV
 
 /**
 * @brief      get the index in the data vector of a color image
@@ -132,17 +118,11 @@ void getBestCandidatesFromCostMatrix(const Eigen::MatrixXf& matrix, unsigned int
 * @param[out] distance_cost, cost component due to proximity to obstacles
 * @param[out] other_costs, cost component due to goal and smoothness
 **/
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
-                  const Eigen::Vector3f& position, const float yaw_angle_histogram_frame_deg,
-                  const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params, float& distance_cost,
-=======
 void costFunction(float e_angle, float z_angle, float obstacle_distance,
                   const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                   float yaw_fcu_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint,
                   costParameters cost_params, float& distance_cost,
->>>>>>> Allow discontinuous FOV
                   float& other_costs);
 
 /**

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -82,10 +82,10 @@ class StarPlanner {
 
   /**
   * @brief     setter method for vehicle position
-  * @param[in] pos, vehicle current position and orientation
-  * @param[in] curr_yaw, vehicle current yaw
+  * @param[in] vehicle current position
+  * @param[in] current yaw of the vehicle in FCU frame convention
   **/
-  void setPose(const Eigen::Vector3f& pos, float curr_yaw);
+  void setPose(const Eigen::Vector3f& pos, float curr_yaw_fcu_frame_deg);
 
   /**
   * @brief     setter method for current goal

--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -1,6 +1,7 @@
 #ifndef WAYPOINT_GENERATOR_H
 #define WAYPOINT_GENERATOR_H
 
+#include "avoidance/common.h"
 #include "avoidance_output.h"
 
 #include <Eigen/Dense>
@@ -38,6 +39,7 @@ class WaypointGenerator {
   Eigen::Vector2f closest_pt_ = Eigen::Vector2f(NAN, NAN);
   Eigen::Vector3f tmp_goal_ = Eigen::Vector3f(NAN, NAN, NAN);
   float curr_yaw_rad_ = NAN;
+  float curr_pitch_deg_ = NAN;
   ros::Time last_time_{99999.};
   ros::Time current_time_{99999.};
 
@@ -49,8 +51,7 @@ class WaypointGenerator {
   float setpoint_yaw_velocity_ = 0.0f;
   float heading_at_goal_rad_ = NAN;
   float speed_ = 1.0f;
-  float h_FOV_deg_ = 59.0f;
-  float v_FOV_deg_ = 46.0f;
+  std::vector<FOV> fov_fcu_frame_;
 
   Eigen::Vector3f hover_position_;
 
@@ -112,10 +113,11 @@ class WaypointGenerator {
   void setPlannerInfo(const avoidanceOutput& input);
   /**
   * @brief set horizontal and vertical Field of View based on camera matrix
-  * @param[in] h_FOV, horizontal Field of View [deg]
-  * @param[in] v_FOV, vertical Field of View [deg]
+  * @param[in] index of the camera
+  * @param[in] FOV structures defining the FOV of the specific camera
   **/
-  void setFOV(float h_FOV, float v_FOV);
+  void setFOV(int i, const FOV& fov);
+
   /**
   * @brief update with FCU vehice states
   * @param[in] act_pose, current vehicle position

--- a/local_planner/launch/local_planner_sitl_3cam.launch
+++ b/local_planner/launch/local_planner_sitl_3cam.launch
@@ -8,9 +8,9 @@
     <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
           args="0 0 0 -1.57 0 -1.57 fcu front_camera_link 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_right_camera"
-          args="0 0 0 -3.14 0 -1.57 fcu right_camera_link 10"/>
+          args="0 0 0 -2.6172 0 -1.57 fcu right_camera_link 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_left_camera"
-          args="0 0 0 0 0 -1.57 fcu left_camera_link 10"/>
+          args="0 0 0 -0.5228 0 -1.57 fcu left_camera_link 10"/>
 
     <!-- Launch PX4 and mavros -->
     <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -15,12 +15,9 @@ LocalPlanner::~LocalPlanner() {}
 // update UAV pose
 void LocalPlanner::setPose(const Eigen::Vector3f& pos, const Eigen::Quaternionf& q) {
   position_ = pos;
-
-  // Azimuth angle in histogram convention is different from FCU convention!
-  // Azimuth is flipped and rotated 90 degrees, elevation is just flipped
-  fov_.azimuth_deg = wrapAngleToPlusMinus180(-getYawFromQuaternion(q) + 90.0f);
-  fov_.elevation_deg = -getPitchFromQuaternion(q);
-  star_planner_->setPose(position_, fov_.azimuth_deg);
+  yaw_fcu_frame_deg_ = getYawFromQuaternion(q);
+  pitch_fcu_frame_deg_ = getPitchFromQuaternion(q);
+  star_planner_->setPose(position_, yaw_fcu_frame_deg_);
 
   if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
     take_off_pose_ = position_;
@@ -65,9 +62,12 @@ void LocalPlanner::setGoal(const Eigen::Vector3f& goal) {
   applyGoal();
 }
 
-void LocalPlanner::setFOV(float h_FOV_deg, float v_FOV_deg) {
-  fov_.h_fov_deg = h_FOV_deg;
-  fov_.v_fov_deg = v_FOV_deg;
+void LocalPlanner::setFOV(int i, const FOV& fov) {
+  if (i < fov_fcu_frame_.size()) {
+    fov_fcu_frame_[i] = fov;
+  } else {
+    fov_fcu_frame_.push_back(fov);
+  }
 }
 
 Eigen::Vector3f LocalPlanner::getGoal() const { return goal_; }
@@ -83,9 +83,18 @@ void LocalPlanner::runPlanner() {
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   float elapsed_since_last_processing = static_cast<float>((ros::Time::now() - last_pointcloud_process_time_).toSec());
   processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_, position_, min_realsense_dist_,
                     max_point_age_s_, elapsed_since_last_processing, min_num_points_per_cell_);
+=======
+  float elapsed_since_last_processing = static_cast<float>(
+      (ros::Time::now() - last_pointcloud_process_time_).toSec());
+  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_,
+                    fov_fcu_frame_, yaw_fcu_frame_deg_, pitch_fcu_frame_deg_,
+                    position_, min_realsense_dist_, max_point_age_s_,
+                    elapsed_since_last_processing, min_num_points_per_cell_);
+>>>>>>> Allow discontinuous FOV
   last_pointcloud_process_time_ = ros::Time::now();
 
   determineStrategy();
@@ -153,16 +162,28 @@ void LocalPlanner::determineStrategy() {
     create2DObstacleRepresentation(px4_.param_mpc_col_prev_d > 0.f);
 
     if (!polar_histogram_.isEmpty()) {
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
       getCostMatrix(polar_histogram_, goal_, position_, fov_.azimuth_deg, last_sent_waypoint_, cost_params_,
                     velocity_.norm() < 0.1f, smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
+=======
+      getCostMatrix(polar_histogram_, goal_, position_, yaw_fcu_frame_deg_,
+                    last_sent_waypoint_, cost_params_, velocity_.norm() < 0.1f,
+                    smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
+>>>>>>> Allow discontinuous FOV
 
       star_planner_->setParams(cost_params_);
       star_planner_->setPointcloud(final_cloud_);
 
       // set last chosen direction for smoothing
-      PolarPoint last_wp_pol = cartesianToPolar(last_sent_waypoint_, position_);
+      PolarPoint last_wp_pol =
+          cartesianToPolarHistogram(last_sent_waypoint_, position_);
       last_wp_pol.r = (position_ - goal_).norm();
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
       Eigen::Vector3f projected_last_wp = polarToCartesian(last_wp_pol, position_);
+=======
+      Eigen::Vector3f projected_last_wp =
+          polarHistogramToCartesian(last_wp_pol, position_);
+>>>>>>> Allow discontinuous FOV
       star_planner_->setLastDirection(projected_last_wp);
 
       // build search tree

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -83,11 +83,9 @@ void LocalPlanner::runPlanner() {
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
-  float elapsed_since_last_processing = static_cast<float>(
-      (ros::Time::now() - last_pointcloud_process_time_).toSec());
-  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_,
-                    fov_fcu_frame_, yaw_fcu_frame_deg_, pitch_fcu_frame_deg_,
-                    position_, min_realsense_dist_, max_point_age_s_,
+  float elapsed_since_last_processing = static_cast<float>((ros::Time::now() - last_pointcloud_process_time_).toSec());
+  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_fcu_frame_, yaw_fcu_frame_deg_,
+                    pitch_fcu_frame_deg_, position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
   last_pointcloud_process_time_ = ros::Time::now();
 
@@ -156,19 +154,16 @@ void LocalPlanner::determineStrategy() {
     create2DObstacleRepresentation(px4_.param_mpc_col_prev_d > 0.f);
 
     if (!polar_histogram_.isEmpty()) {
-      getCostMatrix(polar_histogram_, goal_, position_, yaw_fcu_frame_deg_,
-                    last_sent_waypoint_, cost_params_, velocity_.norm() < 0.1f,
-                    smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
+      getCostMatrix(polar_histogram_, goal_, position_, yaw_fcu_frame_deg_, last_sent_waypoint_, cost_params_,
+                    velocity_.norm() < 0.1f, smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
 
       star_planner_->setParams(cost_params_);
       star_planner_->setPointcloud(final_cloud_);
 
       // set last chosen direction for smoothing
-      PolarPoint last_wp_pol =
-          cartesianToPolarHistogram(last_sent_waypoint_, position_);
+      PolarPoint last_wp_pol = cartesianToPolarHistogram(last_sent_waypoint_, position_);
       last_wp_pol.r = (position_ - goal_).norm();
-      Eigen::Vector3f projected_last_wp =
-          polarHistogramToCartesian(last_wp_pol, position_);
+      Eigen::Vector3f projected_last_wp = polarHistogramToCartesian(last_wp_pol, position_);
       star_planner_->setLastDirection(projected_last_wp);
 
       // build search tree

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -83,18 +83,12 @@ void LocalPlanner::runPlanner() {
 
   histogram_box_.setBoxLimits(position_, ground_distance_);
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  float elapsed_since_last_processing = static_cast<float>((ros::Time::now() - last_pointcloud_process_time_).toSec());
-  processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_, fov_, position_, min_realsense_dist_,
-                    max_point_age_s_, elapsed_since_last_processing, min_num_points_per_cell_);
-=======
   float elapsed_since_last_processing = static_cast<float>(
       (ros::Time::now() - last_pointcloud_process_time_).toSec());
   processPointcloud(final_cloud_, original_cloud_vector_, histogram_box_,
                     fov_fcu_frame_, yaw_fcu_frame_deg_, pitch_fcu_frame_deg_,
                     position_, min_realsense_dist_, max_point_age_s_,
                     elapsed_since_last_processing, min_num_points_per_cell_);
->>>>>>> Allow discontinuous FOV
   last_pointcloud_process_time_ = ros::Time::now();
 
   determineStrategy();
@@ -162,14 +156,9 @@ void LocalPlanner::determineStrategy() {
     create2DObstacleRepresentation(px4_.param_mpc_col_prev_d > 0.f);
 
     if (!polar_histogram_.isEmpty()) {
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-      getCostMatrix(polar_histogram_, goal_, position_, fov_.azimuth_deg, last_sent_waypoint_, cost_params_,
-                    velocity_.norm() < 0.1f, smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
-=======
       getCostMatrix(polar_histogram_, goal_, position_, yaw_fcu_frame_deg_,
                     last_sent_waypoint_, cost_params_, velocity_.norm() < 0.1f,
                     smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
->>>>>>> Allow discontinuous FOV
 
       star_planner_->setParams(cost_params_);
       star_planner_->setPointcloud(final_cloud_);
@@ -178,12 +167,8 @@ void LocalPlanner::determineStrategy() {
       PolarPoint last_wp_pol =
           cartesianToPolarHistogram(last_sent_waypoint_, position_);
       last_wp_pol.r = (position_ - goal_).norm();
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-      Eigen::Vector3f projected_last_wp = polarToCartesian(last_wp_pol, position_);
-=======
       Eigen::Vector3f projected_last_wp =
           polarHistogramToCartesian(last_wp_pol, position_);
->>>>>>> Allow discontinuous FOV
       star_planner_->setLastDirection(projected_last_wp);
 
       // build search tree

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -116,8 +116,7 @@ void LocalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& cam
         camera_topics[i], 1, boost::bind(&LocalPlannerNode::pointCloudCallback, this, _1, i));
     cameras_[i].topic_ = camera_topics[i];
     cameras_[i].received_ = false;
-    cameras_[i].transform_thread_ =
-        std::thread(&LocalPlannerNode::pointCloudTransformThread, this, i);
+    cameras_[i].transform_thread_ = std::thread(&LocalPlannerNode::pointCloudTransformThread, this, i);
   }
 }
 
@@ -486,8 +485,7 @@ void LocalPlannerNode::pointCloudCallback(const sensor_msgs::PointCloud2::ConstP
   cameras_[index].cloud_ready_cv_->notify_one();
 }
 
-void LocalPlannerNode::dynamicReconfigureCallback(
-    avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
+void LocalPlannerNode::dynamicReconfigureCallback(avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
   std::lock_guard<std::mutex> guard(running_mutex_);
   local_planner_->dynamicReconfigureSetParams(config, level);
   wp_generator_->setSmoothingSpeed(config.smoothing_speed_xy_, config.smoothing_speed_z_);
@@ -591,8 +589,7 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
         cloud_msg_lock.reset();
 
           // remove nan padding and compute fov
-          pcl::PointCloud<pcl::PointXYZ> maxima =
-              removeNaNAndGetMaxima(pcl_cloud);
+          pcl::PointCloud<pcl::PointXYZ> maxima = removeNaNAndGetMaxima(pcl_cloud);
           pcl_ros::transformPointCloud("fcu", maxima, maxima, *tf_listener_);
           updateFOVFromMaxima(cameras_[index].fov_fcu_frame_, maxima);
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -598,22 +598,23 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
           // yaw and pitch for this field of view. Note that in the FCU frame
           // positive pitch is downward, zero-yaw is forward and positive-yaw
           // is turning CCW!
-          pcl::PointCloud<pcl::PointXYZ> fake_pc;
-          fake_pc.push_back(pcl::PointXYZ(0.f, 0.f, 1.f));
-          fake_pc.header.frame_id = pcl_cloud.header.frame_id;
-          pcl_ros::transformPointCloud("fcu", fake_pc, fake_pc, *tf_listener_);
+          geometry_msgs::PointStamped p, p_fcu;
+          p.header.frame_id = pcl_cloud.header.frame_id;
+          p.header.stamp = ros::Time(0);
+          p.point = toPoint(Eigen::Vector3f(0.0f, 0.0f, 1.0f));
+          tf_listener_->transformPoint("fcu", p, p_fcu);
 
-          if (fake_pc[0].x * fake_pc[0].x + fake_pc[0].y * fake_pc[0].y >
+          if (p_fcu.point.x * p_fcu.point.x + p_fcu.point.y * p_fcu.point.y >
               0.01f) {
             cameras_[index].fov_fcu_frame_.yaw_deg =
-                atan2(fake_pc[0].y, fake_pc[0].x) * RAD_TO_DEG;
+                atan2(p_fcu.point.y, p_fcu.point.x) * RAD_TO_DEG;
           } else {
             cameras_[index].fov_fcu_frame_.yaw_deg = 0.0f;
           }
-          if (fake_pc[0].x * fake_pc[0].x + fake_pc[0].z * fake_pc[0].z >
+          if (p_fcu.point.x * p_fcu.point.x + p_fcu.point.z * p_fcu.point.z >
               0.01f) {
             cameras_[index].fov_fcu_frame_.pitch_deg =
-                atan2(-fake_pc[0].z, fake_pc[0].x) * RAD_TO_DEG;
+                atan2(-p_fcu.point.z, p_fcu.point.x) * RAD_TO_DEG;
           } else {
             cameras_[index].fov_fcu_frame_.pitch_deg = 0.0f;
           }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -602,10 +602,21 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
           fake_pc.push_back(pcl::PointXYZ(0.f, 0.f, 1.f));
           fake_pc.header.frame_id = pcl_cloud.header.frame_id;
           pcl_ros::transformPointCloud("fcu", fake_pc, fake_pc, *tf_listener_);
-          cameras_[index].fov_fcu_frame_.yaw_deg =
-              atan2(fake_pc[0].y, fake_pc[0].x) * RAD_TO_DEG;
-          cameras_[index].fov_fcu_frame_.pitch_deg =
-              atan2(-fake_pc[0].z, fake_pc[0].x) * RAD_TO_DEG;
+
+          if (fake_pc[0].x * fake_pc[0].x + fake_pc[0].y * fake_pc[0].y >
+              0.01f) {
+            cameras_[index].fov_fcu_frame_.yaw_deg =
+                atan2(fake_pc[0].y, fake_pc[0].x) * RAD_TO_DEG;
+          } else {
+            cameras_[index].fov_fcu_frame_.yaw_deg = 0.0f;
+          }
+          if (fake_pc[0].x * fake_pc[0].x + fake_pc[0].z * fake_pc[0].z >
+              0.01f) {
+            cameras_[index].fov_fcu_frame_.pitch_deg =
+                atan2(-fake_pc[0].z, fake_pc[0].x) * RAD_TO_DEG;
+          } else {
+            cameras_[index].fov_fcu_frame_.pitch_deg = 0.0f;
+          }
 
         // transform cloud to /local_origin frame
         pcl_ros::transformPointCloud(pcl_cloud, pcl_cloud, transform);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -596,10 +596,8 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
         pcl::fromROSMsg(cameras_[index].newest_cloud_msg_, pcl_cloud);
         cloud_msg_lock.reset();
 
-        // remove nan padding
-        std::vector<int> dummy_index;
-        dummy_index.reserve(pcl_cloud.points.size());
-        pcl::removeNaNFromPointCloud(pcl_cloud, pcl_cloud, dummy_index);
+          // remove nan padding and compute fov
+          removeNaNAndGetFOV(pcl_cloud, cameras_[index].fov_camera_frame_);
 
         // transform cloud to /local_origin frame
         pcl_ros::transformPointCloud(pcl_cloud, pcl_cloud, transform);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -106,12 +106,6 @@ void LocalPlannerNode::readParams() {
 void LocalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& camera_topics) {
   cameras_.resize(camera_topics.size());
 
-  // create sting containing the topic with the camera info from
-  // the pointcloud topic
-  std::string s;
-  s.reserve(50);
-  std::vector<std::string> camera_info(camera_topics.size(), s);
-
   for (size_t i = 0; i < camera_topics.size(); i++) {
     cameras_[i].cloud_msg_mutex_.reset(new std::mutex);
     cameras_[i].transformed_cloud_mutex_.reset(new std::mutex);
@@ -122,19 +116,8 @@ void LocalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& cam
         camera_topics[i], 1, boost::bind(&LocalPlannerNode::pointCloudCallback, this, _1, i));
     cameras_[i].topic_ = camera_topics[i];
     cameras_[i].received_ = false;
-
-    // get each namespace in the pointcloud topic and construct the camera_info
-    // topic
-    std::vector<std::string> name_space;
-    boost::split(name_space, camera_topics[i], [](char c) { return c == '/'; });
-    for (int k = 0, name_spaces = name_space.size() - 1; k < name_spaces; ++k) {
-      camera_info[i].append(name_space[k]);
-      camera_info[i].append("/");
-    }
-    camera_info[i].append("camera_info");
-    cameras_[i].camera_info_sub_ = nh_.subscribe<sensor_msgs::CameraInfo>(
-        camera_info[i], 1, boost::bind(&LocalPlannerNode::cameraInfoCallback, this, _1, i));
-    cameras_[i].transform_thread_ = std::thread(&LocalPlannerNode::pointCloudTransformThread, this, i);
+    cameras_[i].transform_thread_ =
+        std::thread(&LocalPlannerNode::pointCloudTransformThread, this, i);
   }
 }
 
@@ -178,15 +161,23 @@ void LocalPlannerNode::updatePlanner() {
 void LocalPlannerNode::updatePlannerInfo() {
   // update the point cloud
   local_planner_->original_cloud_vector_.clear();
+  float h_fov = 0.f, v_fov = 0.f;
   for (size_t i = 0; i < cameras_.size(); ++i) {
     std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].transformed_cloud_mutex_));
     try {
       local_planner_->original_cloud_vector_.push_back(std::move(cameras_[i].pcl_cloud));
       cameras_[i].transformed_ = false;
+
+      // Warning: Implicit assumption that the cameras are perfectly aligned
+      // with no overlapping of FOV or blind spots!
+      h_fov += cameras_[i].fov_camera_frame_.h_fov_deg;
+      v_fov += cameras_[i].fov_camera_frame_.v_fov_deg;
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s", ex.what());
     }
   }
+  local_planner_->setFOV(h_fov, v_fov);
+  wp_generator_->setFOV(h_fov, v_fov);
 
   // update position
   local_planner_->setPose(toEigen(newest_pose_.pose.position), toEigen(newest_pose_.pose.orientation));
@@ -501,27 +492,8 @@ void LocalPlannerNode::pointCloudCallback(const sensor_msgs::PointCloud2::ConstP
   cameras_[index].cloud_ready_cv_->notify_one();
 }
 
-void LocalPlannerNode::cameraInfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg, int index) {
-  // calculate the horizontal and vertical field of view from the image size and
-  // focal length:
-  // h_fov = 2 * atan (image_width / (2 * focal_length_x))
-  // v_fov = 2 * atan (image_height / (2 * focal_length_y))
-  // Assumption: if there are n cameras the total horizonal field of view is n
-  // times the horizontal field of view of a single camera
-  float h_fov = static_cast<float>(static_cast<double>(cameras_.size()) * 2.0 *
-                                   atan(static_cast<double>(msg->width) / (2.0 * msg->K[0])) * 180.0 / M_PI);
-  float v_fov = static_cast<float>(2.0 * atan(static_cast<double>(msg->height) / (2.0 * msg->K[4])) * 180.0 / M_PI);
-
-  // once the camera info have been set once, unsubscribe from topic
-  cameras_[index].camera_info_sub_.shutdown();
-  ROS_INFO("[LocalPlannerNode] Received camera info from camera %d \n", index);
-
-  // make sure to underestimate FOV to avoid blind spots!
-  local_planner_->setFOV(h_fov - 15.0f, v_fov - 15.0f);
-  wp_generator_->setFOV(h_fov - 15.0f, v_fov - 15.0f);
-}
-
-void LocalPlannerNode::dynamicReconfigureCallback(avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
+void LocalPlannerNode::dynamicReconfigureCallback(
+    avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
   std::lock_guard<std::mutex> guard(running_mutex_);
   local_planner_->dynamicReconfigureSetParams(config, level);
   wp_generator_->setSmoothingSpeed(config.smoothing_speed_xy_, config.smoothing_speed_z_);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -161,24 +161,17 @@ void LocalPlannerNode::updatePlanner() {
 void LocalPlannerNode::updatePlannerInfo() {
   // update the point cloud
   local_planner_->original_cloud_vector_.clear();
-  float h_fov = 0.f, v_fov = 0.f;
   for (size_t i = 0; i < cameras_.size(); ++i) {
     std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].transformed_cloud_mutex_));
     try {
       local_planner_->original_cloud_vector_.push_back(std::move(cameras_[i].pcl_cloud));
       cameras_[i].transformed_ = false;
-
-      // Warning: Implicit assumption that the cameras are perfectly aligned
-      // with no overlapping of FOV or blind spots!
-      // vertically the FOV is averaged
-      h_fov += cameras_[i].fov_camera_frame_.h_fov_deg;
-      v_fov += cameras_[i].fov_camera_frame_.v_fov_deg / cameras_.size();
+      local_planner_->setFOV(i, cameras_[i].fov_fcu_frame_);
+      wp_generator_->setFOV(i, cameras_[i].fov_fcu_frame_);
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s", ex.what());
     }
   }
-  local_planner_->setFOV(h_fov, v_fov);
-  wp_generator_->setFOV(h_fov, v_fov);
 
   // update position
   local_planner_->setPose(toEigen(newest_pose_.pose.position), toEigen(newest_pose_.pose.orientation));
@@ -598,7 +591,21 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
         cloud_msg_lock.reset();
 
           // remove nan padding and compute fov
-          removeNaNAndGetFOV(pcl_cloud, cameras_[index].fov_camera_frame_);
+          removeNaNAndGetFOV(pcl_cloud, cameras_[index].fov_fcu_frame_);
+
+          // Assume camera axis is defined as +z (CV convention)!
+          // So we transform the z unit vector into FCU frame and compute
+          // yaw and pitch for this field of view. Note that in the FCU frame
+          // positive pitch is downward, zero-yaw is forward and positive-yaw
+          // is turning CCW!
+          pcl::PointCloud<pcl::PointXYZ> fake_pc;
+          fake_pc.push_back(pcl::PointXYZ(0.f, 0.f, 1.f));
+          fake_pc.header.frame_id = pcl_cloud.header.frame_id;
+          pcl_ros::transformPointCloud("fcu", fake_pc, fake_pc, *tf_listener_);
+          cameras_[index].fov_fcu_frame_.yaw_deg =
+              atan2(fake_pc[0].y, fake_pc[0].x) * RAD_TO_DEG;
+          cameras_[index].fov_fcu_frame_.pitch_deg =
+              atan2(-fake_pc[0].z, fake_pc[0].x) * RAD_TO_DEG;
 
         // transform cloud to /local_origin frame
         pcl_ros::transformPointCloud(pcl_cloud, pcl_cloud, transform);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -170,8 +170,9 @@ void LocalPlannerNode::updatePlannerInfo() {
 
       // Warning: Implicit assumption that the cameras are perfectly aligned
       // with no overlapping of FOV or blind spots!
+      // vertically the FOV is averaged
       h_fov += cameras_[i].fov_camera_frame_.h_fov_deg;
-      v_fov += cameras_[i].fov_camera_frame_.v_fov_deg;
+      v_fov += cameras_[i].fov_camera_frame_.v_fov_deg / cameras_.size();
     } catch (tf::TransformException& ex) {
       ROS_ERROR("Received an exception trying to transform a pointcloud: %s", ex.what());
     }

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -588,10 +588,10 @@ void LocalPlannerNode::pointCloudTransformThread(int index) {
         pcl::fromROSMsg(cameras_[index].newest_cloud_msg_, pcl_cloud);
         cloud_msg_lock.reset();
 
-          // remove nan padding and compute fov
-          pcl::PointCloud<pcl::PointXYZ> maxima = removeNaNAndGetMaxima(pcl_cloud);
-          pcl_ros::transformPointCloud("fcu", maxima, maxima, *tf_listener_);
-          updateFOVFromMaxima(cameras_[index].fov_fcu_frame_, maxima);
+        // remove nan padding and compute fov
+        pcl::PointCloud<pcl::PointXYZ> maxima = removeNaNAndGetMaxima(pcl_cloud);
+        pcl_ros::transformPointCloud("fcu", maxima, maxima, *tf_listener_);
+        updateFOVFromMaxima(cameras_[index].fov_fcu_frame_, maxima);
 
         // transform cloud to /local_origin frame
         pcl_ros::transformPointCloud(pcl_cloud, pcl_cloud, transform);

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -31,7 +31,7 @@ void LocalPlannerVisualization::initializePublishers(ros::NodeHandle& nh) {
   cost_image_pub_ = nh.advertise<sensor_msgs::Image>("/cost_image", 1);
   closest_point_pub_ = nh.advertise<visualization_msgs::Marker>("/closest_point", 1);
   deg60_point_pub_ = nh.advertise<visualization_msgs::Marker>("/deg60_point", 1);
-  fov_pub_ = nh.advertise<visualization_msgs::Marker>("/fov", 1);
+  fov_pub_ = nh.advertise<visualization_msgs::Marker>("/fov", 4);
 }
 
 void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner,
@@ -66,18 +66,17 @@ void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner
   publishFOV(planner.getFOV(), planner.histogram_box_.radius_);
 }
 
-void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec,
-                                           const float max_range) const {
+void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec, const float max_range) const {
   Eigen::Vector3f drone_pos = Eigen::Vector3f(0.f, 0.f, 0.f);
   for (int i = 0; i < fov_vec.size(); ++i) {
-    PolarPoint p1(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f,
-                  fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f, max_range);
-    PolarPoint p2(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f,
-                  fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f, max_range);
-    PolarPoint p3(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f,
-                  fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f, max_range);
-    PolarPoint p4(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f,
-                  fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f, max_range);
+    PolarPoint p1(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f, fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f,
+                  max_range);
+    PolarPoint p2(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f, fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f,
+                  max_range);
+    PolarPoint p3(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f, fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f,
+                  max_range);
+    PolarPoint p4(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f, fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f,
+                  max_range);
 
     visualization_msgs::Marker m;
     m.header.frame_id = "fcu";
@@ -325,15 +324,12 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 
   // current setpoint
-  PolarPoint waypoint_pol = cartesianToPolarHistogram(
-      toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
-  Eigen::Vector2i waypoint_index =
-      polarToHistogramIndex(waypoint_pol, ALPHA_RES);
+  PolarPoint waypoint_pol =
+      cartesianToPolarHistogram(toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
+  Eigen::Vector2i waypoint_index = polarToHistogramIndex(waypoint_pol, ALPHA_RES);
   PolarPoint adapted_waypoint_pol =
-      cartesianToPolarHistogram(toEigen(newest_adapted_waypoint_position),
-                                toEigen(newest_pose.pose.position));
-  Eigen::Vector2i adapted_waypoint_index =
-      polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
+      cartesianToPolarHistogram(toEigen(newest_adapted_waypoint_position), toEigen(newest_pose.pose.position));
+  Eigen::Vector2i adapted_waypoint_index = polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
 
   // color in the image
   if (cost_img.data.size() == 3 * GRID_LENGTH_E * GRID_LENGTH_Z) {

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -63,50 +63,6 @@ void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner
                     newest_adapted_waypoint_position, newest_pose);
 
   // publish the FOV
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  publishFOV(planner.getPosition(), planner.getFOV(), planner.histogram_box_.radius_);
-}
-
-void LocalPlannerVisualization::publishFOV(const Eigen::Vector3f& drone_pos, const FOV& fov,
-                                           const float max_range) const {
-  PolarPoint p1(fov.elevation_deg - fov.v_fov_deg / 2.f, fov.azimuth_deg + fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p2(fov.elevation_deg + fov.v_fov_deg / 2.f, fov.azimuth_deg + fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p3(fov.elevation_deg + fov.v_fov_deg / 2.f, fov.azimuth_deg - fov.h_fov_deg / 2.f, max_range);
-  PolarPoint p4(fov.elevation_deg - fov.v_fov_deg / 2.f, fov.azimuth_deg - fov.h_fov_deg / 2.f, max_range);
-
-  visualization_msgs::Marker m;
-  m.header.frame_id = "local_origin";
-  m.header.stamp = ros::Time::now();
-  m.id = 0;
-  m.type = visualization_msgs::Marker::TRIANGLE_LIST;
-  m.action = visualization_msgs::Marker::ADD;
-  m.scale.x = 1.0;
-  m.scale.y = 1.0;
-  m.scale.z = 1.0;
-  m.color.a = 0.4;
-  m.color.r = 0.5;
-  m.color.g = 0.5;
-  m.color.b = 1.0;
-
-  // side 1
-  m.points.push_back(toPoint(drone_pos));
-  m.points.push_back(toPoint(polarToCartesian(p1, drone_pos)));
-  m.points.push_back(toPoint(polarToCartesian(p2, drone_pos)));
-  // side 2
-  m.points.push_back(toPoint(drone_pos));
-  m.points.push_back(toPoint(polarToCartesian(p2, drone_pos)));
-  m.points.push_back(toPoint(polarToCartesian(p3, drone_pos)));
-  // side 3
-  m.points.push_back(toPoint(drone_pos));
-  m.points.push_back(toPoint(polarToCartesian(p3, drone_pos)));
-  m.points.push_back(toPoint(polarToCartesian(p4, drone_pos)));
-  // side 4
-  m.points.push_back(toPoint(drone_pos));
-  m.points.push_back(toPoint(polarToCartesian(p4, drone_pos)));
-  m.points.push_back(toPoint(polarToCartesian(p1, drone_pos)));
-
-  fov_pub_.publish(m);
-=======
   publishFOV(planner.getFOV(), planner.histogram_box_.radius_);
 }
 
@@ -156,7 +112,6 @@ void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec,
 
     fov_pub_.publish(m);
   }
->>>>>>> Allow discontinuous FOV
 }
 
 void LocalPlannerVisualization::publishOfftrackPoints(Eigen::Vector3f& closest_pt, Eigen::Vector3f& deg60_pt) {
@@ -370,13 +325,6 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 
   // current setpoint
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  PolarPoint waypoint_pol = cartesianToPolar(toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
-  Eigen::Vector2i waypoint_index = polarToHistogramIndex(waypoint_pol, ALPHA_RES);
-  PolarPoint adapted_waypoint_pol =
-      cartesianToPolar(toEigen(newest_adapted_waypoint_position), toEigen(newest_pose.pose.position));
-  Eigen::Vector2i adapted_waypoint_index = polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
-=======
   PolarPoint waypoint_pol = cartesianToPolarHistogram(
       toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
   Eigen::Vector2i waypoint_index =
@@ -386,7 +334,6 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
                                 toEigen(newest_pose.pose.position));
   Eigen::Vector2i adapted_waypoint_index =
       polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
->>>>>>> Allow discontinuous FOV
 
   // color in the image
   if (cost_img.data.size() == 3 * GRID_LENGTH_E * GRID_LENGTH_Z) {

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -66,7 +66,7 @@ void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner
   publishFOV(planner.getFOV(), planner.histogram_box_.radius_);
 }
 
-void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec, const float max_range) const {
+void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec, float max_range) const {
   Eigen::Vector3f drone_pos = Eigen::Vector3f(0.f, 0.f, 0.f);
   for (int i = 0; i < fov_vec.size(); ++i) {
     PolarPoint p1(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f, fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f,

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -63,6 +63,7 @@ void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner
                     newest_adapted_waypoint_position, newest_pose);
 
   // publish the FOV
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   publishFOV(planner.getPosition(), planner.getFOV(), planner.histogram_box_.radius_);
 }
 
@@ -105,6 +106,57 @@ void LocalPlannerVisualization::publishFOV(const Eigen::Vector3f& drone_pos, con
   m.points.push_back(toPoint(polarToCartesian(p1, drone_pos)));
 
   fov_pub_.publish(m);
+=======
+  publishFOV(planner.getFOV(), planner.histogram_box_.radius_);
+}
+
+void LocalPlannerVisualization::publishFOV(const std::vector<FOV>& fov_vec,
+                                           const float max_range) const {
+  Eigen::Vector3f drone_pos = Eigen::Vector3f(0.f, 0.f, 0.f);
+  for (int i = 0; i < fov_vec.size(); ++i) {
+    PolarPoint p1(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f,
+                  fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f, max_range);
+    PolarPoint p2(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f,
+                  fov_vec[i].yaw_deg + fov_vec[i].h_fov_deg / 2.f, max_range);
+    PolarPoint p3(fov_vec[i].pitch_deg + fov_vec[i].v_fov_deg / 2.f,
+                  fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f, max_range);
+    PolarPoint p4(fov_vec[i].pitch_deg - fov_vec[i].v_fov_deg / 2.f,
+                  fov_vec[i].yaw_deg - fov_vec[i].h_fov_deg / 2.f, max_range);
+
+    visualization_msgs::Marker m;
+    m.header.frame_id = "fcu";
+    m.header.stamp = ros::Time::now();
+    m.id = i;
+    m.type = visualization_msgs::Marker::TRIANGLE_LIST;
+    m.action = visualization_msgs::Marker::ADD;
+    m.scale.x = 1.0;
+    m.scale.y = 1.0;
+    m.scale.z = 1.0;
+    m.color.a = 0.4;
+    m.color.r = 0.5;
+    m.color.g = 0.5;
+    m.color.b = 1.0;
+
+    // side 1
+    m.points.push_back(toPoint(drone_pos));
+    m.points.push_back(toPoint(polarFCUToCartesian(p1, drone_pos)));
+    m.points.push_back(toPoint(polarFCUToCartesian(p2, drone_pos)));
+    // side 2
+    m.points.push_back(toPoint(drone_pos));
+    m.points.push_back(toPoint(polarFCUToCartesian(p2, drone_pos)));
+    m.points.push_back(toPoint(polarFCUToCartesian(p3, drone_pos)));
+    // side 3
+    m.points.push_back(toPoint(drone_pos));
+    m.points.push_back(toPoint(polarFCUToCartesian(p3, drone_pos)));
+    m.points.push_back(toPoint(polarFCUToCartesian(p4, drone_pos)));
+    // side 4
+    m.points.push_back(toPoint(drone_pos));
+    m.points.push_back(toPoint(polarFCUToCartesian(p4, drone_pos)));
+    m.points.push_back(toPoint(polarFCUToCartesian(p1, drone_pos)));
+
+    fov_pub_.publish(m);
+  }
+>>>>>>> Allow discontinuous FOV
 }
 
 void LocalPlannerVisualization::publishOfftrackPoints(Eigen::Vector3f& closest_pt, Eigen::Vector3f& deg60_pt) {
@@ -318,11 +370,23 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 
   // current setpoint
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   PolarPoint waypoint_pol = cartesianToPolar(toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
   Eigen::Vector2i waypoint_index = polarToHistogramIndex(waypoint_pol, ALPHA_RES);
   PolarPoint adapted_waypoint_pol =
       cartesianToPolar(toEigen(newest_adapted_waypoint_position), toEigen(newest_pose.pose.position));
   Eigen::Vector2i adapted_waypoint_index = polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
+=======
+  PolarPoint waypoint_pol = cartesianToPolarHistogram(
+      toEigen(newest_waypoint_position), toEigen(newest_pose.pose.position));
+  Eigen::Vector2i waypoint_index =
+      polarToHistogramIndex(waypoint_pol, ALPHA_RES);
+  PolarPoint adapted_waypoint_pol =
+      cartesianToPolarHistogram(toEigen(newest_adapted_waypoint_position),
+                                toEigen(newest_pose.pose.position));
+  Eigen::Vector2i adapted_waypoint_index =
+      polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
+>>>>>>> Allow discontinuous FOV
 
   // color in the image
   if (cost_img.data.size() == 3 * GRID_LENGTH_E * GRID_LENGTH_Z) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -10,20 +10,10 @@ namespace avoidance {
 
 // trim the point cloud so that only points inside the bounding box are
 // considered
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                        const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box, FOV& fov,
                        const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
                        int min_num_points_per_cell) {
-=======
-void processPointcloud(
-    pcl::PointCloud<pcl::PointXYZI>& final_cloud,
-    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
-    Box histogram_box, const std::vector<FOV>& fov, float yaw_fcu_frame_deg,
-    float pitch_fcu_frame_deg, const Eigen::Vector3f& position,
-    float min_realsense_dist, int max_age, float elapsed_s,
-    int min_num_points_per_cell) {
->>>>>>> Allow discontinuous FOV
   pcl::PointCloud<pcl::PointXYZI> old_cloud;
   std::swap(final_cloud, old_cloud);
   final_cloud.points.clear();
@@ -32,14 +22,6 @@ void processPointcloud(
 
   float distance;
 
-<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
-  float fov_azimuth_lower_boundary = wrapAngleToPlusMinus180(fov.azimuth_deg - fov.h_fov_deg / 2.0f);
-  float fov_azimuth_upper_boundary = wrapAngleToPlusMinus180(fov.azimuth_deg + fov.h_fov_deg / 2.0f);
-  float fov_elevation_lower_boundary = fov.elevation_deg - fov.v_fov_deg / 2.0f;
-  float fov_elevation_upper_boundary = fov.elevation_deg + fov.v_fov_deg / 2.0f;
-
-=======
->>>>>>> Compute FOV in camera frame
   // counter to keep track of how many points lie in a given cell
   Eigen::MatrixXi histogram_points_counter(180 / (ALPHA_RES / 2), 360 / (ALPHA_RES / 2));
   histogram_points_counter.fill(0);
@@ -50,22 +32,10 @@ void processPointcloud(
       if (!std::isnan(xyz.x) && !std::isnan(xyz.y) && !std::isnan(xyz.z)) {
         if (histogram_box.isPointWithinBox(xyz.x, xyz.y, xyz.z)) {
           distance = (position - toEigen(xyz)).norm();
-<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
-          if (distance > min_realsense_dist && distance < histogram_box.radius_) {
-            // Keep track of the FOV
-            PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
-            fov_azimuth_lower_boundary = std::min(fov_azimuth_lower_boundary, p_pol.z);
-            fov_azimuth_upper_boundary = std::max(fov_azimuth_upper_boundary, p_pol.z);
-            fov_elevation_lower_boundary = std::min(fov_elevation_lower_boundary, p_pol.e);
-            fov_elevation_upper_boundary = std::max(fov_elevation_upper_boundary, p_pol.e);
-
-=======
           if (distance > min_realsense_dist &&
               distance < histogram_box.radius_) {
->>>>>>> Compute FOV in camera frame
             // subsampling the cloud
-            PolarPoint p_pol =
-                cartesianToPolarHistogram(toEigen(xyz), position);
+            PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
             histogram_points_counter(p_ind.y(), p_ind.x())++;
             if (histogram_points_counter(p_ind.y(), p_ind.x()) == min_num_points_per_cell) {
@@ -77,16 +47,6 @@ void processPointcloud(
     }
   }
 
-<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
-  // Update the FOV, accounting for discontinuity. Also subtract a tolerance
-  // margin to avoid creating a blind spot due to latency and fast yaw movements
-  fov.h_fov_deg = std::max(fov.h_fov_deg, std::min(360.0f - (fov_azimuth_upper_boundary - fov_azimuth_lower_boundary),
-                                                   fov_azimuth_upper_boundary - fov_azimuth_lower_boundary) -
-                                              15.0f);
-  fov.v_fov_deg = std::max(fov.v_fov_deg, fov_elevation_upper_boundary - fov_elevation_lower_boundary - 15.0f);
-
-=======
->>>>>>> Compute FOV in camera frame
   // combine with old cloud
   for (const pcl::PointXYZI& xyzi : old_cloud) {
     // adding older points if not expired and space is free according to new
@@ -94,27 +54,15 @@ void processPointcloud(
     if (histogram_box.isPointWithinBox(xyzi.x, xyzi.y, xyzi.z)) {
       distance = (position - toEigen(xyzi)).norm();
       if (distance < histogram_box.radius_) {
-        PolarPoint p_pol = cartesianToPolarHistogram(toEigen(xyzi), position);
-        PolarPoint p_pol_fcu = cartesianToPolarFCU(toEigen(xyzi), position);
-        p_pol_fcu.e -= pitch_fcu_frame_deg;
-        p_pol_fcu.z -= yaw_fcu_frame_deg;
-        wrapPolar(p_pol_fcu);
+        PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
 
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
 
         // only remember point if it's in a cell not previously populated by
         // complete_cloud, as well as outside FOV and 'young' enough
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
         if (histogram_points_counter(p_ind.y(), p_ind.x()) < min_num_points_per_cell && xyzi.intensity < max_age &&
             !pointInsideFOV(fov, p_pol)) {
           final_cloud.points.push_back(toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
-=======
-        if (histogram_points_counter(p_ind.y(), p_ind.x()) <
-                min_num_points_per_cell &&
-            xyzi.intensity < max_age && !pointInsideFOV(fov, p_pol_fcu)) {
-          final_cloud.points.push_back(
-              toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
->>>>>>> Allow discontinuous FOV
 
           // to indicate that this cell now has a point
           histogram_points_counter(p_ind.y(), p_ind.x()) = min_num_points_per_cell;
@@ -136,7 +84,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
   counter.fill(0);
   for (auto xyz : cropped_cloud) {
     Eigen::Vector3f p = toEigen(xyz);
-    PolarPoint p_pol = cartesianToPolarHistogram(p, position);
+    PolarPoint p_pol = cartesianToPolar(p, position);
     float dist = p_pol.r;
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES);
 
@@ -173,21 +121,10 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
   }
 }
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                    const float yaw_angle_histogram_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed, const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data) {
-=======
-void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
-                   const Eigen::Vector3f& position,
-                   const float yaw_fcu_frame_deg,
-                   const Eigen::Vector3f& last_sent_waypoint,
-                   costParameters cost_params, bool only_yawed,
-                   const float smoothing_margin_degrees,
-                   Eigen::MatrixXf& cost_matrix,
-                   std::vector<uint8_t>& image_data) {
->>>>>>> Allow discontinuous FOV
   Eigen::MatrixXf distance_matrix(GRID_LENGTH_E, GRID_LENGTH_Z);
   distance_matrix.fill(NAN);
   float distance_cost = 0.f;
@@ -207,14 +144,8 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
       float obstacle_distance = histogram.get_dist(e_index, z_index);
       PolarPoint p_pol = histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
 
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
       costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position, yaw_angle_histogram_frame_deg,
                    last_sent_waypoint, cost_params, distance_cost, other_costs);
-=======
-      costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position,
-                   yaw_fcu_frame_deg, last_sent_waypoint, cost_params,
-                   distance_cost, other_costs);
->>>>>>> Allow discontinuous FOV
       cost_matrix(e_index, z_index) = other_costs;
       distance_matrix(e_index, z_index) = distance_cost;
     }
@@ -371,35 +302,19 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 }
 
 // costfunction for every free histogram cell
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params, float& distance_cost,
-=======
-void costFunction(float e_angle, float z_angle, float obstacle_distance,
-                  const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                  const float yaw_fcu_frame_deg,
-                  const Eigen::Vector3f& last_sent_waypoint,
-                  costParameters cost_params, float& distance_cost,
->>>>>>> Allow discontinuous FOV
                   float& other_costs) {
-  // Azimuth angle in histogram convention is different from FCU convention!
-  // Azimuth is flipped and rotated 90 degrees, elevation is just flipped
-  float azimuth_hist_frame_deg =
-      wrapAngleToPlusMinus180(-yaw_fcu_frame_deg + 90.0f);
   float goal_dist = (position - goal).norm();
   PolarPoint p_pol(e_angle, z_angle, goal_dist);
-  Eigen::Vector3f projected_candidate =
-      polarHistogramToCartesian(p_pol, position);
-  PolarPoint heading_pol(e_angle, azimuth_hist_frame_deg, goal_dist);
-  Eigen::Vector3f projected_heading =
-      polarHistogramToCartesian(heading_pol, position);
+  Eigen::Vector3f projected_candidate = polarToCartesian(p_pol, position);
+  PolarPoint heading_pol(e_angle, yaw_angle_histogram_frame_deg, goal_dist);
+  Eigen::Vector3f projected_heading = polarToCartesian(heading_pol, position);
   Eigen::Vector3f projected_goal = goal;
-  PolarPoint last_wp_pol =
-      cartesianToPolarHistogram(last_sent_waypoint, position);
+  PolarPoint last_wp_pol = cartesianToPolar(last_sent_waypoint, position);
   last_wp_pol.r = goal_dist;
-  Eigen::Vector3f projected_last_wp =
-      polarHistogramToCartesian(last_wp_pol, position);
+  Eigen::Vector3f projected_last_wp = polarToCartesian(last_wp_pol, position);
 
   // goal costs
   float yaw_cost =
@@ -495,7 +410,7 @@ bool getDirectionFromTree(PolarPoint& p_pol, const std::vector<Eigen::Vector3f>&
       Eigen::Vector3f mean_point =
           (1.f - l_frac) * path_node_positions_extended[wp_idx - 1] + l_frac * path_node_positions_extended[wp_idx];
 
-      p_pol = cartesianToPolarHistogram(mean_point, position);
+      p_pol = cartesianToPolar(mean_point, position);
       p_pol.r = 0.0f;
     }
   } else {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -121,10 +121,12 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
   }
 }
 
-void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                   const float yaw_angle_histogram_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                   costParameters cost_params, bool only_yawed, const float smoothing_margin_degrees,
-                   Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data) {
+void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
+                   const Eigen::Vector3f& position, float yaw_fcu_frame_deg,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed,
+                   float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
+                   std::vector<uint8_t>& image_data) {
   Eigen::MatrixXf distance_matrix(GRID_LENGTH_E, GRID_LENGTH_Z);
   distance_matrix.fill(NAN);
   float distance_cost = 0.f;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -22,11 +22,14 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
 
   float distance;
 
+<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
   float fov_azimuth_lower_boundary = wrapAngleToPlusMinus180(fov.azimuth_deg - fov.h_fov_deg / 2.0f);
   float fov_azimuth_upper_boundary = wrapAngleToPlusMinus180(fov.azimuth_deg + fov.h_fov_deg / 2.0f);
   float fov_elevation_lower_boundary = fov.elevation_deg - fov.v_fov_deg / 2.0f;
   float fov_elevation_upper_boundary = fov.elevation_deg + fov.v_fov_deg / 2.0f;
 
+=======
+>>>>>>> Compute FOV in camera frame
   // counter to keep track of how many points lie in a given cell
   Eigen::MatrixXi histogram_points_counter(180 / (ALPHA_RES / 2), 360 / (ALPHA_RES / 2));
   histogram_points_counter.fill(0);
@@ -37,6 +40,7 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
       if (!std::isnan(xyz.x) && !std::isnan(xyz.y) && !std::isnan(xyz.z)) {
         if (histogram_box.isPointWithinBox(xyz.x, xyz.y, xyz.z)) {
           distance = (position - toEigen(xyz)).norm();
+<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
           if (distance > min_realsense_dist && distance < histogram_box.radius_) {
             // Keep track of the FOV
             PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
@@ -45,7 +49,12 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
             fov_elevation_lower_boundary = std::min(fov_elevation_lower_boundary, p_pol.e);
             fov_elevation_upper_boundary = std::max(fov_elevation_upper_boundary, p_pol.e);
 
+=======
+          if (distance > min_realsense_dist &&
+              distance < histogram_box.radius_) {
+>>>>>>> Compute FOV in camera frame
             // subsampling the cloud
+            PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
             histogram_points_counter(p_ind.y(), p_ind.x())++;
             if (histogram_points_counter(p_ind.y(), p_ind.x()) == min_num_points_per_cell) {
@@ -57,6 +66,7 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     }
   }
 
+<<<<<<< b31d149a7433a261f6365c32bb02f12fd1727330
   // Update the FOV, accounting for discontinuity. Also subtract a tolerance
   // margin to avoid creating a blind spot due to latency and fast yaw movements
   fov.h_fov_deg = std::max(fov.h_fov_deg, std::min(360.0f - (fov_azimuth_upper_boundary - fov_azimuth_lower_boundary),
@@ -64,6 +74,8 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                                               15.0f);
   fov.v_fov_deg = std::max(fov.v_fov_deg, fov_elevation_upper_boundary - fov_elevation_lower_boundary - 15.0f);
 
+=======
+>>>>>>> Compute FOV in camera frame
   // combine with old cloud
   for (const pcl::PointXYZI& xyzi : old_cloud) {
     // adding older points if not expired and space is free according to new

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -54,8 +54,10 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     if (histogram_box.isPointWithinBox(xyzi.x, xyzi.y, xyzi.z)) {
       distance = (position - toEigen(xyzi)).norm();
       if (distance < histogram_box.radius_) {
-        PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
-
+        PolarPoint p_pol = cartesianToPolarHistogram(toEigen(xyzi), position);
+        PolarPoint p_pol_fcu = cartesianToPolarFCU(toEigen(xyzi), position);
+        p_pol_fcu.e -= pitch_fcu_frame_deg;
+        p_pol_fcu.z -= yaw_fcu_frame_deg;
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
 
         // only remember point if it's in a cell not previously populated by
@@ -84,7 +86,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
   counter.fill(0);
   for (auto xyz : cropped_cloud) {
     Eigen::Vector3f p = toEigen(xyz);
-    PolarPoint p_pol = cartesianToPolar(p, position);
+    PolarPoint p_pol = cartesianToPolarHistogram(p, position);
     float dist = p_pol.r;
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES);
 
@@ -413,7 +415,7 @@ bool getDirectionFromTree(PolarPoint& p_pol, const std::vector<Eigen::Vector3f>&
       Eigen::Vector3f mean_point =
           (1.f - l_frac) * path_node_positions_extended[wp_idx - 1] + l_frac * path_node_positions_extended[wp_idx];
 
-      p_pol = cartesianToPolar(mean_point, position);
+      p_pol = cartesianToPolarHistogram(mean_point, position);
       p_pol.r = 0.0f;
     }
   } else {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -10,10 +10,20 @@ namespace avoidance {
 
 // trim the point cloud so that only points inside the bounding box are
 // considered
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                        const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, Box histogram_box, FOV& fov,
                        const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
                        int min_num_points_per_cell) {
+=======
+void processPointcloud(
+    pcl::PointCloud<pcl::PointXYZI>& final_cloud,
+    const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud,
+    Box histogram_box, const std::vector<FOV>& fov, float yaw_fcu_frame_deg,
+    float pitch_fcu_frame_deg, const Eigen::Vector3f& position,
+    float min_realsense_dist, int max_age, float elapsed_s,
+    int min_num_points_per_cell) {
+>>>>>>> Allow discontinuous FOV
   pcl::PointCloud<pcl::PointXYZI> old_cloud;
   std::swap(final_cloud, old_cloud);
   final_cloud.points.clear();
@@ -54,7 +64,8 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
               distance < histogram_box.radius_) {
 >>>>>>> Compute FOV in camera frame
             // subsampling the cloud
-            PolarPoint p_pol = cartesianToPolar(toEigen(xyz), position);
+            PolarPoint p_pol =
+                cartesianToPolarHistogram(toEigen(xyz), position);
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
             histogram_points_counter(p_ind.y(), p_ind.x())++;
             if (histogram_points_counter(p_ind.y(), p_ind.x()) == min_num_points_per_cell) {
@@ -83,15 +94,27 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
     if (histogram_box.isPointWithinBox(xyzi.x, xyzi.y, xyzi.z)) {
       distance = (position - toEigen(xyzi)).norm();
       if (distance < histogram_box.radius_) {
-        PolarPoint p_pol = cartesianToPolar(toEigen(xyzi), position);
+        PolarPoint p_pol = cartesianToPolarHistogram(toEigen(xyzi), position);
+        PolarPoint p_pol_fcu = cartesianToPolarFCU(toEigen(xyzi), position);
+        p_pol_fcu.e -= pitch_fcu_frame_deg;
+        p_pol_fcu.z -= yaw_fcu_frame_deg;
+        wrapPolar(p_pol_fcu);
 
         Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
 
         // only remember point if it's in a cell not previously populated by
         // complete_cloud, as well as outside FOV and 'young' enough
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
         if (histogram_points_counter(p_ind.y(), p_ind.x()) < min_num_points_per_cell && xyzi.intensity < max_age &&
             !pointInsideFOV(fov, p_pol)) {
           final_cloud.points.push_back(toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
+=======
+        if (histogram_points_counter(p_ind.y(), p_ind.x()) <
+                min_num_points_per_cell &&
+            xyzi.intensity < max_age && !pointInsideFOV(fov, p_pol_fcu)) {
+          final_cloud.points.push_back(
+              toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
+>>>>>>> Allow discontinuous FOV
 
           // to indicate that this cell now has a point
           histogram_points_counter(p_ind.y(), p_ind.x()) = min_num_points_per_cell;
@@ -113,7 +136,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
   counter.fill(0);
   for (auto xyz : cropped_cloud) {
     Eigen::Vector3f p = toEigen(xyz);
-    PolarPoint p_pol = cartesianToPolar(p, position);
+    PolarPoint p_pol = cartesianToPolarHistogram(p, position);
     float dist = p_pol.r;
     Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES);
 
@@ -150,10 +173,21 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
   }
 }
 
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                    const float yaw_angle_histogram_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
                    costParameters cost_params, bool only_yawed, const float smoothing_margin_degrees,
                    Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data) {
+=======
+void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal,
+                   const Eigen::Vector3f& position,
+                   const float yaw_fcu_frame_deg,
+                   const Eigen::Vector3f& last_sent_waypoint,
+                   costParameters cost_params, bool only_yawed,
+                   const float smoothing_margin_degrees,
+                   Eigen::MatrixXf& cost_matrix,
+                   std::vector<uint8_t>& image_data) {
+>>>>>>> Allow discontinuous FOV
   Eigen::MatrixXf distance_matrix(GRID_LENGTH_E, GRID_LENGTH_Z);
   distance_matrix.fill(NAN);
   float distance_cost = 0.f;
@@ -173,8 +207,14 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, cons
       float obstacle_distance = histogram.get_dist(e_index, z_index);
       PolarPoint p_pol = histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
 
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
       costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position, yaw_angle_histogram_frame_deg,
                    last_sent_waypoint, cost_params, distance_cost, other_costs);
+=======
+      costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position,
+                   yaw_fcu_frame_deg, last_sent_waypoint, cost_params,
+                   distance_cost, other_costs);
+>>>>>>> Allow discontinuous FOV
       cost_matrix(e_index, z_index) = other_costs;
       distance_matrix(e_index, z_index) = distance_cost;
     }
@@ -331,19 +371,35 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 }
 
 // costfunction for every free histogram cell
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
                   const Eigen::Vector3f& position, const float yaw_angle_histogram_frame_deg,
                   const Eigen::Vector3f& last_sent_waypoint, costParameters cost_params, float& distance_cost,
+=======
+void costFunction(float e_angle, float z_angle, float obstacle_distance,
+                  const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                  const float yaw_fcu_frame_deg,
+                  const Eigen::Vector3f& last_sent_waypoint,
+                  costParameters cost_params, float& distance_cost,
+>>>>>>> Allow discontinuous FOV
                   float& other_costs) {
+  // Azimuth angle in histogram convention is different from FCU convention!
+  // Azimuth is flipped and rotated 90 degrees, elevation is just flipped
+  float azimuth_hist_frame_deg =
+      wrapAngleToPlusMinus180(-yaw_fcu_frame_deg + 90.0f);
   float goal_dist = (position - goal).norm();
   PolarPoint p_pol(e_angle, z_angle, goal_dist);
-  Eigen::Vector3f projected_candidate = polarToCartesian(p_pol, position);
-  PolarPoint heading_pol(e_angle, yaw_angle_histogram_frame_deg, goal_dist);
-  Eigen::Vector3f projected_heading = polarToCartesian(heading_pol, position);
+  Eigen::Vector3f projected_candidate =
+      polarHistogramToCartesian(p_pol, position);
+  PolarPoint heading_pol(e_angle, azimuth_hist_frame_deg, goal_dist);
+  Eigen::Vector3f projected_heading =
+      polarHistogramToCartesian(heading_pol, position);
   Eigen::Vector3f projected_goal = goal;
-  PolarPoint last_wp_pol = cartesianToPolar(last_sent_waypoint, position);
+  PolarPoint last_wp_pol =
+      cartesianToPolarHistogram(last_sent_waypoint, position);
   last_wp_pol.r = goal_dist;
-  Eigen::Vector3f projected_last_wp = polarToCartesian(last_wp_pol, position);
+  Eigen::Vector3f projected_last_wp =
+      polarHistogramToCartesian(last_wp_pol, position);
 
   // goal costs
   float yaw_cost =
@@ -439,7 +495,7 @@ bool getDirectionFromTree(PolarPoint& p_pol, const std::vector<Eigen::Vector3f>&
       Eigen::Vector3f mean_point =
           (1.f - l_frac) * path_node_positions_extended[wp_idx - 1] + l_frac * path_node_positions_extended[wp_idx];
 
-      p_pol = cartesianToPolar(mean_point, position);
+      p_pol = cartesianToPolarHistogram(mean_point, position);
       p_pol.r = 0.0f;
     }
   } else {

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -115,14 +115,9 @@ void StarPlanner::buildLookAheadTree() {
     cost_matrix.fill(0.f);
     cost_image_data.clear();
     candidate_vector.clear();
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-
-    getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_, projected_last_wp_, cost_params_, false,
-=======
     float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90);
     getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg,
                   projected_last_wp_, cost_params_, false,
->>>>>>> Allow discontinuous FOV
                   smoothing_margin_degrees_, cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_, candidate_vector);
 
@@ -137,12 +132,8 @@ void StarPlanner::buildLookAheadTree() {
         PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle, tree_node_distance_);
 
         // check if another close node has been added
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-        Eigen::Vector3f node_location = polarToCartesian(p_pol, origin_position);
-=======
         Eigen::Vector3f node_location =
             polarHistogramToCartesian(p_pol, origin_position);
->>>>>>> Allow discontinuous FOV
         int close_nodes = 0;
         for (size_t i = 0; i < tree_.size(); i++) {
           float dist = (tree_[i].getPosition() - node_location).norm();

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -24,9 +24,11 @@ void StarPlanner::setParams(costParameters cost_params) { cost_params_ = cost_pa
 
 void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) { projected_last_wp_ = projected_last_wp; }
 
-void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw) {
+void StarPlanner::setPose(const Eigen::Vector3f& pos,
+                          float curr_yaw_fcu_frame_deg) {
   position_ = pos;
-  curr_yaw_histogram_frame_deg_ = curr_yaw;
+  curr_yaw_histogram_frame_deg_ =
+      wrapAngleToPlusMinus180(-curr_yaw_fcu_frame_deg + 90.0f);
 }
 
 void StarPlanner::setGoal(const Eigen::Vector3f& goal) {
@@ -41,7 +43,7 @@ float StarPlanner::treeCostFunction(int node_number) const {
   float e = tree_[node_number].last_e_;
   float z = tree_[node_number].last_z_;
   Eigen::Vector3f origin_position = tree_[origin].getPosition();
-  PolarPoint goal_pol = cartesianToPolar(goal_, origin_position);
+  PolarPoint goal_pol = cartesianToPolarHistogram(goal_, origin_position);
 
   float target_cost = indexAngleDifference(z, goal_pol.z) +
                       10.0f * indexAngleDifference(e, goal_pol.e);     // include effective direction?
@@ -69,7 +71,7 @@ float StarPlanner::treeCostFunction(int node_number) const {
 
 float StarPlanner::treeHeuristicFunction(int node_number) const {
   Eigen::Vector3f node_position = tree_[node_number].getPosition();
-  PolarPoint goal_pol = cartesianToPolar(goal_, node_position);
+  PolarPoint goal_pol = cartesianToPolarHistogram(goal_, node_position);
 
   int origin = tree_[node_number].origin_;
   Eigen::Vector3f origin_position = tree_[origin].getPosition();
@@ -113,8 +115,14 @@ void StarPlanner::buildLookAheadTree() {
     cost_matrix.fill(0.f);
     cost_image_data.clear();
     candidate_vector.clear();
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
 
     getCostMatrix(histogram, goal_, origin_position, tree_[origin].yaw_, projected_last_wp_, cost_params_, false,
+=======
+    float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90);
+    getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg,
+                  projected_last_wp_, cost_params_, false,
+>>>>>>> Allow discontinuous FOV
                   smoothing_margin_degrees_, cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_, candidate_vector);
 
@@ -129,7 +137,12 @@ void StarPlanner::buildLookAheadTree() {
         PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle, tree_node_distance_);
 
         // check if another close node has been added
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
         Eigen::Vector3f node_location = polarToCartesian(p_pol, origin_position);
+=======
+        Eigen::Vector3f node_location =
+            polarHistogramToCartesian(p_pol, origin_position);
+>>>>>>> Allow discontinuous FOV
         int close_nodes = 0;
         for (size_t i = 0; i < tree_.size(); i++) {
           float dist = (tree_[i].getPosition() - node_location).norm();

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -113,7 +113,7 @@ void StarPlanner::buildLookAheadTree() {
     cost_matrix.fill(0.f);
     cost_image_data.clear();
     candidate_vector.clear();
-    float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90);
+    float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90.0f);
     getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg, projected_last_wp_, cost_params_, false,
                   smoothing_margin_degrees_, cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_, candidate_vector);

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -24,11 +24,9 @@ void StarPlanner::setParams(costParameters cost_params) { cost_params_ = cost_pa
 
 void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) { projected_last_wp_ = projected_last_wp; }
 
-void StarPlanner::setPose(const Eigen::Vector3f& pos,
-                          float curr_yaw_fcu_frame_deg) {
+void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw_fcu_frame_deg) {
   position_ = pos;
-  curr_yaw_histogram_frame_deg_ =
-      wrapAngleToPlusMinus180(-curr_yaw_fcu_frame_deg + 90.0f);
+  curr_yaw_histogram_frame_deg_ = wrapAngleToPlusMinus180(-curr_yaw_fcu_frame_deg + 90.0f);
 }
 
 void StarPlanner::setGoal(const Eigen::Vector3f& goal) {
@@ -116,8 +114,7 @@ void StarPlanner::buildLookAheadTree() {
     cost_image_data.clear();
     candidate_vector.clear();
     float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90);
-    getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg,
-                  projected_last_wp_, cost_params_, false,
+    getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg, projected_last_wp_, cost_params_, false,
                   smoothing_margin_degrees_, cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_, candidate_vector);
 
@@ -132,8 +129,7 @@ void StarPlanner::buildLookAheadTree() {
         PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle, tree_node_distance_);
 
         // check if another close node has been added
-        Eigen::Vector3f node_location =
-            polarHistogramToCartesian(p_pol, origin_position);
+        Eigen::Vector3f node_location = polarHistogramToCartesian(p_pol, origin_position);
         int close_nodes = 0;
         for (size_t i = 0; i < tree_.size(); i++) {
           float dist = (tree_[i].getPosition() - node_location).norm();

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -241,19 +241,12 @@ void WaypointGenerator::adaptSpeed() {
   } else {
     // Scale the speed by a factor that is 0 if the waypoint is outside the FOV
     if (output_.waypoint_type != reachHeight) {
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-      float angle_diff_deg = std::abs(nextYaw(position_, output_.goto_position) - curr_yaw_rad_) * 180.f / M_PI_F;
-      angle_diff_deg = std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
-      angle_diff_deg = std::min(h_FOV_deg_ / 2, angle_diff_deg);  // Clamp at h_FOV/2
-      speed_ *= (1.0f - 2 * angle_diff_deg / h_FOV_deg_);
-=======
       PolarPoint p_pol_fcu =
           cartesianToPolarFCU(output_.goto_position, position_);
       p_pol_fcu.e -= curr_pitch_deg_;
       p_pol_fcu.z -= RAD_TO_DEG * curr_yaw_rad_;
       wrapPolar(p_pol_fcu);
       speed_ *= scaleToFOV(fov_fcu_frame_, p_pol_fcu);
->>>>>>> Allow discontinuous FOV
     }
 
     // Scale the pose_to_wp by the speed

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -241,8 +241,7 @@ void WaypointGenerator::adaptSpeed() {
   } else {
     // Scale the speed by a factor that is 0 if the waypoint is outside the FOV
     if (output_.waypoint_type != reachHeight) {
-      PolarPoint p_pol_fcu =
-          cartesianToPolarFCU(output_.goto_position, position_);
+      PolarPoint p_pol_fcu = cartesianToPolarFCU(output_.goto_position, position_);
       p_pol_fcu.e -= curr_pitch_deg_;
       p_pol_fcu.z -= RAD_TO_DEG * curr_yaw_rad_;
       wrapPolar(p_pol_fcu);

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -43,7 +43,7 @@ void WaypointGenerator::calculateWaypoint() {
       if (tree_available && (planner_info_.obstacle_ahead || dist_goal > 4.0f) && since_last_path < ros::Duration(5)) {
         ROS_DEBUG("[WG] Use calculated tree\n");
         p_pol.r = 1.0;
-        output_.goto_position = polarToCartesian(p_pol, position_);
+        output_.goto_position = polarHistogramToCartesian(p_pol, position_);
       } else {
         ROS_DEBUG("[WG] No valid tree, going straight");
         output_.waypoint_type = direct;
@@ -91,9 +91,12 @@ void WaypointGenerator::calculateWaypoint() {
   last_wp_type_ = planner_info_.waypoint_type;
 }
 
-void WaypointGenerator::setFOV(float h_FOV, float v_FOV) {
-  h_FOV_deg_ = h_FOV;
-  v_FOV_deg_ = v_FOV;
+void WaypointGenerator::setFOV(int i, const FOV& fov) {
+  if (i < fov_fcu_frame_.size()) {
+    fov_fcu_frame_[i] = fov;
+  } else {
+    fov_fcu_frame_.push_back(fov);
+  }
 }
 
 void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose, const Eigen::Quaternionf& q,
@@ -104,6 +107,7 @@ void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose, const Eigen
   goal_ = goal;
   prev_goal_ = prev_goal;
   curr_yaw_rad_ = getYawFromQuaternion(q) * DEG_TO_RAD;
+  curr_pitch_deg_ = getPitchFromQuaternion(q);
 
   if (stay) {
     planner_info_.waypoint_type = hover;
@@ -237,10 +241,19 @@ void WaypointGenerator::adaptSpeed() {
   } else {
     // Scale the speed by a factor that is 0 if the waypoint is outside the FOV
     if (output_.waypoint_type != reachHeight) {
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
       float angle_diff_deg = std::abs(nextYaw(position_, output_.goto_position) - curr_yaw_rad_) * 180.f / M_PI_F;
       angle_diff_deg = std::min(angle_diff_deg, std::abs(360.f - angle_diff_deg));
       angle_diff_deg = std::min(h_FOV_deg_ / 2, angle_diff_deg);  // Clamp at h_FOV/2
       speed_ *= (1.0f - 2 * angle_diff_deg / h_FOV_deg_);
+=======
+      PolarPoint p_pol_fcu =
+          cartesianToPolarFCU(output_.goto_position, position_);
+      p_pol_fcu.e -= curr_pitch_deg_;
+      p_pol_fcu.z -= RAD_TO_DEG * curr_yaw_rad_;
+      wrapPolar(p_pol_fcu);
+      speed_ *= scaleToFOV(fov_fcu_frame_, p_pol_fcu);
+>>>>>>> Allow discontinuous FOV
     }
 
     // Scale the pose_to_wp by the speed

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -23,7 +23,7 @@ class LocalPlannerTests : public ::testing::Test {
     planner.setDefaultPx4Parameters();
     avoidance::LocalPlannerNodeConfig config = avoidance::LocalPlannerNodeConfig::__getDefault__();
     planner.dynamicReconfigureSetParams(config, 1);
-    planner.setFOV(59.0f, 46.0f);
+    planner.setFOV(0, FOV(0.0f, 0.0f, 59.0f, 46.0f));
 
     // start with basic pose
     Eigen::Vector3f pos(0.f, 0.f, 0.f);
@@ -70,7 +70,7 @@ TEST_F(LocalPlannerTests, all_obstacles) {
   // GIVEN: a local planner, a scan with obstacles everywhere, pose and goal
   float shift = 0.f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV(0) * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -124,7 +124,7 @@ TEST_F(LocalPlannerTests, obstacles_right) {
   // GIVEN: a local planner, a scan with obstacles on the right, pose and goal
   float shift = -0.5f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV(0) * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;
@@ -174,7 +174,7 @@ TEST_F(LocalPlannerTests, obstacles_left) {
   // GIVEN: a local planner, a scan with obstacles on the left, pose and goal
   float shift = 0.5f;
   float distance = 2.f;
-  float fov_half_y = distance * std::tan(planner.getHFOV() * TO_RAD / 2.f);
+  float fov_half_y = distance * std::tan(planner.getHFOV(0) * TO_RAD / 2.f);
   float max_y = shift + fov_half_y, min_y = shift - fov_half_y;
 
   pcl::PointCloud<pcl::PointXYZ> cloud;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -41,7 +41,7 @@ TEST(PlannerFunctions, generateNewHistogramSpecificCells) {
   for (auto i : e_angle_filled) {
     for (auto j : z_angle_filled) {
       PolarPoint p_pol(i, j, distance);
-      middle_of_cell.push_back(polarToCartesian(p_pol, location));
+      middle_of_cell.push_back(polarHistogramToCartesian(p_pol, location));
       e_index.push_back(polarToHistogramIndex(p_pol, ALPHA_RES).y());
       z_index.push_back(polarToHistogramIndex(p_pol, ALPHA_RES).x());
     }
@@ -99,24 +99,25 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   pcl::PointCloud<pcl::PointXYZI> processed_cloud1, processed_cloud2, processed_cloud3;
   Eigen::Vector3f memory_point(1.4f, 0.0f, 0.0f);
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   PolarPoint memory_point_polar = cartesianToPolar(position + memory_point, position);
+=======
+  PolarPoint memory_point_polar =
+      cartesianToPolarFCU(position + memory_point, position);
+>>>>>>> Allow discontinuous FOV
   processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
 
-  FOV FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
-  FOV_zero.h_fov_deg = 0.0f;
-  FOV_zero.v_fov_deg = 0.0f;
-  FOV_zero.azimuth_deg = 1.0f;
-  FOV_zero.elevation_deg = 1.0f;
+  std::vector<FOV>
+      FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
+  FOV_zero.push_back(FOV(1.0f, 1.0f, 0.0f, 0.0f));
 
-  FOV FOV_regular;
-  FOV_regular.h_fov_deg = 85.0f;
-  FOV_regular.v_fov_deg = 65.0f;
-  FOV_regular.azimuth_deg = 90.0f;  // in histogram frame!
-  FOV_regular.elevation_deg = 1.0f;
+  std::vector<FOV> FOV_regular;
+  FOV_regular.push_back(FOV(0.0f, 1.0f, 85.0f, 65.0f));
 
   // WHEN: we filter the PointCloud with different values max_age
+<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
   processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero, position, min_realsense_dist, 0.0f, 0.5f,
                     1);
 
@@ -125,6 +126,18 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   processPointcloud(processed_cloud3, complete_cloud, histogram_box, FOV_regular, position, min_realsense_dist, 10.0f,
                     0.5f, 1);
+=======
+  processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,
+                    0.0f, 0.0f, position, min_realsense_dist, 0.0f, 0.5f, 1);
+
+  processPointcloud(processed_cloud2, complete_cloud, histogram_box, FOV_zero,
+                    0.0f, 0.0f,  // todo: test different yaw and pitch
+                    position, min_realsense_dist, 10.0f, .5f, 1);
+
+  processPointcloud(processed_cloud3, complete_cloud, histogram_box,
+                    FOV_regular, 0.0f, 0.0f, position, min_realsense_dist,
+                    10.0f, 0.5f, 1);
+>>>>>>> Allow discontinuous FOV
 
   // THEN: we expect the first cloud to have 6 points
   // the second cloud should contain 7 points
@@ -382,7 +395,7 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
                 cost_matrix, cost_image_data);
 
   // THEN: The minimum cost should be in the direction of the goal
-  PolarPoint best_pol = cartesianToPolar(goal, position);
+  PolarPoint best_pol = cartesianToPolarHistogram(goal, position);
   Eigen::Vector2i best_index = polarToHistogramIndex(best_pol, ALPHA_RES);
 
   Eigen::MatrixXf::Index minRow, minCol;
@@ -508,7 +521,7 @@ TEST(PlannerFunctions, CostfunctionHeadingCost) {
   Eigen::Vector3f position(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
   Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
-  float heading_1 = 10.f;
+  float heading_1 = 60.f;  // in fcu frame: 90deg yaw is toward the goal
   float heading_2 = 30.f;
   costParameters cost_params;
   cost_params.goal_cost_param = 3.f;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -99,12 +99,8 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   pcl::PointCloud<pcl::PointXYZI> processed_cloud1, processed_cloud2, processed_cloud3;
   Eigen::Vector3f memory_point(1.4f, 0.0f, 0.0f);
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  PolarPoint memory_point_polar = cartesianToPolar(position + memory_point, position);
-=======
   PolarPoint memory_point_polar =
       cartesianToPolarFCU(position + memory_point, position);
->>>>>>> Allow discontinuous FOV
   processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
@@ -117,16 +113,6 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   FOV_regular.push_back(FOV(0.0f, 1.0f, 85.0f, 65.0f));
 
   // WHEN: we filter the PointCloud with different values max_age
-<<<<<<< 6b3cc5fb383f725bb12842eed2d619fc5de0d1f4
-  processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero, position, min_realsense_dist, 0.0f, 0.5f,
-                    1);
-
-  processPointcloud(processed_cloud2, complete_cloud, histogram_box, FOV_zero, position, min_realsense_dist, 10.0f, .5f,
-                    1);
-
-  processPointcloud(processed_cloud3, complete_cloud, histogram_box, FOV_regular, position, min_realsense_dist, 10.0f,
-                    0.5f, 1);
-=======
   processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,
                     0.0f, 0.0f, position, min_realsense_dist, 0.0f, 0.5f, 1);
 
@@ -137,7 +123,6 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   processPointcloud(processed_cloud3, complete_cloud, histogram_box,
                     FOV_regular, 0.0f, 0.0f, position, min_realsense_dist,
                     10.0f, 0.5f, 1);
->>>>>>> Allow discontinuous FOV
 
   // THEN: we expect the first cloud to have 6 points
   // the second cloud should contain 7 points

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -99,30 +99,27 @@ TEST(PlannerFunctionsTests, processPointcloud) {
 
   pcl::PointCloud<pcl::PointXYZI> processed_cloud1, processed_cloud2, processed_cloud3;
   Eigen::Vector3f memory_point(1.4f, 0.0f, 0.0f);
-  PolarPoint memory_point_polar =
-      cartesianToPolarFCU(position + memory_point, position);
+  PolarPoint memory_point_polar = cartesianToPolarFCU(position + memory_point, position);
   processed_cloud1.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud2.push_back(toXYZI(position + memory_point, 5.0f));
   processed_cloud3.push_back(toXYZI(position + memory_point, 5.0f));
 
-  std::vector<FOV>
-      FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
+  std::vector<FOV> FOV_zero;  // zero FOV means all pts are outside FOV, and thus remembered
   FOV_zero.push_back(FOV(1.0f, 1.0f, 0.0f, 0.0f));
 
   std::vector<FOV> FOV_regular;
   FOV_regular.push_back(FOV(0.0f, 1.0f, 85.0f, 65.0f));
 
   // WHEN: we filter the PointCloud with different values max_age
-  processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero,
-                    0.0f, 0.0f, position, min_realsense_dist, 0.0f, 0.5f, 1);
+  processPointcloud(processed_cloud1, complete_cloud, histogram_box, FOV_zero, 0.0f, 0.0f, position, min_realsense_dist,
+                    0.0f, 0.5f, 1);
 
-  processPointcloud(processed_cloud2, complete_cloud, histogram_box, FOV_zero,
-                    0.0f, 0.0f,  // todo: test different yaw and pitch
+  processPointcloud(processed_cloud2, complete_cloud, histogram_box, FOV_zero, 0.0f,
+                    0.0f,  // todo: test different yaw and pitch
                     position, min_realsense_dist, 10.0f, .5f, 1);
 
-  processPointcloud(processed_cloud3, complete_cloud, histogram_box,
-                    FOV_regular, 0.0f, 0.0f, position, min_realsense_dist,
-                    10.0f, 0.5f, 1);
+  processPointcloud(processed_cloud3, complete_cloud, histogram_box, FOV_regular, 0.0f, 0.0f, position,
+                    min_realsense_dist, 10.0f, 0.5f, 1);
 
   // THEN: we expect the first cloud to have 6 points
   // the second cloud should contain 7 points

--- a/local_planner/test/test_star_planner.cpp
+++ b/local_planner/test/test_star_planner.cpp
@@ -81,7 +81,7 @@ TEST_F(StarPlannerTests, buildTree) {
     // we set the vehicle position to be the first node position after the
     // origin for the next algorithm iterarion
     position = star_planner.tree_[1].getPosition();
-    star_planner.setPose(position, 0.0);
+    star_planner.setPose(position, 0.0f);
   }
 }
 
@@ -177,8 +177,8 @@ TEST_F(StarPlannerBasicTests, treeCostFunctionYawCost) {
   // insert two nodes to both sides
   PolarPoint node1_pol(0, 110, 1);  // to the right
   PolarPoint node2_pol(0, 70, 1);   // to the left
-  Eigen::Vector3f node1 = polarToCartesian(node1_pol, tree_root);
-  Eigen::Vector3f node2 = polarToCartesian(node2_pol, tree_root);
+  Eigen::Vector3f node1 = polarHistogramToCartesian(node1_pol, tree_root);
+  Eigen::Vector3f node2 = polarHistogramToCartesian(node2_pol, tree_root);
 
   tree_.push_back(TreeNode(0, 1, node1));
   tree_.back().last_e_ = node1_pol.e;
@@ -242,8 +242,8 @@ TEST_F(StarPlannerBasicTests, treeCostFunctionSmoothingCost) {
   // insert two more nodes with node 1 as origin
   PolarPoint node2_pol(0, 100, 1);
   PolarPoint node3_pol(0, 110, 1);
-  Eigen::Vector3f node2 = polarToCartesian(node2_pol, node1);
-  Eigen::Vector3f node3 = polarToCartesian(node3_pol, node1);
+  Eigen::Vector3f node2 = polarHistogramToCartesian(node2_pol, node1);
+  Eigen::Vector3f node3 = polarHistogramToCartesian(node3_pol, node1);
 
   tree_.push_back(TreeNode(1, 2, node2));
   tree_.back().last_e_ = node2_pol.e;
@@ -256,8 +256,8 @@ TEST_F(StarPlannerBasicTests, treeCostFunctionSmoothingCost) {
   // calculate two goal positions in direction of the nodes 2, 3
   PolarPoint goal2_pol(0, 100, 5);
   PolarPoint goal3_pol(0, 110, 5);
-  Eigen::Vector3f goal2 = polarToCartesian(goal2_pol, node1);
-  Eigen::Vector3f goal3 = polarToCartesian(goal3_pol, node1);
+  Eigen::Vector3f goal2 = polarHistogramToCartesian(goal2_pol, node1);
+  Eigen::Vector3f goal3 = polarHistogramToCartesian(goal3_pol, node1);
 
   // WHEN: we calculate the cost for nodes 2, 3
   setGoal(goal2);

--- a/local_planner/test/test_waypoint_generator.cpp
+++ b/local_planner/test/test_waypoint_generator.cpp
@@ -51,7 +51,8 @@ class WaypointGeneratorTests : public ::testing::Test, public WaypointGenerator 
 
     updateState(position, q, goal, prev_goal, velocity, stay, is_airborne);
     setPlannerInfo(avoidance_output);
-    setFOV(270.f, 45.f);
+    FOV fov(0.0f, 0.0f, 270.f, 45.f);
+    setFOV(0, fov);
   }
   void TearDown() override {}
 };


### PR DESCRIPTION
This commit moves the dynamic calculation of the FOV into the camera
frame, such that it is not affected by faulty transforms.

This removes the need to subscribe to the camera_info topic.

Furthermore, we no longer make the assumption that the FOV consists of a central forward-pointing camera, but we can account for multiple cameras, with overlapping FOV or gaps.

![image](https://user-images.githubusercontent.com/14265408/60814477-f7bbf480-a195-11e9-93ca-ec4fb39d2171.png)


The adaptSpeed() function now scales the waypoint only toward the "true" edge of the FOV, meaning that it will not be scaled when moving from one camera to the other, as long as they have adjacent or overlapping FOV