### PR TITLE
Simplify cost functions

### DIFF
--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -221,6 +221,7 @@ void wrapPolar(PolarPoint& p_pol);
 **/
 float nextYaw(const Eigen::Vector3f& u, const Eigen::Vector3f& v);
 
+// todo: is this used?
 void createPoseMsg(Eigen::Vector3f& out_waypt, Eigen::Quaternionf& out_q, const Eigen::Vector3f& in_waypt, float yaw);
 
 /**

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -248,6 +248,15 @@ float WARN_UNUSED wrapAngleToPlusMinusPI(float angle);
 * @returns   wrapped angle [deg]
 **/
 float WARN_UNUSED wrapAngleToPlusMinus180(float angle);
+
+/**
+* @brief     returns the correctly wrapped angle difference in degrees
+* @param[in] the first angle in degrees
+* @param[in] the second angle in degrees
+* @returns   the angle between the two given angles [0, 180]
+**/
+float angleDifference(float a, float b);
+
 /**
 * @brief     computes an angular velocity to reach the desired_yaw
 * @param[in] adesired_yaw  [rad]

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -226,6 +226,11 @@ float wrapAngleToPlusMinusPI(float angle) { return angle - 2.0f * M_PI_F * std::
 
 float wrapAngleToPlusMinus180(float angle) { return angle - 360.f * std::floor(angle / 360.f + 0.5f); }
 
+float angleDifference(float a, float b) {
+  float angle = fmod(a - b, 360.f);
+  return angle >= 0.f ? (angle < 180.f) ? angle : angle - 360.f : (angle >= -180.f) ? angle : angle + 360.f;
+}
+
 double getAngularVelocity(float desired_yaw, float curr_yaw) {
   desired_yaw = wrapAngleToPlusMinusPI(desired_yaw);
   float yaw_vel1 = desired_yaw - curr_yaw;

--- a/local_planner/cfg/local_planner_node.cfg
+++ b/local_planner/cfg/local_planner_node.cfg
@@ -7,12 +7,13 @@ gen = ParameterGenerator()
 
 # local_planner
 
-gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 12.0,  0, 20)
-gen.add("goal_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 10.0, 0, 20.0)
-gen.add("heading_cost_param_", double_t, 0, "Cost function weight for constant heading", 0.5, 0, 20.0)
-gen.add("smooth_cost_param_", double_t, 0, "Cost function weight for path smoothness", 1.5, 0.5, 20.0)
+gen.add("box_radius_",    double_t,    0, "Data points farther away will be discarded", 15.0,  0, 20)
+gen.add("pitch_cost_param_", double_t, 0, "Cost function weight for goal oriented behavior", 150.0, 0, 500.0)
+gen.add("yaw_cost_param_", double_t, 0, "Cost function weight for constant heading", 6.0, 0, 20.0)
+gen.add("velocity_cost_param_", double_t, 0, "Cost function weight for path smoothness", 35000.0, 0.0, 50000.0)
+gen.add("obstacle_cost_param_", double_t, 0,"Approximate distance from obstacles (m) when the obstacle distance term dominates the cost function", 8.5, 0.0, 30.0)
+gen.add("tree_heuristic_weight_", double_t, 0, "Weight for the tree heuristic cost", 35.0, 0.0, 50.0)
 gen.add("goal_z_param", double_t, 0, "Height of the goal position", 3.5, -20.0, 20.0)
-gen.add("no_progress_slope_", double_t, 0, "If progress derivative higher than this value the drone rises", -0.0007, -1.0, 1.0)
 gen.add("min_realsense_dist_", double_t, 0, "Discard points closer than that", 0.2, 0, 10)
 gen.add("timeout_startup_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 5, 0, 60)
 gen.add("timeout_critical_", double_t, 0, "After this timeout the companion status is MAV_STATE_CRITICAL", 0.5, 0, 10)
@@ -24,12 +25,10 @@ gen.add("smoothing_speed_z_", double_t, 0, "response speed of the smoothing syst
 gen.add("smoothing_margin_degrees_", double_t, 0, "smoothing radius for obstacle cost in cost histogram", 40, 0, 90)
 
 gen.add("use_vel_setpoints_", bool_t, 0, "Enable velocity setpoints (if false, position setpoints are used)", False)
-gen.add("adapt_cost_params_", bool_t, 0, "If no progress towards goal is made, allow rising", True)
 
 # star_planner
-gen.add("children_per_node_",    int_t,    0, "Branching factor of the search tree", 50,  0, 100)
-gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 10,  0, 200)
-gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 1,  0, 20)
-gen.add("tree_discount_factor_",    double_t,    0, "Discount factor in tree cost function", 0.8,  0, 1)
+gen.add("children_per_node_",    int_t,    0, "Branching factor of the search tree", 8,  0, 100)
+gen.add("n_expanded_nodes_",    int_t,    0, "Number of nodes expanded in complete tree", 40,  0, 200)
+gen.add("tree_node_distance_",    double_t,    0, "Distance between nodes", 2,  0, 20)
 
 exit(gen.generate(PACKAGE, "avoidance", "LocalPlannerNode"))

--- a/local_planner/include/local_planner/candidate_direction.h
+++ b/local_planner/include/local_planner/candidate_direction.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "avoidance/common.h"
 
 namespace avoidance {
 
@@ -12,5 +13,7 @@ struct candidateDirection {
   bool operator<(const candidateDirection& y) const { return cost < y.cost; }
 
   bool operator>(const candidateDirection& y) const { return cost > y.cost; }
+
+  PolarPoint toPolar(float r) const { return PolarPoint(elevation_angle, azimuth_angle, r); }
 };
 }

--- a/local_planner/include/local_planner/cost_parameters.h
+++ b/local_planner/include/local_planner/cost_parameters.h
@@ -3,10 +3,9 @@
 namespace avoidance {
 
 struct costParameters {
-  float heading_cost_param = 0.5f;
-  float goal_cost_param = 3.f;
-  float smooth_cost_param = 1.5f;
-  float height_change_cost_param = 4.f;
-  float height_change_cost_param_adapted = 4.f;
+  float yaw_cost_param = 0.5f;
+  float pitch_cost_param = 3.f;
+  float velocity_cost_param = 1.5f;
+  float obstacle_cost_param = 5.0f;
 };
 }

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -66,20 +66,12 @@ struct ModelParameters {
 
 class LocalPlanner {
  private:
-  bool adapt_cost_params_;
   bool reach_altitude_ = false;
-  bool waypoint_outside_FOV_ = false;
 
-  size_t dist_incline_window_size_ = 50;
-  int origin_;
-  int tree_age_ = 0;
   int children_per_node_;
   int n_expanded_nodes_;
   int min_num_points_per_cell_ = 3;
 
-  ros::Time integral_time_old_;
-  float no_progress_slope_;
-  float new_yaw_;
   float min_realsense_dist_ = 0.2f;
   float smoothing_margin_degrees_ = 30.f;
   float max_point_age_s_ = 10;
@@ -92,11 +84,7 @@ class LocalPlanner {
   ros::Time last_path_time_;
   ros::Time last_pointcloud_process_time_;
 
-  std::deque<float> goal_dist_incline_;
-  std::vector<float> cost_path_candidates_;
-  std::vector<int> cost_idx_sorted_;
   std::vector<int> closed_set_;
-
   std::vector<TreeNode> tree_;
   std::unique_ptr<StarPlanner> star_planner_;
   costParameters cost_params_;
@@ -106,17 +94,11 @@ class LocalPlanner {
   Eigen::Vector3f position_ = Eigen::Vector3f::Zero();
   Eigen::Vector3f velocity_ = Eigen::Vector3f::Zero();
   Eigen::Vector3f goal_ = Eigen::Vector3f::Zero();
-  Eigen::Vector3f position_old_ = Eigen::Vector3f::Zero();
 
   Histogram polar_histogram_ = Histogram(ALPHA_RES);
   Histogram to_fcu_histogram_ = Histogram(ALPHA_RES);
   Eigen::MatrixXf cost_matrix_;
 
-  /**
-  * @brief     calculates the cost function weights to fly around or over
-  *            obstacles based on the progress towards the goal over time
-  **/
-  void evaluateProgressRate();
   /**
   * @brief     fills message to send histogram to the FCU
   **/
