### PR TITLE
Fix for segfault with mutex

### DIFF
--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <boost/bind.hpp>
+#include <mutex>
 #include <set>
 #include <string>
 
@@ -57,6 +58,8 @@ class GlobalPlannerNode {
   ~GlobalPlannerNode();
 
  private:
+  std::mutex mutex_;
+
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
 

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -3,7 +3,7 @@
 namespace global_planner {
 
 GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private)
-    : nh_(nh), nh_private_(nh_private), avoidance_node_(nh, nh_private), cmdloop_dt_(0.1), plannerloop_dt_(2.0) {
+    : nh_(nh), nh_private_(nh_private), avoidance_node_(nh, nh_private), cmdloop_dt_(0.1), plannerloop_dt_(1.0) {
   // Set up Dynamic Reconfigure Server
   dynamic_reconfigure::Server<global_planner::GlobalPlannerNodeConfig>::CallbackType f;
   f = boost::bind(&GlobalPlannerNode::dynamicReconfigureCallback, this, _1, _2);

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -273,6 +273,7 @@ void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
   if (num_octomap_msg_++ % 10 > 0) {
     return;  // We get too many of those messages. Only process 1/10 of them
   }
+  std::lock_guard<std::mutex> lock(mutex_);
 
   bool current_path_is_ok = global_planner_.updateFullOctomap(msg);
   if (!current_path_is_ok) {
@@ -341,6 +342,7 @@ void GlobalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
 }
 
 void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
+  std::lock_guard<std::mutex> lock(mutex_);
   bool is_in_goal = global_planner_.goal_pos_.withinPositionRadius(global_planner_.curr_pos_);
   if (is_in_goal || global_planner_.goal_is_blocked_) {
     popNextGoal();


### PR DESCRIPTION
This PR is an attempt to fix issue #425, where the global_planner has been crashing with a segfault.

The issue comes from the map update being done by deleting the `octree_` pointer while the replanning was still using the `octree_` information. 