### PR TITLE
Port avoidance_node to local_planner

### DIFF
--- a/avoidance/include/avoidance/avoidance_node.h
+++ b/avoidance/include/avoidance/avoidance_node.h
@@ -25,6 +25,8 @@ class AvoidanceNode {
   **/
   void checkFailsafe(ros::Duration since_last_cloud, ros::Duration since_start,
                      bool& hover);
+  void setSystemStatus(MAV_STATE state);
+  MAV_STATE getSystemStatus();
 
  private:
   ros::NodeHandle nh_;
@@ -49,7 +51,6 @@ class AvoidanceNode {
   void cmdLoopCallback(const ros::TimerEvent& event);
   void statusLoopCallback(const ros::TimerEvent& event);
   void publishSystemStatus();
-  void setSystemStatus(MAV_STATE state);
 };
 }
 #endif  // AVOIDANCE_AVOIDANCE_NODE_H

--- a/avoidance/src/avoidance_node.cpp
+++ b/avoidance/src/avoidance_node.cpp
@@ -46,9 +46,7 @@ void AvoidanceNode::setSystemStatus(MAV_STATE state) {
   companion_state_ = state;
 }
 
-MAV_STATE AvoidanceNode::getSystemStatus(){
-  return companion_state_;
-}
+MAV_STATE AvoidanceNode::getSystemStatus() { return companion_state_; }
 
 // Publish companion process status
 void AvoidanceNode::publishSystemStatus() {

--- a/avoidance/src/avoidance_node.cpp
+++ b/avoidance/src/avoidance_node.cpp
@@ -46,6 +46,10 @@ void AvoidanceNode::setSystemStatus(MAV_STATE state) {
   companion_state_ = state;
 }
 
+MAV_STATE AvoidanceNode::getSystemStatus(){
+  return companion_state_;
+}
+
 // Publish companion process status
 void AvoidanceNode::publishSystemStatus() {
   mavros_msgs::CompanionProcessStatus status_msg;

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -37,9 +37,9 @@
 #include <boost/bind.hpp>
 
 #include <avoidance/common.h>
-#include "avoidance/avoidance_node.h"
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
+#include "avoidance/avoidance_node.h"
 
 #include <atomic>
 #include <condition_variable>

--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -37,6 +37,7 @@
 #include <boost/bind.hpp>
 
 #include <avoidance/common.h>
+#include "avoidance/avoidance_node.h"
 #include <dynamic_reconfigure/server.h>
 #include <local_planner/LocalPlannerNodeConfig.h>
 
@@ -84,6 +85,7 @@ class LocalPlannerNode {
   std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
 
   LocalPlannerVisualization visualizer_;
+  avoidance::AvoidanceNode avoidance_node_;
 
 #ifndef DISABLE_SIMULATION
   std::unique_ptr<WorldVisualizer> world_visualizer_;
@@ -224,7 +226,6 @@ class LocalPlannerNode {
   bool new_goal_ = false;
 
   NavigationState nav_state_ = NavigationState::none;
-  MAV_STATE companion_state_ = MAV_STATE::MAV_STATE_STANDBY;
 
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_;
   tf::TransformListener* tf_listener_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -18,7 +18,10 @@ namespace avoidance {
 LocalPlannerNode::LocalPlannerNode(const ros::NodeHandle& nh,
                                    const ros::NodeHandle& nh_private,
                                    const bool tf_spin_thread)
-    : nh_(nh), nh_private_(nh_private),  avoidance_node_(nh, nh_private), spin_dt_(0.1) {
+    : nh_(nh),
+      nh_private_(nh_private),
+      avoidance_node_(nh, nh_private),
+      spin_dt_(0.1) {
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
 
@@ -328,7 +331,9 @@ void LocalPlannerNode::setSystemStatus(MAV_STATE state) {
   avoidance_node_.setSystemStatus(state);
 }
 
-MAV_STATE LocalPlannerNode::getSystemStatus() { return avoidance_node_.getSystemStatus(); }
+MAV_STATE LocalPlannerNode::getSystemStatus() {
+  return avoidance_node_.getSystemStatus();
+}
 
 void LocalPlannerNode::calculateWaypoints(bool hover) {
   bool is_airborne = armed_ && (nav_state_ != NavigationState::none);

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -587,48 +587,7 @@ void LocalPlannerNode::threadFunction() {
 
 void LocalPlannerNode::checkFailsafe(ros::Duration since_last_cloud,
                                      ros::Duration since_start, bool& hover) {
-  ros::Duration timeout_termination =
-      ros::Duration(local_planner_->timeout_termination_);
-  ros::Duration timeout_critical =
-      ros::Duration(local_planner_->timeout_critical_);
-  ros::Duration timeout_startup =
-      ros::Duration(local_planner_->timeout_startup_);
-
-  if (since_last_cloud > timeout_termination &&
-      since_start > timeout_termination) {
-    setSystemStatus(MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
-    ROS_WARN("\033[1;33m Planner abort: missing required data \n \033[0m");
-  } else {
-    if (since_last_cloud > timeout_critical && since_start > timeout_startup) {
-      if (position_received_) {
-        hover = true;
-        setSystemStatus(MAV_STATE::MAV_STATE_CRITICAL);
-        std::string not_received = "";
-        for (size_t i = 0; i < cameras_.size(); i++) {
-          if (!cameras_[i].received_) {
-            not_received.append(", no cloud received on topic ");
-            not_received.append(cameras_[i].topic_);
-          }
-          if (!cameras_[i].transformed_) {
-            not_received.append(", missing tf on topic ");
-            not_received.append(cameras_[i].topic_);
-          }
-        }
-
-        ROS_WARN(
-            "\033[1;33m Pointcloud timeout %s (Hovering at current position) "
-            "\n "
-            "\033[0m",
-            not_received.c_str());
-      } else {
-        ROS_WARN(
-            "\033[1;33m Pointcloud timeout: No position received, no WP to "
-            "output.... \n \033[0m");
-      }
-    } else {
-      if (!hover) setSystemStatus(MAV_STATE::MAV_STATE_ACTIVE);
-    }
-  }
+  avoidance_node_.checkFailsafe(since_last_cloud, since_start, hover);
 }
 
 void LocalPlannerNode::pointCloudTransformThread(int index) {


### PR DESCRIPTION
This PR ports `avoidance_node` to `local_planner` which makes the companion process status publishing run independently on a separate queue.

The global_planner has already been using the `avoidance_node`, and it would be useful to have a single node that takes care of the companion process status communication as well as failsafe checks