@@ -143,14 +125,12 @@ class LocalPlanner {
   std::vector<uint8_t> cost_image_data_;
   bool use_vel_setpoints_;
   bool currently_armed_ = false;
-  bool smooth_waypoints_ = true;
   bool disable_rise_to_goal_altitude_ = false;
 
   double timeout_startup_;
   double timeout_critical_;
   double timeout_termination_;
   double starting_height_ = 0.0;
-  float speed_ = 1.0f;
   float ground_distance_ = 2.0;
 
   ModelParameters px4_;  // PX4 Firmware paramters
@@ -166,11 +146,12 @@ class LocalPlanner {
   ~LocalPlanner();
 
   /**
-  * @brief     setter method for vehicle position
-  * @param[in] pos, vehicle position message coming from the FCU
+  * @brief     setter method for vehicle position, orientation and velocity
+  * @param[in] pos, vehicle position coming from the FCU
+  * @param[in] vel, vehicle velocity in the FCU frame
   * @param[in] q, vehicle orientation message coming from the FCU
   **/
-  void setPose(const Eigen::Vector3f& pos, const Eigen::Quaternionf& q);
+  void setState(const Eigen::Vector3f& pos, const Eigen::Vector3f& vel, const Eigen::Quaternionf& q);
 
   /**
   * @brief     setter method for mission goal
@@ -218,12 +199,6 @@ class LocalPlanner {
   * @returns   reference to pointcloud
   **/
   const pcl::PointCloud<pcl::PointXYZI>& getPointcloud() const;
-
-  /**
-  * @brief     setter method for vehicle velocity
-  * @param[in] vel, velocity message coming from the FCU
-  **/
-  void setCurrentVelocity(const Eigen::Vector3f& vel);
 
   /**
   * @brief     getter method to visualize the tree in rviz

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -26,7 +26,7 @@ namespace avoidance {
 * @param[in]  FOV, struct defining current field of view
 * @param[in]  position, current vehicle position
 * @param[in]  min_realsense_dist, minimum sensor range [m]
-* @param[in]  max_age, maximum age (compute cycles) to keep data
+* @param[in]  max_age, maximum age in seconds to keep data
 * @param[in]  elapsed, time elapsed since last processing [s]
 * @param[in]  min_num_points_per_cell, number of points from which on they will
 *             be kept, less points are discarded as noise (careful: 0 is not
@@ -35,7 +35,7 @@ namespace avoidance {
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                        const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, const Box& histogram_box,
                        const std::vector<FOV>& fov, float yaw_fcu_frame_deg, float pitch_fcu_frame_deg,
-                       const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
+                       const Eigen::Vector3f& position, float min_realsense_dist, float max_age, float elapsed_s,
                        int min_num_points_per_cell);
 
 /**

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -69,9 +69,8 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 * @param[out] image of the cost matrix for visualization
 **/
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                   float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                   const costParameters& cost_params, float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
-                   std::vector<uint8_t>& image_data);
+                   const Eigen::Vector3f& velocity, const costParameters& cost_params, float smoothing_margin_degrees,
+                   Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data);
 
 /**
 * @brief      get the index in the data vector of a color image
@@ -101,20 +100,16 @@ void getBestCandidatesFromCostMatrix(const Eigen::MatrixXf& matrix, unsigned int
 
 /**
 * @brief      computes the cost of each direction in the polar histogram
-* @param[in]  e_angle, elevation angle [deg]
-* @param[in]  z_angle, azimuth angle [deg]
+* @param[in]  PolarPoint of the candidate direction
 * @param[in]  goal, current goal position
 * @param[in]  position, current vehicle position
-* @param[in]  position, current vehicle heading in histogram angle convention
-*             [deg]
-* @param[in]  last_sent_waypoint, previous position waypoint
+* @param[in]  velocity, current vehicle velocity
 * @param[in]  cost_params, weights for goal oriented vs smooth behaviour
-* @param[out] distance_cost, cost component due to proximity to obstacles
-* @param[out] other_costs, cost component due to goal and smoothness
+* @returns    a pair with the first value representing the distance cost, and the second the sum of all other costs
 **/
-void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
-                  const Eigen::Vector3f& position, float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                  const costParameters& cost_params, float& distance_cost, float& other_costs);
+std::pair<float, float> costFunction(const PolarPoint& candidate_polar, float obstacle_distance,
+                                     const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                                     const Eigen::Vector3f& velocity, const costParameters& cost_params);
 
 /**
 * @brief      max-median filtes the cost matrix

--- a/local_planner/include/local_planner/star_planner.h
+++ b/local_planner/include/local_planner/star_planner.h
@@ -24,28 +24,18 @@ class StarPlanner {
   int children_per_node_ = 1;
   int n_expanded_nodes_ = 5;
   float tree_node_distance_ = 1.0f;
-  float tree_discount_factor_ = 0.8f;
   float max_path_length_ = 4.f;
-  float curr_yaw_histogram_frame_deg_ = 90.f;
   float smoothing_margin_degrees_ = 30.f;
-
-  std::vector<int> path_node_origins_;
+  float tree_heuristic_weight_ = 10.0f;
 
   pcl::PointCloud<pcl::PointXYZI> cloud_;
 
   Eigen::Vector3f goal_ = Eigen::Vector3f(NAN, NAN, NAN);
-  Eigen::Vector3f projected_last_wp_ = Eigen::Vector3f::Zero();
   Eigen::Vector3f position_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f velocity_ = Eigen::Vector3f(NAN, NAN, NAN);
   costParameters cost_params_;
 
  protected:
-  /**
-  * @brief     computes the cost of a node
-  * @param[in] node_number, sequential number of entry in the tree
-  * @returns
-  **/
-  float treeCostFunction(int node_number) const;
-
   /**
   * @brief     computes the heuristic for a node
   * @param[in] node_number, sequential number of entry in the tree
@@ -56,7 +46,6 @@ class StarPlanner {
  public:
   std::vector<Eigen::Vector3f> path_node_positions_;
   std::vector<int> closed_set_;
-  int tree_age_;
   std::vector<TreeNode> tree_;
 
   StarPlanner();
@@ -69,12 +58,6 @@ class StarPlanner {
   void setParams(costParameters cost_params);
 
   /**
-  * @brief     setter method for last sent waypoint
-  * @param[in] projected_last_wp, last waypoint projected out to goal distance
-  **/
-  void setLastDirection(const Eigen::Vector3f& projected_last_wp);
-
-  /**
   * @brief     setter method for star_planner pointcloud
   * @param[in] cloud, processed data already cropped and combined with history
   **/
@@ -83,9 +66,8 @@ class StarPlanner {
   /**
   * @brief     setter method for vehicle position
   * @param[in] vehicle current position
-  * @param[in] current yaw of the vehicle in FCU frame convention
   **/
-  void setPose(const Eigen::Vector3f& pos, float curr_yaw_fcu_frame_deg);
+  void setPose(const Eigen::Vector3f& pos, const Eigen::Vector3f& vel);
 
   /**
   * @brief     setter method for current goal

--- a/local_planner/include/local_planner/tree_node.h
+++ b/local_planner/include/local_planner/tree_node.h
@@ -8,19 +8,16 @@ namespace avoidance {
 
 class TreeNode {
   Eigen::Vector3f position_;
+  Eigen::Vector3f velocity_;
 
  public:
   float total_cost_;
   float heuristic_;
-  float last_e_;
-  float last_z_;
   int origin_;
-  int depth_;
-  float yaw_;
   bool closed_;
 
   TreeNode();
-  TreeNode(int from, int d, const Eigen::Vector3f& pos);
+  TreeNode(int from, const Eigen::Vector3f& pos, const Eigen::Vector3f& vel);
   ~TreeNode() = default;
 
   /**
@@ -35,6 +32,7 @@ class TreeNode {
   * @returns   node position in 3D cartesian coordinates
   **/
   Eigen::Vector3f getPosition() const;
+  Eigen::Vector3f getVelocity() const;
 };
 }
 

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -13,11 +13,12 @@ LocalPlanner::LocalPlanner() : star_planner_(new StarPlanner()) {}
 LocalPlanner::~LocalPlanner() {}
 
 // update UAV pose
