### PR TITLE
clip depth camera at 18m instead of 9

### DIFF
--- a/avoidance/sim/models/depth_camera_new/depth_camera_new.sdf
+++ b/avoidance/sim/models/depth_camera_new/depth_camera_new.sdf
@@ -34,7 +34,7 @@
           </image>
           <clip>
             <near>0.5</near>
-            <far>9</far>
+            <far>18</far>
           </clip>
         </camera>
         <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">

--- a/avoidance/sim/models/iris_depth_camera_3/iris_depth_camera.sdf
+++ b/avoidance/sim/models/iris_depth_camera_3/iris_depth_camera.sdf
@@ -37,7 +37,7 @@
           </image>
           <clip>
             <near>0.5</near>
-            <far>9</far>
+            <far>18</far>
           </clip>
         </camera>
         <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
@@ -58,10 +58,10 @@
           <distortion_t1>0.0</distortion_t1>
           <distortion_t2>0.0</distortion_t2>
         </plugin>
-      </sensor>  
+      </sensor>
     </link>
   </model>
-  
+
     <joint name="depth_camera_new_joint_front" type="revolute">
       <child>front_camera::link</child>
       <parent>iris::base_link</parent>
@@ -73,8 +73,8 @@
         </limit>
       </axis>
     </joint>
-    
-    
+
+
   <model name="left_camera">
     <pose>0.05 0.05 -0.03 0 0 1.57</pose>
     <link name="link">
@@ -109,7 +109,7 @@
           </image>
           <clip>
             <near>0.5</near>
-            <far>9</far>
+            <far>18</far>
           </clip>
         </camera>
         <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
@@ -133,7 +133,7 @@
       </sensor>
     </link>
   </model>
-  
+
     <joint name="depth_camera_new_joint_left" type="revolute">
       <child>left_camera::link</child>
       <parent>iris::base_link</parent>
@@ -145,7 +145,7 @@
         </limit>
       </axis>
     </joint>
-    
+
   <model name="right_camera">
     <pose>0.05 -0.05 -0.03 0 0 -1.57</pose>
     <link name="link">
@@ -180,7 +180,7 @@
           </image>
           <clip>
             <near>0.5</near>
-            <far>9</far>
+            <far>18</far>
           </clip>
         </camera>
         <plugin filename="libgazebo_ros_openni_kinect.so" name="camera_controller">
@@ -204,7 +204,7 @@
       </sensor>
     </link>
   </model>
-  
+
     <joint name="depth_camera_new_joint_right" type="revolute">
       <child>right_camera::link</child>
       <parent>iris::base_link</parent>
@@ -216,7 +216,7 @@
         </limit>
       </axis>
     </joint>
-    
+
     <include>
       <uri>model://lidar</uri>
       <pose>-0.12 0 0 0 3.1415 0</pose>
@@ -232,7 +232,7 @@
         </limit>
       </axis>
     </joint>
-  
+
   <!--<model name="distance_sensor">
     <pose>-0.01 0 -0.02 0 1.57 0</pose>
     <link name="link">
@@ -275,7 +275,7 @@
 	    </sensor>
       </link>
     </model> -->
-    
+
     <!-- <joint name="distance_sensor_new_joint_right" type="revolute">
       <child>distance_sensor::link</child>
       <parent>iris::base_link</parent>
@@ -287,6 +287,6 @@
         </limit>
       </axis>
     </joint> -->
-  
+
   </model>
-</sdf> 
+</sdf>


### PR DESCRIPTION
On the local planner we require a box size of 12m but actually in the model we're clipping at 9m.

Master:
![before](https://user-images.githubusercontent.com/15078736/60452270-78c33b00-9c2e-11e9-84a6-1129b99992c9.png)

PR:
![after](https://user-images.githubusercontent.com/15078736/60452277-7e208580-9c2e-11e9-8873-866106bba429.png)

Needs testing on ROS Kinetic since the problem was showing up only in Melodic