### PR TITLE
poll px4 paramters at a higher rate if they aren't set

### DIFF
--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -495,7 +495,8 @@ void LocalPlannerNode::checkPx4Parameters() {
     request_param("MPC_XY_CRUISE", local_planner_->px4_.param_mpc_xy_cruise);
     request_param("MPC_COL_PREV_D", local_planner_->px4_.param_mpc_col_prev_d);
 
-    if (!std::isfinite(local_planner_->px4_.param_mpc_xy_cruise) || !std::isfinite(local_planner_->px4_.param_mpc_col_prev_d)) {
+    if (!std::isfinite(local_planner_->px4_.param_mpc_xy_cruise) ||
+        !std::isfinite(local_planner_->px4_.param_mpc_col_prev_d)) {
       std::this_thread::sleep_for(std::chrono::seconds(5));
     } else {
       std::this_thread::sleep_for(std::chrono::seconds(30));

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -495,7 +495,11 @@ void LocalPlannerNode::checkPx4Parameters() {
     request_param("MPC_XY_CRUISE", local_planner_->px4_.param_mpc_xy_cruise);
     request_param("MPC_COL_PREV_D", local_planner_->px4_.param_mpc_col_prev_d);
 
-    std::this_thread::sleep_for(std::chrono::seconds(30));
+    if (!std::isfinite(local_planner_->px4_.param_mpc_xy_cruise) || !std::isfinite(local_planner_->px4_.param_mpc_col_prev_d)) {
+      std::this_thread::sleep_for(std::chrono::seconds(5));
+    } else {
+      std::this_thread::sleep_for(std::chrono::seconds(30));
+    }
   }
 }
 


### PR DESCRIPTION
Issue in Master: the first time we try to retrieve the parameters we get
``` [ERROR] [1561541271.521030400, 0.420000000]: PR: Unknown parameter to get: MPC_XY_CRUISE
[ERROR] [1561541271.523737193, 0.424000000]: PR: Unknown parameter to get: MPC_COL_PREV_D
 ```
The next poll happens 30 seconds later which is a huge time delay. 

This is more a workaround to make sure that the CI is working. It would be nice to investigate why the first attempt always fails. 