-void LocalPlanner::setPose(const Eigen::Vector3f& pos, const Eigen::Quaternionf& q) {
+void LocalPlanner::setState(const Eigen::Vector3f& pos, const Eigen::Vector3f& vel, const Eigen::Quaternionf& q) {
   position_ = pos;
+  velocity_ = vel;
   yaw_fcu_frame_deg_ = getYawFromQuaternion(q);
   pitch_fcu_frame_deg_ = getPitchFromQuaternion(q);
-  star_planner_->setPose(position_, yaw_fcu_frame_deg_);
+  star_planner_->setPose(position_, velocity_);
 
   if (!currently_armed_ && !disable_rise_to_goal_altitude_) {
     take_off_pose_ = position_;
@@ -28,12 +29,12 @@ void LocalPlanner::setPose(const Eigen::Vector3f& pos, const Eigen::Quaternionf&
 // set parameters changed by dynamic rconfigure
 void LocalPlanner::dynamicReconfigureSetParams(avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
   histogram_box_.radius_ = static_cast<float>(config.box_radius_);
-  cost_params_.goal_cost_param = config.goal_cost_param_;
-  cost_params_.heading_cost_param = config.heading_cost_param_;
-  cost_params_.smooth_cost_param = config.smooth_cost_param_;
+  cost_params_.pitch_cost_param = config.pitch_cost_param_;
+  cost_params_.yaw_cost_param = config.yaw_cost_param_;
+  cost_params_.velocity_cost_param = config.velocity_cost_param_;
+  cost_params_.obstacle_cost_param = config.obstacle_cost_param_;
   max_point_age_s_ = static_cast<float>(config.max_point_age_s_);
   min_num_points_per_cell_ = config.min_num_points_per_cell_;
-  no_progress_slope_ = static_cast<float>(config.no_progress_slope_);
   min_realsense_dist_ = static_cast<float>(config.min_realsense_dist_);
   timeout_startup_ = config.timeout_startup_;
   timeout_critical_ = config.timeout_critical_;
@@ -49,7 +50,6 @@ void LocalPlanner::dynamicReconfigureSetParams(avoidance::LocalPlannerNodeConfig
   }
 
   use_vel_setpoints_ = config.use_vel_setpoints_;
-  adapt_cost_params_ = config.adapt_cost_params_;
 
   star_planner_->dynamicReconfigureSetStarParams(config, level);
 
@@ -72,10 +72,7 @@ void LocalPlanner::setFOV(int i, const FOV& fov) {
 
 Eigen::Vector3f LocalPlanner::getGoal() const { return goal_; }
 
-void LocalPlanner::applyGoal() {
-  star_planner_->setGoal(goal_);
-  goal_dist_incline_.clear();
-}
+void LocalPlanner::applyGoal() { star_planner_->setGoal(goal_); }
 
 void LocalPlanner::runPlanner() {
   ROS_INFO("\033[1;35m[OA] Planning started, using %i cameras\n \033[0m",
@@ -124,8 +121,6 @@ void LocalPlanner::generateHistogramImage(Histogram& histogram) {
 }
 
 void LocalPlanner::determineStrategy() {
-  star_planner_->tree_age_++;
-
   // clear cost image
   cost_image_data_.clear();
   cost_image_data_.resize(3 * GRID_LENGTH_E * GRID_LENGTH_Z, 0);
@@ -150,28 +145,20 @@ void LocalPlanner::determineStrategy() {
   } else {
     waypoint_type_ = tryPath;
 
-    evaluateProgressRate();
     create2DObstacleRepresentation(px4_.param_mpc_col_prev_d > 0.f);
 
     if (!polar_histogram_.isEmpty()) {
-      getCostMatrix(polar_histogram_, goal_, position_, yaw_fcu_frame_deg_, last_sent_waypoint_, cost_params_,
-                    smoothing_margin_degrees_, cost_matrix_, cost_image_data_);
+      getCostMatrix(polar_histogram_, goal_, position_, velocity_, cost_params_, smoothing_margin_degrees_,
+                    cost_matrix_, cost_image_data_);
 
       star_planner_->setParams(cost_params_);
       star_planner_->setPointcloud(final_cloud_);
-
-      // set last chosen direction for smoothing
-      PolarPoint last_wp_pol = cartesianToPolarHistogram(last_sent_waypoint_, position_);
-      last_wp_pol.r = (position_ - goal_).norm();
-      Eigen::Vector3f projected_last_wp = polarHistogramToCartesian(last_wp_pol, position_);
-      star_planner_->setLastDirection(projected_last_wp);
 
       // build search tree
       star_planner_->buildLookAheadTree();
       last_path_time_ = ros::Time::now();
     }
   }
-  position_old_ = position_;
 }
 
 void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
@@ -206,52 +193,9 @@ void LocalPlanner::updateObstacleDistanceMsg() {
   distance_data_ = msg;
 }
 
-// calculate the correct weight between fly over and fly around
-void LocalPlanner::evaluateProgressRate() {
-  if (reach_altitude_ && adapt_cost_params_) {
-    float goal_dist = (position_ - goal_).norm();
-    float goal_dist_old = (position_old_ - goal_).norm();
-
-    ros::Time time = ros::Time::now();
-    float time_diff_sec = static_cast<float>((time - integral_time_old_).toSec());
-    float incline = (goal_dist - goal_dist_old) / time_diff_sec;
-    integral_time_old_ = time;
-
-    goal_dist_incline_.push_back(incline);
-    if (goal_dist_incline_.size() > dist_incline_window_size_) {
-      goal_dist_incline_.pop_front();
-    }
-
-    float sum_incline = 0.0f;
-    int n_incline = 0;
-    for (size_t i = 0; i < goal_dist_incline_.size(); i++) {
-      sum_incline += goal_dist_incline_[i];
-      n_incline++;
-    }
-    float avg_incline = sum_incline / static_cast<float>(n_incline);
-
-    if (avg_incline > no_progress_slope_ && goal_dist_incline_.size() == dist_incline_window_size_) {
-      if (cost_params_.height_change_cost_param_adapted > 0.75f) {
-        cost_params_.height_change_cost_param_adapted -= 0.02f;
-      }
-    }
-    if (avg_incline < no_progress_slope_) {
-      if (cost_params_.height_change_cost_param_adapted < cost_params_.height_change_cost_param - 0.03f) {
-        cost_params_.height_change_cost_param_adapted += 0.03f;
-      }
-    }
-    ROS_DEBUG("\033[0;35m[OA] Progress rate to goal: %f, adapted height change cost: %f .\033[0m", avg_incline,
-              cost_params_.height_change_cost_param_adapted);
-  } else {
-    cost_params_.height_change_cost_param_adapted = cost_params_.height_change_cost_param;
-  }
-}
-
 Eigen::Vector3f LocalPlanner::getPosition() const { return position_; }
 
 const pcl::PointCloud<pcl::PointXYZI>& LocalPlanner::getPointcloud() const { return final_cloud_; }
-
-void LocalPlanner::setCurrentVelocity(const Eigen::Vector3f& vel) { velocity_ = vel; }
 
 void LocalPlanner::setDefaultPx4Parameters() {
   px4_.param_mpc_auto_mode = 1;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -172,11 +172,9 @@ void LocalPlannerNode::updatePlannerInfo() {
     }
   }
 
-  // update position
-  local_planner_->setPose(toEigen(newest_pose_.pose.position), toEigen(newest_pose_.pose.orientation));
-
-  // Update velocity
-  local_planner_->setCurrentVelocity(toEigen(vel_msg_.twist.linear));
+  // update pose
+  local_planner_->setState(toEigen(newest_pose_.pose.position), toEigen(vel_msg_.twist.linear),
+                           toEigen(newest_pose_.pose.orientation));
 
   // update state
   local_planner_->currently_armed_ = armed_;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -63,8 +63,7 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
 
         // only remember point if it's in a cell not previously populated by
         // complete_cloud, as well as outside FOV and 'young' enough
-        if (histogram_points_counter(p_ind.y(), p_ind.x()) < min_num_points_per_cell && xyzi.intensity < max_age &&
-            !pointInsideFOV(fov, p_pol_fcu)) {
+        if (xyzi.intensity < max_age && !pointInsideFOV(fov, p_pol_fcu)) {
           final_cloud.points.push_back(toXYZI(toEigen(xyzi), xyzi.intensity + elapsed_s));
 
           // to indicate that this cell now has a point

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -125,13 +125,11 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
 }
 
 void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
-                   float yaw_fcu_frame_deg, const Eigen::Vector3f& last_sent_waypoint,
-                   const costParameters& cost_params, float smoothing_margin_degrees, Eigen::MatrixXf& cost_matrix,
-                   std::vector<uint8_t>& image_data) {
+                   const Eigen::Vector3f& velocity, const costParameters& cost_params, float smoothing_margin_degrees,
+                   Eigen::MatrixXf& cost_matrix, std::vector<uint8_t>& image_data) {
   Eigen::MatrixXf distance_matrix(GRID_LENGTH_E, GRID_LENGTH_Z);
   distance_matrix.fill(NAN);
-  float distance_cost = 0.f;
-  float other_costs = 0.f;
+
   // reset cost matrix to zero
   cost_matrix.resize(GRID_LENGTH_E, GRID_LENGTH_Z);
   cost_matrix.fill(NAN);
@@ -145,12 +143,11 @@ void getCostMatrix(const Histogram& histogram, const Eigen::Vector3f& goal, cons
 
     for (int z_index = 0; z_index < GRID_LENGTH_Z; z_index += step_size) {
       float obstacle_distance = histogram.get_dist(e_index, z_index);
-      PolarPoint p_pol = histogramIndexToPolar(e_index, z_index, ALPHA_RES, obstacle_distance);
+      PolarPoint p_pol = histogramIndexToPolar(e_index, z_index, ALPHA_RES, 1.0f);  // unit vector of current direction
 
-      costFunction(p_pol.e, p_pol.z, obstacle_distance, goal, position, yaw_fcu_frame_deg, last_sent_waypoint,
-                   cost_params, distance_cost, other_costs);
-      cost_matrix(e_index, z_index) = other_costs;
-      distance_matrix(e_index, z_index) = distance_cost;
+      std::pair<float, float> costs = costFunction(p_pol, obstacle_distance, goal, position, velocity, cost_params);
+      cost_matrix(e_index, z_index) = costs.second;
+      distance_matrix(e_index, z_index) = costs.first;
     }
     if (step_size > 1) {
       // horizontally interpolate all of the un-calculated values
@@ -305,54 +302,23 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
 }
 
 // costfunction for every free histogram cell
-void costFunction(float e_angle, float z_angle, float obstacle_distance, const Eigen::Vector3f& goal,
-                  const Eigen::Vector3f& position, const float yaw_fcu_frame_deg,
-                  const Eigen::Vector3f& last_sent_waypoint, const costParameters& cost_params, float& distance_cost,
-                  float& other_costs) {
-  // Azimuth angle in histogram convention is different from FCU convention!
-  // Azimuth is flipped and rotated 90 degrees, elevation is just flipped
-  float azimuth_hist_frame_deg = wrapAngleToPlusMinus180(-yaw_fcu_frame_deg + 90.0f);
-  float goal_dist = (position - goal).norm();
-  PolarPoint p_pol(e_angle, z_angle, goal_dist);
-  Eigen::Vector3f projected_candidate = polarHistogramToCartesian(p_pol, position);
-  PolarPoint heading_pol(e_angle, azimuth_hist_frame_deg, goal_dist);
-  Eigen::Vector3f projected_heading = polarHistogramToCartesian(heading_pol, position);
-  Eigen::Vector3f projected_goal = goal;
-  PolarPoint last_wp_pol = cartesianToPolarHistogram(last_sent_waypoint, position);
-  last_wp_pol.r = goal_dist;
-  Eigen::Vector3f projected_last_wp = polarHistogramToCartesian(last_wp_pol, position);
+std::pair<float, float> costFunction(const PolarPoint& candidate_polar, float obstacle_distance,
+                                     const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
+                                     const Eigen::Vector3f& velocity, const costParameters& cost_params) {
+  // Compute  polar direction to goal and cartesian representation of current direction to evaluate
+  const PolarPoint facing_goal = cartesianToPolarHistogram(goal, position);
+  const Eigen::Vector3f candidate_velocity_cartesian =
+      polarHistogramToCartesian(candidate_polar, Eigen::Vector3f(0.0f, 0.0f, 0.0f));
 
-  // goal costs
-  float yaw_cost =
-      cost_params.goal_cost_param * (projected_goal.topRows<2>() - projected_candidate.topRows<2>()).norm();
-  float pitch_cost_up = 0.0f;
-  float pitch_cost_down = 0.0f;
-  if (projected_candidate.z() > projected_goal.z()) {
-    pitch_cost_up = cost_params.goal_cost_param * std::abs(projected_goal.z() - projected_candidate.z());
-  } else {
-    pitch_cost_down = cost_params.goal_cost_param * std::abs(projected_goal.z() - projected_candidate.z());
-  }
-
-  // smooth costs
-  float yaw_cost_smooth =
-      cost_params.smooth_cost_param * (projected_last_wp.topRows<2>() - projected_candidate.topRows<2>()).norm();
-  float pitch_cost_smooth = cost_params.smooth_cost_param * std::abs(projected_last_wp.z() - projected_candidate.z());
-
-  // heading cost
-  float heading_cost =
-      cost_params.heading_cost_param * (projected_heading.topRows<2>() - projected_candidate.topRows<2>()).norm();
-
-  // distance cost
-  distance_cost = 0.0f;
-  if (obstacle_distance > 0.0f) {
-    distance_cost = 700.0f / obstacle_distance;
-  }
-
-  // combine costs
-  other_costs = 0.0f;
-  other_costs = yaw_cost + cost_params.height_change_cost_param_adapted * pitch_cost_up +
-                cost_params.height_change_cost_param * pitch_cost_down + yaw_cost_smooth + pitch_cost_smooth +
-                heading_cost;
+  const float velocity_cost =
+      cost_params.velocity_cost_param * (velocity.norm() - candidate_velocity_cartesian.normalized().dot(velocity));
+  const float yaw_cost =
+      cost_params.yaw_cost_param * (candidate_polar.z - facing_goal.z) * (candidate_polar.z - facing_goal.z);
+  const float pitch_cost =
+      cost_params.pitch_cost_param * (candidate_polar.e - facing_goal.e) * (candidate_polar.e - facing_goal.e);
+  const float d = cost_params.obstacle_cost_param - obstacle_distance;
+  const float distance_cost = obstacle_distance > 0 ? 5000.0f * (1 + d / sqrt(1 + d * d)) : 0.0f;
+  return std::pair<float, float>(distance_cost, velocity_cost + yaw_cost + pitch_cost);
 }
 
 bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
@@ -370,9 +336,8 @@ bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Ti
   }
 
   // step through the path until the point where we should be if we had traveled perfectly with velocity along it
-  float distance_left = std::max(0.1, (ros::Time::now() - path_generation_time).toSec() * velocity);
-
   Eigen::Vector3f path_segment = path[i - 3] - path[i - 2];
+  float distance_left = (ros::Time::now() - path_generation_time).toSec() * velocity;
   setpoint = path[i - 2] + (distance_left / path_segment.norm()) * path_segment;
 
   for (i = path.size() - 3; i > 0 && distance_left > path_segment.norm(); --i) {
@@ -380,7 +345,9 @@ bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Ti
     path_segment = path[i - 1] - path[i];
     setpoint = path[i] + (distance_left / path_segment.norm()) * path_segment;
   }
-  return i > 0;  // If we excited because we're passed the last node of the path, the path is no longer valid!
+
+  // If we excited because we're past the last node of the path, the path is no longer valid!
+  return distance_left < path_segment.norm();
 }
 
 void printHistogram(Histogram& histogram) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -300,7 +300,7 @@ void padPolarMatrix(const Eigen::MatrixXf& matrix, unsigned int n_lines_padding,
       matrix_padded.block(0, n_lines_padding, matrix_padded.rows(), n_lines_padding);
 }
 
-// costfunction for every free histogram cell
+// cost function for every histogram cell
 std::pair<float, float> costFunction(const PolarPoint& candidate_polar, float obstacle_distance,
                                      const Eigen::Vector3f& goal, const Eigen::Vector3f& position,
                                      const Eigen::Vector3f& velocity, const costParameters& cost_params) {
@@ -309,10 +309,11 @@ std::pair<float, float> costFunction(const PolarPoint& candidate_polar, float ob
   const Eigen::Vector3f candidate_velocity_cartesian =
       polarHistogramToCartesian(candidate_polar, Eigen::Vector3f(0.0f, 0.0f, 0.0f));
 
+  const float angle_diff = angleDifference(candidate_polar.z, facing_goal.z);
+
   const float velocity_cost =
       cost_params.velocity_cost_param * (velocity.norm() - candidate_velocity_cartesian.normalized().dot(velocity));
-  const float yaw_cost =
-      cost_params.yaw_cost_param * (candidate_polar.z - facing_goal.z) * (candidate_polar.z - facing_goal.z);
+  const float yaw_cost = cost_params.yaw_cost_param * angle_diff * angle_diff;
   const float pitch_cost =
       cost_params.pitch_cost_param * (candidate_polar.e - facing_goal.e) * (candidate_polar.e - facing_goal.e);
   const float d = cost_params.obstacle_cost_param - obstacle_distance;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -13,7 +13,7 @@ namespace avoidance {
 void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
                        const std::vector<pcl::PointCloud<pcl::PointXYZ>>& complete_cloud, const Box& histogram_box,
                        const std::vector<FOV>& fov, float yaw_fcu_frame_deg, float pitch_fcu_frame_deg,
-                       const Eigen::Vector3f& position, float min_realsense_dist, int max_age, float elapsed_s,
+                       const Eigen::Vector3f& position, float min_realsense_dist, float max_age, float elapsed_s,
                        int min_num_points_per_cell) {
   pcl::PointCloud<pcl::PointXYZI> old_cloud;
   std::swap(final_cloud, old_cloud);
@@ -39,7 +39,7 @@ void processPointcloud(pcl::PointCloud<pcl::PointXYZI>& final_cloud,
             Eigen::Vector2i p_ind = polarToHistogramIndex(p_pol, ALPHA_RES / 2);
             histogram_points_counter(p_ind.y(), p_ind.x())++;
             if (histogram_points_counter(p_ind.y(), p_ind.x()) == min_num_points_per_cell) {
-              final_cloud.points.push_back(toXYZI(toEigen(xyz), 0));
+              final_cloud.points.push_back(toXYZI(toEigen(xyz), 0.0f));
             }
           }
         }

--- a/local_planner/src/nodes/star_planner.cpp
+++ b/local_planner/src/nodes/star_planner.cpp
@@ -8,78 +8,31 @@
 
 namespace avoidance {
 
-StarPlanner::StarPlanner() : tree_age_(0) {}
+StarPlanner::StarPlanner() {}
 
 // set parameters changed by dynamic rconfigure
 void StarPlanner::dynamicReconfigureSetStarParams(const avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
   children_per_node_ = config.children_per_node_;
   n_expanded_nodes_ = config.n_expanded_nodes_;
   tree_node_distance_ = static_cast<float>(config.tree_node_distance_);
-  tree_discount_factor_ = static_cast<float>(config.tree_discount_factor_);
   max_path_length_ = static_cast<float>(config.box_radius_);
   smoothing_margin_degrees_ = static_cast<float>(config.smoothing_margin_degrees_);
+  tree_heuristic_weight_ = static_cast<float>(config.tree_heuristic_weight_);
 }
 
 void StarPlanner::setParams(costParameters cost_params) { cost_params_ = cost_params; }
 
-void StarPlanner::setLastDirection(const Eigen::Vector3f& projected_last_wp) { projected_last_wp_ = projected_last_wp; }
-
-void StarPlanner::setPose(const Eigen::Vector3f& pos, float curr_yaw_fcu_frame_deg) {
+void StarPlanner::setPose(const Eigen::Vector3f& pos, const Eigen::Vector3f& vel) {
   position_ = pos;
-  curr_yaw_histogram_frame_deg_ = wrapAngleToPlusMinus180(-curr_yaw_fcu_frame_deg + 90.0f);
+  velocity_ = vel;
 }
 
-void StarPlanner::setGoal(const Eigen::Vector3f& goal) {
-  goal_ = goal;
-  tree_age_ = 1000;
-}
+void StarPlanner::setGoal(const Eigen::Vector3f& goal) { goal_ = goal; }
 
 void StarPlanner::setPointcloud(const pcl::PointCloud<pcl::PointXYZI>& cloud) { cloud_ = cloud; }
 
-float StarPlanner::treeCostFunction(int node_number) const {
-  int origin = tree_[node_number].origin_;
-  float e = tree_[node_number].last_e_;
-  float z = tree_[node_number].last_z_;
-  Eigen::Vector3f origin_position = tree_[origin].getPosition();
-  PolarPoint goal_pol = cartesianToPolarHistogram(goal_, origin_position);
-
-  float target_cost = indexAngleDifference(z, goal_pol.z) +
-                      10.0f * indexAngleDifference(e, goal_pol.e);  // include effective direction?
-
-  float last_e = tree_[origin].last_e_;
-  float last_z = tree_[origin].last_z_;
-
-  float smooth_cost = 5.0f * (2.0f * indexAngleDifference(z, last_z) + 5.0f * indexAngleDifference(e, last_e));
-
-  float smooth_cost_to_old_tree = 0.0f;
-  if (tree_age_ < 10) {
-    int partner_node_idx = path_node_positions_.size() - 1 - tree_[node_number].depth_;
-    if (partner_node_idx >= 0) {
-      Eigen::Vector3f partner_node_position = path_node_positions_[partner_node_idx];
-      Eigen::Vector3f node_position = tree_[node_number].getPosition();
-      float dist = (partner_node_position - node_position).norm();
-      smooth_cost_to_old_tree = 200.0f * dist / (0.5f * static_cast<float>(tree_[node_number].depth_));
-    }
-  }
-
-  return std::pow(tree_discount_factor_, static_cast<float>(tree_[node_number].depth_)) *
-         (target_cost + smooth_cost + smooth_cost_to_old_tree);
-}
-
 float StarPlanner::treeHeuristicFunction(int node_number) const {
-  Eigen::Vector3f node_position = tree_[node_number].getPosition();
-  PolarPoint goal_pol = cartesianToPolarHistogram(goal_, node_position);
-
-  int origin = tree_[node_number].origin_;
-  Eigen::Vector3f origin_position = tree_[origin].getPosition();
-  float origin_goal_dist = (goal_ - origin_position).norm();
-  float goal_dist = (goal_ - node_position).norm();
-  float goal_cost = (goal_dist / origin_goal_dist - 0.9f) * 5000.0f;
-
-  float smooth_cost = 10.0f * (indexAngleDifference(goal_pol.z, tree_[node_number].last_z_) +
-                               indexAngleDifference(goal_pol.e, tree_[node_number].last_e_));
-
-  return std::pow(tree_discount_factor_, static_cast<float>(tree_[node_number].depth_)) * (smooth_cost + goal_cost);
+  return (goal_ - tree_[node_number].getPosition()).norm() * tree_heuristic_weight_;
 }
 
 void StarPlanner::buildLookAheadTree() {
@@ -96,14 +49,15 @@ void StarPlanner::buildLookAheadTree() {
   closed_set_.clear();
 
   // insert first node
-  tree_.push_back(TreeNode(0, 0, position_));
+  tree_.push_back(TreeNode(0, position_, velocity_));
   tree_.back().setCosts(treeHeuristicFunction(0), treeHeuristicFunction(0));
-  tree_.back().yaw_ = curr_yaw_histogram_frame_deg_;
-  tree_.back().last_z_ = tree_.back().yaw_;
 
   int origin = 0;
   for (int n = 0; n < n_expanded_nodes_ && is_expanded_node; n++) {
     Eigen::Vector3f origin_position = tree_[origin].getPosition();
+    Eigen::Vector3f origin_velocity = tree_[origin].getVelocity();
+    PolarPoint facing_goal = cartesianToPolarHistogram(goal_, origin_position);
+    float distance_to_goal = (goal_ - origin_position).norm();
 
     histogram.setZero();
     generateNewHistogram(histogram, cloud_, origin_position);
@@ -112,9 +66,8 @@ void StarPlanner::buildLookAheadTree() {
     cost_matrix.fill(0.f);
     cost_image_data.clear();
     candidate_vector.clear();
-    float yaw_fcu_frame_deg = wrapAngleToPlusMinus180(-tree_[origin].yaw_ + 90.0f);
-    getCostMatrix(histogram, goal_, origin_position, yaw_fcu_frame_deg, projected_last_wp_, cost_params_,
-                  smoothing_margin_degrees_, cost_matrix, cost_image_data);
+    getCostMatrix(histogram, goal_, origin_position, origin_velocity, cost_params_, smoothing_margin_degrees_,
+                  cost_matrix, cost_image_data);
     getBestCandidatesFromCostMatrix(cost_matrix, children_per_node_, candidate_vector);
 
     // add candidates as nodes
@@ -122,13 +75,13 @@ void StarPlanner::buildLookAheadTree() {
       tree_[origin].total_cost_ = HUGE_VAL;
     } else {
       // insert new nodes
-      int depth = tree_[origin].depth_ + 1;
       int children = 0;
       for (candidateDirection candidate : candidate_vector) {
-        PolarPoint p_pol(candidate.elevation_angle, candidate.azimuth_angle, tree_node_distance_);
+        PolarPoint candidate_polar = candidate.toPolar(tree_node_distance_);
+        Eigen::Vector3f node_location = polarHistogramToCartesian(candidate_polar, origin_position);
+        Eigen::Vector3f node_velocity = node_location - origin_position;  // todo: simulate!
 
         // check if another close node has been added
-        Eigen::Vector3f node_location = polarHistogramToCartesian(p_pol, origin_position);
         int close_nodes = 0;
         for (size_t i = 0; i < tree_.size(); i++) {
           float dist = (tree_[i].getPosition() - node_location).norm();
@@ -139,16 +92,10 @@ void StarPlanner::buildLookAheadTree() {
         }
 
         if (children < children_per_node_ && close_nodes == 0) {
-          tree_.push_back(TreeNode(origin, depth, node_location));
-          tree_.back().last_e_ = p_pol.e;
-          tree_.back().last_z_ = p_pol.z;
+          tree_.push_back(TreeNode(origin, node_location, node_velocity));
           float h = treeHeuristicFunction(tree_.size() - 1);
-          float c = treeCostFunction(tree_.size() - 1);
           tree_.back().heuristic_ = h;
-          tree_.back().total_cost_ = tree_[origin].total_cost_ - tree_[origin].heuristic_ + c + h;
-          Eigen::Vector3f diff = node_location - origin_position;
-          float yaw_radians = atan2(diff.y(), diff.x());
-          tree_.back().yaw_ = std::round((-yaw_radians * 180.0f / M_PI_F)) + 90.0f;
+          tree_.back().total_cost_ = tree_[origin].total_cost_ - tree_[origin].heuristic_ + candidate.cost + h;
           children++;
         }
       }
@@ -177,22 +124,21 @@ void StarPlanner::buildLookAheadTree() {
   // smoothing between trees
   int tree_end = origin;
   path_node_positions_.clear();
-  path_node_origins_.clear();
   while (tree_end > 0) {
-    path_node_origins_.push_back(tree_end);
     path_node_positions_.push_back(tree_[tree_end].getPosition());
     tree_end = tree_[tree_end].origin_;
   }
   path_node_positions_.push_back(tree_[0].getPosition());
-  path_node_origins_.push_back(0);
-  tree_age_ = 0;
 
   ROS_INFO("\033[0;35m[SP]Tree (%lu nodes, %lu path nodes, %lu expanded) calculated in %2.2fms.\033[0m", tree_.size(),
            path_node_positions_.size(), closed_set_.size(),
            static_cast<double>((std::clock() - start_time) / static_cast<double>(CLOCKS_PER_SEC / 1000)));
+
+#ifndef DISABLE_SIMULATION  // For large trees, this could be very slow!
   for (int j = 0; j < path_node_positions_.size(); j++) {
     ROS_DEBUG("\033[0;35m[SP] node %i : [ %f, %f, %f]\033[0m", j, path_node_positions_[j].x(),
               path_node_positions_[j].y(), path_node_positions_[j].z());
   }
+#endif
 }
 }

--- a/local_planner/src/nodes/tree_node.cpp
+++ b/local_planner/src/nodes/tree_node.cpp
@@ -2,28 +2,15 @@
 
 namespace avoidance {
 
-TreeNode::TreeNode()
-    : total_cost_{0.0f},
-      heuristic_{0.0f},
-      last_e_{0.0f},
-      last_z_{0.0f},
-      origin_{0},
-      depth_{0},
-      yaw_{0.0f},
-      closed_{false} {
+TreeNode::TreeNode() : total_cost_{0.0f}, heuristic_{0.0f}, origin_{0}, closed_{false} {
   position_ = Eigen::Vector3f::Zero();
+  velocity_ = Eigen::Vector3f::Zero();
 }
 
-TreeNode::TreeNode(int from, int d, const Eigen::Vector3f& pos)
-    : total_cost_{0.0f},
-      heuristic_{0.0f},
-      last_e_{0.0f},
-      last_z_{0.0f},
-      origin_{from},
-      depth_{d},
-      yaw_{0.0f},
-      closed_{false} {
+TreeNode::TreeNode(int from, const Eigen::Vector3f& pos, const Eigen::Vector3f& vel)
+    : total_cost_{0.0f}, heuristic_{0.0f}, origin_{from}, closed_{false} {
   position_ = pos;
+  velocity_ = vel;
 }
 
 void TreeNode::setCosts(float h, float c) {
@@ -32,4 +19,5 @@ void TreeNode::setCosts(float h, float c) {
 }
 
 Eigen::Vector3f TreeNode::getPosition() const { return position_; }
+Eigen::Vector3f TreeNode::getVelocity() const { return velocity_; }
 }

--- a/local_planner/test/test_local_planner.cpp
+++ b/local_planner/test/test_local_planner.cpp
@@ -27,14 +27,15 @@ class LocalPlannerTests : public ::testing::Test {
 
     // start with basic pose
     Eigen::Vector3f pos(0.f, 0.f, 0.f);
+    Eigen::Vector3f vel(0.f, 0.f, 0.f);
     Eigen::Quaternionf q(1.f, 0.f, 0.f, 0.f);
     planner.currently_armed_ = false;
-    planner.setPose(pos, q);
+    planner.setState(pos, vel, q);
 
     // rise to altitude
     planner.currently_armed_ = true;
     pos.z() = 30.f;
-    planner.setPose(pos, q);
+    planner.setState(pos, vel, q);
 
     // goal straight in front, 100m away
     Eigen::Vector3f goal(100.f, 0.f, 30.f);

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -377,22 +377,20 @@ TEST(PlannerFunctions, smoothMatrix) {
 TEST(PlannerFunctions, getCostMatrixNoObstacles) {
   // GIVEN: a position, goal and an empty histogram
   Eigen::Vector3f position(0.f, 0.f, 0.f);
+  Eigen::Vector3f velocity(1.f, 0.f, 0.f);  // despite some initial velocity orthogonal to the goal!
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
-  float heading = 0.f;
   costParameters cost_params;
-  cost_params.goal_cost_param = 2.f;
-  cost_params.smooth_cost_param = 1.5f;
-  cost_params.height_change_cost_param = 4.f;
-  cost_params.height_change_cost_param_adapted = 4.f;
+  cost_params.yaw_cost_param = 2.5f;
+  cost_params.pitch_cost_param = 10.0f;
+  cost_params.velocity_cost_param = 1200.f;
+  cost_params.obstacle_cost_param = 5.0f;
   Eigen::MatrixXf cost_matrix;
   Histogram histogram = Histogram(ALPHA_RES);
   float smoothing_radius = 30.f;
 
   // WHEN: we calculate the cost matrix from the input data
   std::vector<uint8_t> cost_image_data;
-  getCostMatrix(histogram, goal, position, heading, last_sent_waypoint, cost_params, smoothing_radius, cost_matrix,
-                cost_image_data);
+  getCostMatrix(histogram, goal, position, velocity, cost_params, smoothing_radius, cost_matrix, cost_image_data);
 
   // THEN: The minimum cost should be in the direction of the goal
   PolarPoint best_pol = cartesianToPolarHistogram(goal, position);
@@ -454,126 +452,85 @@ TEST(PlannerFunctions, getCostMatrixNoObstacles) {
 TEST(PlannerFunctions, CostfunctionGoalCost) {
   // GIVEN: a scenario with two different goal locations
   Eigen::Vector3f position(0.f, 0.f, 0.f);
+  Eigen::Vector3f velocity(0.f, 0.f, 0.f);
   Eigen::Vector3f goal_1(0.f, 5.f, 0.f);
   Eigen::Vector3f goal_2(3.f, 3.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
-  float heading = 0.f;
-  costParameters cost_params;
-  cost_params.goal_cost_param = 3.f;
-  cost_params.heading_cost_param = 0.5f;
-  cost_params.smooth_cost_param = 1.5f;
-  cost_params.height_change_cost_param = 4.f;
-  cost_params.height_change_cost_param_adapted = 4.f;
-  float obstacle_distance = 0.f;
-  float distance_cost_1, other_costs_1, distance_cost_2, other_costs_2;
 
-  Eigen::Vector2f candidate_1(0.f, 0.f);
+  costParameters cost_params;
+  cost_params.yaw_cost_param = 2.5f;
+  cost_params.pitch_cost_param = 10.0f;
+  cost_params.velocity_cost_param = 1200.f;
+  cost_params.obstacle_cost_param = 5.0f;
+  float obstacle_distance = 0.f;
+  std::pair<float, float> cost_1, cost_2;
+
+  PolarPoint candidate_1(0.f, 0.f, 1.0f);
 
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different goals
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal_1, position, heading, last_sent_waypoint,
-               cost_params, distance_cost_1, other_costs_1);
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal_2, position, heading, last_sent_waypoint,
-               cost_params, distance_cost_2, other_costs_2);
+  cost_1 = costFunction(candidate_1, obstacle_distance, goal_1, position, velocity, cost_params);
+  cost_2 = costFunction(candidate_1, obstacle_distance, goal_2, position, velocity, cost_params);
 
   // THEN: The cost in the case where the goal is in the cell direction should
   // be lower
-  EXPECT_LT(other_costs_1, other_costs_2);
+  EXPECT_LT(cost_1.second, cost_2.second);
 }
 
 TEST(PlannerFunctions, CostfunctionDistanceCost) {
   // GIVEN: a scenario with two different obstacle distances
   Eigen::Vector3f position(0.f, 0.f, 0.f);
+  Eigen::Vector3f velocity(0.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
-  float heading = 0.f;
+
   costParameters cost_params;
-  cost_params.goal_cost_param = 3.f;
-  cost_params.heading_cost_param = 0.5f;
-  cost_params.smooth_cost_param = 1.5f;
-  cost_params.height_change_cost_param = 4.f;
-  cost_params.height_change_cost_param_adapted = 4.f;
+  cost_params.yaw_cost_param = 2.5f;
+  cost_params.pitch_cost_param = 10.0f;
+  cost_params.velocity_cost_param = 1200.f;
+  cost_params.obstacle_cost_param = 5.0f;
   float distance_1 = 0.f;
   float distance_2 = 3.f;
   float distance_3 = 5.f;
-  float distance_cost_1, distance_cost_2, distance_cost_3, other_costs;
-
-  Eigen::Vector2f candidate_1(0.f, 0.f);
+  std::pair<float, float> cost_1, cost_2, cost_3;
+  PolarPoint candidate_1(0.f, 0.f, 1.0f);
 
   // WHEN: we calculate the cost of one cell for the same scenario but with two
   // different obstacle distance
-  costFunction(candidate_1.y(), candidate_1.x(), distance_1, goal, position, heading, last_sent_waypoint, cost_params,
-               distance_cost_1, other_costs);
-  costFunction(candidate_1.y(), candidate_1.x(), distance_2, goal, position, heading, last_sent_waypoint, cost_params,
-               distance_cost_2, other_costs);
-  costFunction(candidate_1.y(), candidate_1.x(), distance_3, goal, position, heading, last_sent_waypoint, cost_params,
-               distance_cost_3, other_costs);
+  cost_1 = costFunction(candidate_1, distance_1, goal, position, velocity, cost_params);
+  cost_2 = costFunction(candidate_1, distance_2, goal, position, velocity, cost_params);
+  cost_3 = costFunction(candidate_1, distance_3, goal, position, velocity, cost_params);
 
   // THEN: The distance cost for no obstacle should be zero and the distance
   // cost for the closer obstacle should be bigger
-  EXPECT_LT(distance_cost_1, distance_cost_2);
-  EXPECT_LT(distance_cost_3, distance_cost_2);
-  EXPECT_FLOAT_EQ(distance_cost_1, 0.f);
+  EXPECT_LT(cost_1.first, cost_2.first);
+  EXPECT_LT(cost_3.first, cost_2.first);
+  EXPECT_FLOAT_EQ(cost_1.first, 0.f);
 }
 
-TEST(PlannerFunctions, CostfunctionHeadingCost) {
+TEST(PlannerFunctions, CostfunctionVelocityCost) {
   // GIVEN: a scenario with two different initial headings
   Eigen::Vector3f position(0.f, 0.f, 0.f);
+  Eigen::Vector3f velocity_1(0.f, 1.f, 0.f);
+  Eigen::Vector3f velocity_2(1.f, 0.f, 0.f);
   Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint(0.f, 1.f, 0.f);
-  float heading_1 = 60.f;  // in fcu frame: 90deg yaw is toward the goal
-  float heading_2 = 30.f;
-  costParameters cost_params;
-  cost_params.goal_cost_param = 3.f;
-  cost_params.heading_cost_param = 0.5f;
-  cost_params.smooth_cost_param = 1.5f;
-  cost_params.height_change_cost_param = 4.f;
-  cost_params.height_change_cost_param_adapted = 4.f;
-  float obstacle_distance = 0.f;
-  float distance_cost, other_costs_1, other_costs_2;
 
-  Eigen::Vector2f candidate_1(0.f, 0.f);
+  costParameters cost_params;
+  cost_params.yaw_cost_param = 2.5f;
+  cost_params.pitch_cost_param = 10.0f;
+  cost_params.velocity_cost_param = 1200.f;
+  cost_params.obstacle_cost_param = 5.0f;
+  float obstacle_distance = 0.f;
+  std::pair<float, float> cost_1, cost_2;
+
+  PolarPoint candidate_1(0.f, 0.f, 1.0f);
 
   // WHEN: we calculate the cost of one cell for the same scenario but with two
-  // different initial headings
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal, position, heading_1, last_sent_waypoint,
-               cost_params, distance_cost, other_costs_1);
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal, position, heading_2, last_sent_waypoint,
-               cost_params, distance_cost, other_costs_2);
+  // different initial velocities
+  cost_1 = costFunction(candidate_1, obstacle_distance, goal, position, velocity_1, cost_params);
+  cost_2 = costFunction(candidate_1, obstacle_distance, goal, position, velocity_2, cost_params);
 
   // THEN: The cost in the case where the initial heading is closer to the
   // candidate should be lower
-  EXPECT_LT(other_costs_1, other_costs_2);
-}
-
-TEST(PlannerFunctions, CostfunctionSmoothingCost) {
-  // GIVEN: a scenario with two different initial headings
-  Eigen::Vector3f position(0.f, 0.f, 0.f);
-  Eigen::Vector3f goal(0.f, 5.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint_1(1.f, 2.f, 0.f);
-  Eigen::Vector3f last_sent_waypoint_2(1.5f, 1.5f, 0.f);
-  float heading = 0.f;
-  costParameters cost_params;
-  cost_params.goal_cost_param = 3.f;
-  cost_params.heading_cost_param = 0.5f;
-  cost_params.smooth_cost_param = 1.5f;
-  cost_params.height_change_cost_param = 4.f;
-  cost_params.height_change_cost_param_adapted = 4.f;
-  float obstacle_distance = 0.f;
-  float distance_cost, other_costs_1, other_costs_2;
-
-  Eigen::Vector2f candidate_1(0.f, 0.f);
-
-  // WHEN: we calculate the cost of one cell for the same scenario but with two
-  // different last waypoints
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal, position, heading, last_sent_waypoint_1,
-               cost_params, distance_cost, other_costs_1);
-  costFunction(candidate_1.y(), candidate_1.x(), obstacle_distance, goal, position, heading, last_sent_waypoint_2,
-               cost_params, distance_cost, other_costs_2);
-
-  // THEN: The cost in the case where the last waypoint is closer to the
-  // candidate should be lower
-  EXPECT_LT(other_costs_1, other_costs_2);
+  EXPECT_LT(cost_1.second, cost_2.second);
 }
 
 TEST(Histogram, HistogramDownsampleCorrectUsage) {

--- a/local_planner/test/test_star_planner.cpp
+++ b/local_planner/test/test_star_planner.cpp
@@ -20,6 +20,7 @@ class StarPlannerTests : public ::testing::Test {
   float obstacle_y = 2.0f;
   Eigen::Vector3f goal;
   Eigen::Vector3f position;
+  Eigen::Vector3f velocity;
 
   void SetUp() override {
     ros::Time::init();
@@ -27,11 +28,16 @@ class StarPlannerTests : public ::testing::Test {
     avoidance::LocalPlannerNodeConfig config = avoidance::LocalPlannerNodeConfig::__getDefault__();
     config.children_per_node_ = 2;
     config.n_expanded_nodes_ = 10;
+    config.tree_node_distance_ = 1.0;
     star_planner.dynamicReconfigureSetStarParams(config, 1);
 
     position.x() = 1.2f;
     position.y() = 0.4f;
     position.z() = 4.0f;
+
+    velocity.x() = 0.0f;
+    velocity.y() = 0.0f;
+    velocity.z() = 0.0f;
 
     goal.x() = 2.0f;
     goal.y() = 14.0f;
@@ -47,7 +53,7 @@ class StarPlannerTests : public ::testing::Test {
 
     star_planner.setParams(cost_params);
     star_planner.setPointcloud(cloud);
-    star_planner.setPose(position, 0.0f);
+    star_planner.setPose(position, velocity);
     star_planner.setGoal(goal);
   }
   void TearDown() override {}
@@ -81,193 +87,8 @@ TEST_F(StarPlannerTests, buildTree) {
     // we set the vehicle position to be the first node position after the
     // origin for the next algorithm iterarion
     position = star_planner.tree_[1].getPosition();
-    star_planner.setPose(position, 0.0f);
+    star_planner.setPose(position, velocity);
   }
 }
 
-TEST_F(StarPlannerBasicTests, treeCostFunctionTargetCost) {
-  // GIVEN: a tree, the last path and two different goal locations
-  Eigen::Vector3f goal1(5.f, 1.f, 0.f);
-  Eigen::Vector3f goal2(5.f, 3.f, 0.f);
-
-  // insert tree root
-  Eigen::Vector3f tree_root(0.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 0, tree_root));
-  tree_.back().yaw_ = 90.0;  // drone looks straight ahead
-  tree_.back().last_z_ = tree_.back().yaw_;
-
-  // insert first Node
-  Eigen::Vector3f node1(1.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 1, node1));
-  tree_.back().last_e_ = 0.f;
-  tree_.back().last_z_ = 90.f;
-
-  // last path equal to the given nodes
-  std::vector<Eigen::Vector3f> path_node_positions_;
-  path_node_positions_.push_back(node1);
-  path_node_positions_.push_back(tree_root);
-
-  // WHEN: we calculate the cost of node 1 for two different goal locations
-  setGoal(goal1);
-  tree_age_ = 1;
-  float cost1 = treeCostFunction(1);
-  setGoal(goal2);
-  tree_age_ = 1;
-  float cost2 = treeCostFunction(1);
-
-  // THEN: The cost1 should be less than cost2, as in case 1 the node heads
-  // closer to the goal
-  EXPECT_GT(cost2, cost1);
-}
-
-TEST_F(StarPlannerBasicTests, treeCostFunctionOldPathCost) {
-  // GIVEN: a tree, a goal and the last path
-  StarPlanner star_planner;
-  Eigen::Vector3f goal(5.f, 0.f, 0.f);
-  setGoal(goal);
-  tree_age_ = 1;
-
-  // insert tree root
-  Eigen::Vector3f tree_root(0.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 0, tree_root));
-  tree_.back().yaw_ = 90.0;  // drone looks straight ahead
-  tree_.back().last_z_ = tree_.back().yaw_;
-
-  // insert first Node
-  Eigen::Vector3f node1(1.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 1, node1));
-  tree_.back().last_e_ = 0.f;
-  tree_.back().last_z_ = 90.f;
-
-  // last path case 1: equal to the current nodes
-  std::vector<Eigen::Vector3f> path_node_positions1;
-  path_node_positions1.push_back(node1);
-  path_node_positions1.push_back(tree_root);
-
-  // last path case 2: different from current nodes
-  Eigen::Vector3f node1_old(0.5f, 0.5f, 0.f);
-  std::vector<Eigen::Vector3f> path_node_positions2;
-  path_node_positions2.push_back(node1_old);
-  path_node_positions2.push_back(tree_root);
-
-  // WHEN: we calculate the cost of node 1 for two different old paths
-  path_node_positions_ = path_node_positions1;
-  float cost1 = treeCostFunction(1);
-  path_node_positions_ = path_node_positions2;
-  float cost2 = treeCostFunction(1);
-
-  // THEN: The cost1 should be less than cost2, as in case 1 the node lies
-  // closer to the path of the last iteration
-  EXPECT_GT(cost2, cost1);
-}
-
-TEST_F(StarPlannerBasicTests, treeCostFunctionYawCost) {
-  // GIVEN: a tree, a goal and the last path
-  StarPlanner star_planner;
-  Eigen::Vector3f goal(5.f, 0.f, 0.f);
-  setGoal(goal);
-  tree_age_ = 1;
-
-  // insert tree root
-  Eigen::Vector3f tree_root(0.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 0, tree_root));
-  tree_.back().yaw_ = 90;  // drone looks straight ahead
-  tree_.back().last_z_ = tree_.back().yaw_;
-
-  // insert two nodes to both sides
-  PolarPoint node1_pol(0, 110, 1);  // to the right
-  PolarPoint node2_pol(0, 70, 1);   // to the left
-  Eigen::Vector3f node1 = polarHistogramToCartesian(node1_pol, tree_root);
-  Eigen::Vector3f node2 = polarHistogramToCartesian(node2_pol, tree_root);
-
-  tree_.push_back(TreeNode(0, 1, node1));
-  tree_.back().last_e_ = node1_pol.e;
-  tree_.back().last_z_ = node1_pol.z;
-
-  tree_.push_back(TreeNode(0, 1, node2));
-  tree_.back().last_e_ = node2_pol.e;
-  tree_.back().last_z_ = node2_pol.z;
-
-  // last path straight ahead
-  Eigen::Vector3f node_old(1.f, 0.f, 0.f);
-  path_node_positions_.clear();
-  path_node_positions_.push_back(node_old);
-  path_node_positions_.push_back(tree_root);
-
-  // WHEN: we calculate the cost for both nodes as the drone looks straight
-  // ahead
-  float cost1_straight = treeCostFunction(1);
-  float cost2_straight = treeCostFunction(2);
-
-  // WHEN: we calculate the cost for both nodes as the drone looks to the right
-  tree_[0].yaw_ = 100;  // drone looks 10 degrees to the right
-  tree_[0].last_z_ = tree_[0].yaw_;
-  float cost1_right = treeCostFunction(1);
-  float cost2_right = treeCostFunction(2);
-
-  // WHEN: we calculate the cost for both nodes as the drone looks to the left
-  tree_[0].yaw_ = 80;  // drone looks 10 degrees to the right
-  tree_[0].last_z_ = tree_[0].yaw_;
-  float cost1_left = treeCostFunction(1);
-  float cost2_left = treeCostFunction(2);
-
-  // THEN: case 1: drone looks straight ahead, nodes symmetrical to the left and
-  // right should have same costs
-  //       case 2: drone looks to the right, node to the right should be cheaper
-  //       case 3: drone looks to the left, node to the left should be cheaper
-  //       and costs should be symmetrical as well
-  EXPECT_FLOAT_EQ(cost2_straight, cost1_straight);
-  EXPECT_GT(cost2_right, cost1_right);
-  EXPECT_GT(cost1_left, cost2_left);
-  EXPECT_FLOAT_EQ(cost2_left, cost1_right);
-  EXPECT_FLOAT_EQ(cost1_left, cost2_right);
-}
-
-TEST_F(StarPlannerBasicTests, treeCostFunctionSmoothingCost) {
-  // GIVEN: a tree, a goal
-  StarPlanner star_planner;
-  path_node_positions_.clear();
-
-  // insert tree root
-  Eigen::Vector3f tree_root(0.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 0, tree_root));
-  tree_.back().last_z_ = 90;
-
-  // insert first node (straight ahead)
-  Eigen::Vector3f node1(1.f, 0.f, 0.f);
-  tree_.push_back(TreeNode(0, 1, node1));
-  tree_.back().last_e_ = 0.f;
-  tree_.back().last_z_ = 90.f;
-
-  // insert two more nodes with node 1 as origin
-  PolarPoint node2_pol(0, 100, 1);
-  PolarPoint node3_pol(0, 110, 1);
-  Eigen::Vector3f node2 = polarHistogramToCartesian(node2_pol, node1);
-  Eigen::Vector3f node3 = polarHistogramToCartesian(node3_pol, node1);
-
-  tree_.push_back(TreeNode(1, 2, node2));
-  tree_.back().last_e_ = node2_pol.e;
-  tree_.back().last_z_ = node2_pol.z;
-
-  tree_.push_back(TreeNode(1, 2, node3));
-  tree_.back().last_e_ = node3_pol.e;
-  tree_.back().last_z_ = node3_pol.z;
-
-  // calculate two goal positions in direction of the nodes 2, 3
-  PolarPoint goal2_pol(0, 100, 5);
-  PolarPoint goal3_pol(0, 110, 5);
-  Eigen::Vector3f goal2 = polarHistogramToCartesian(goal2_pol, node1);
-  Eigen::Vector3f goal3 = polarHistogramToCartesian(goal3_pol, node1);
-
-  // WHEN: we calculate the cost for nodes 2, 3
-  setGoal(goal2);
-  tree_[0].yaw_ = 100;
-  float cost2 = treeCostFunction(2);
-  setGoal(goal3);
-  tree_[0].yaw_ = 110;
-  float cost3 = treeCostFunction(3);
-
-  // THEN: the path node with the more curved path (node 3) should be more
-  // expensive
-  EXPECT_GT(cost3, cost2);
-}
+TEST_F(StarPlannerTests, heuristicFunction) {}


### PR DESCRIPTION
These are some pretty drastic (and for now, experimental) changes on the algorithmic side:

- We always plan to the sensor horizon (#374 )
- The tree generation as well as the "next node to add" decision are now based on the same cost function
- The "tree cost function" was removed completely
- The "histogramic cost function" was reduced in complexity by orders of magnitude. It now does basically only a decision based on "direction to goal" vs. "distance to obstacles". We should probably re-introduce one term that takes into account current velocity
- The tree heuristic was reduced in complexity as well, now just cartesian distance to goal (very common heuristic for A* path planning)

This brutally rips out tons of sophisticated logic, yet somehow it flies surprisingly well in SITL