### PR TITLE
Global Planner Cleanup

### DIFF
--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -142,7 +142,6 @@ class GlobalPlannerNode {
   void positionCallback(const geometry_msgs::PoseStamped& msg);
   void clickedPointCallback(const geometry_msgs::PointStamped& msg);
   void moveBaseSimpleCallback(const geometry_msgs::PoseStamped& msg);
-  void laserSensorCallback(const sensor_msgs::LaserScan& msg);
   void octomapFullCallback(const octomap_msgs::Octomap& msg);
   void depthCameraCallback(const sensor_msgs::PointCloud2& msg);
   void fcuInputGoalCallback(const mavros_msgs::Trajectory& msg);
@@ -150,7 +149,6 @@ class GlobalPlannerNode {
   void plannerLoopCallback(const ros::TimerEvent& event);
   void publishGoal(const GoalCell& goal);
   void publishPath();
-  void publishExploredCells();
   void publishSetpoint();
   void printPointInfo(double x, double y, double z);
 };

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -359,7 +359,6 @@ void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
   }
 
   publishPath();
-  publishExploredCells();
 }
 
 // Publish the position of goal
@@ -389,42 +388,6 @@ void GlobalPlannerNode::publishPath() {
   global_temp_path_pub_.publish(simple_path_msg);
   setCurrentPath(simple_path_msg.poses);
   smooth_path_pub_.publish(smoothPath(simple_path_msg));
-}
-
-// Publish the cells that were explored in the last search
-// Can be tweeked to publish other info (path_cells)
-void GlobalPlannerNode::publishExploredCells() {
-  visualization_msgs::MarkerArray msg;
-
-  // The first marker deletes the ones from previous search
-  int id = 0;
-  visualization_msgs::Marker marker;
-  marker.id = id;
-  marker.action = 3;  // same as visualization_msgs::Marker::DELETEALL
-  msg.markers.push_back(marker);
-
-  id = 1;
-  for (const auto& cell : global_planner_.visitor_.seen_) {
-    // for (auto const& x : global_planner_.bubble_risk_cache_) {
-    // Cell cell = x.first;
-
-    // double hue = (cell.zPos()-1.0) / 7.0;                // height from 1 to
-    // 8 meters double hue = 0.5;                                    // single
-    // color (green) double hue = global_planner_.getHeuristic(Node(cell, cell),
-    // global_planner_.goal_pos_) / global_planner_.curr_path_info_.cost; The
-    // color is the square root of the risk, shows difference in low risk
-    double hue = std::sqrt(global_planner_.getRisk(cell));
-    auto color = spectralColor(hue);
-    if (!global_planner_.octree_->search(cell.xPos(), cell.yPos(), cell.zPos())) {
-      // Unknown space
-      color.r = color.g = color.b = 0.2;  // Dark gray
-    }
-    visualization_msgs::Marker marker = createMarker(id++, cell.toPoint(), color);
-
-    // risk from 0% to 100%, sqrt is used to increase difference in low risk
-    msg.markers.push_back(marker);
-  }
-  explored_cells_pub_.publish(msg);
 }
 
 // Prints information about the point, mostly the risk of the containing cell

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -276,12 +276,6 @@ void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   bool current_path_is_ok = global_planner_.updateFullOctomap(msg);
-  if (!current_path_is_ok) {
-    ROS_INFO("  Path is bad, planning a new path \n");
-    if (global_planner_.goal_pos_.is_temporary_) {
-      popNextGoal();  // Throw away temporary goal
-    }
-  }
 }
 
 // Go through obstacle points and store them

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -427,28 +427,6 @@ int main(int argc, char** argv) {
 
   global_planner::GlobalPlannerNode global_planner_node(nh, nh_private);
 
-  // Read waypoints from file, if any
-  ros::V_string args;
-  ros::removeROSArgs(argc, argv, args);
-
-  if (args.size() > 1) {
-    ROS_INFO("    ARGS: %s", args.at(1).c_str());
-    std::ifstream wp_file(args.at(1).c_str());
-    if (wp_file.is_open()) {
-      double x, y, z;
-      while (wp_file >> x >> y >> z) {
-        global_planner_node.waypoints_.push_back(global_planner::Cell(x, y, z));
-      }
-      wp_file.close();
-      ROS_INFO("  Read %d waypoints.", static_cast<int>(global_planner_node.waypoints_.size()));
-    } else {
-      ROS_ERROR_STREAM("Unable to open goal file: " << args.at(1));
-      return -1;
-    }
-  } else {
-    ROS_INFO("  No goal file given.");
-  }
-
   ros::spin();
   return 0;
 }


### PR DESCRIPTION
This PR removes unsupported functionalities and minor functional fixes

- Removes waypoint file reading - This should be done through the flight controller, not from the avoidance package
- Remove support for laser scanner - Currently there is no usecase for using `sensor_msgs::LaserScan` and currently not being tested
- Do not pop next goal when there is a octomap update
- Do not publish explored cells - This is currently not being used