### PR TITLE
Refactor getDirectionFromTree

### DIFF
--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -148,7 +148,7 @@ void printHistogram(const Histogram& histogram);
 
 /**
 * @brief      Returns a setpoint that lies on the given path
-* @param[in]  vector of nodes defining the path
+* @param[in]  vector of nodes defining the path, with the last node of the path at index 0
 * @param[in]  ros time of path generation
 * @param[in]  velocity, scalar value for the norm of the current vehicle velocity
 * @param[out] setpoint on the tree toward which the drone should fly

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -147,14 +147,14 @@ Eigen::ArrayXf getConicKernel(int radius);
 void printHistogram(const Histogram& histogram);
 
 /**
-* @brief      finds the minimum cost direction in the tree
-* @param[in]  vector of nodes defining the tree
-* @param[in]  ros time of tree generation
-* @param[in]  velocity, scalar value for the current vehicle velocitz
+* @brief      Returns a setpoint that lies on the given path
+* @param[in]  vector of nodes defining the path
+* @param[in]  ros time of path generation
+* @param[in]  velocity, scalar value for the norm of the current vehicle velocity
 * @param[out] setpoint on the tree toward which the drone should fly
 * @returns    boolean indicating whether the tree was valid
 **/
-bool getSetpointFromTree(const std::vector<Eigen::Vector3f>& tree, const ros::Time& tree_generation_time,
+bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
                          float velocity, Eigen::Vector3f& setpoint);
 }
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -148,11 +148,13 @@ void printHistogram(const Histogram& histogram);
 
 /**
 * @brief      finds the minimum cost direction in the tree
-* @param[out] p_pol, polar coordinates of the cheapest direction
-* @param[in]  path_node_positions, array of expanded tree nodes
-* @param[in]  position, current vehicle position
+* @param[in]  vector of nodes defining the tree
+* @param[in]  ros time of tree generation
+* @param[in]  velocity, scalar value for the current vehicle velocitz
+* @param[out] setpoint on the tree toward which the drone should fly
+* @returns    boolean indicating whether the tree was valid
 **/
-bool getDirectionFromTree(PolarPoint& p_pol, const std::vector<Eigen::Vector3f>& path_node_positions,
-                          const Eigen::Vector3f& position, const Eigen::Vector3f& goal);
+bool getSetpointFromTree(const std::vector<Eigen::Vector3f>& tree, const ros::Time& tree_generation_time,
+                         float velocity, Eigen::Vector3f& setpoint);
 }
 #endif  // LOCAL_PLANNER_FUNCTIONS_H

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -355,9 +355,9 @@ void costFunction(float e_angle, float z_angle, float obstacle_distance, const E
                 heading_cost;
 }
 
-bool getSetpointFromTree(const std::vector<Eigen::Vector3f>& tree, const ros::Time& tree_generation_time,
+bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
                          float velocity, Eigen::Vector3f& setpoint) {
-  int i = tree.size();
+  int i = path.size();
   // path contains nothing meaningful
   if (i < 2) {
     return false;
@@ -365,22 +365,22 @@ bool getSetpointFromTree(const std::vector<Eigen::Vector3f>& tree, const ros::Ti
 
   // path only has one segment: return end of that segment as setpoint
   if (i == 2) {
-    setpoint = tree[0];
+    setpoint = path[0];
     return true;
   }
 
-  // step through the tree until the point where we should be if we had traveled perfectly with velocity along it
-  float distance_left = std::max(0.1, (ros::Time::now() - tree_generation_time).toSec() * velocity);
+  // step through the path until the point where we should be if we had traveled perfectly with velocity along it
+  float distance_left = std::max(0.1, (ros::Time::now() - path_generation_time).toSec() * velocity);
 
-  Eigen::Vector3f tree_segment = tree[i - 3] - tree[i - 2];
-  setpoint = tree[i - 2] + (distance_left / tree_segment.norm()) * tree_segment;
+  Eigen::Vector3f path_segment = path[i - 3] - path[i - 2];
+  setpoint = path[i - 2] + (distance_left / path_segment.norm()) * path_segment;
 
-  for (i = tree.size() - 3; i > 0 && distance_left > tree_segment.norm(); --i) {
-    distance_left -= tree_segment.norm();
-    tree_segment = tree[i - 1] - tree[i];
-    setpoint = tree[i] + (distance_left / tree_segment.norm()) * tree_segment;
+  for (i = path.size() - 3; i > 0 && distance_left > path_segment.norm(); --i) {
+    distance_left -= path_segment.norm();
+    path_segment = path[i - 1] - path[i];
+    setpoint = path[i] + (distance_left / path_segment.norm()) * path_segment;
   }
-  return i > 0;  // If we excited because we're passed the last node of the tree, the tree is no longer valid!
+  return i > 0;  // If we excited because we're passed the last node of the path, the path is no longer valid!
 }
 
 void printHistogram(Histogram& histogram) {

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -355,74 +355,25 @@ void costFunction(float e_angle, float z_angle, float obstacle_distance, const E
                 heading_cost;
 }
 
-bool getDirectionFromTree(PolarPoint& p_pol, const std::vector<Eigen::Vector3f>& path_node_positions,
-                          const Eigen::Vector3f& position, const Eigen::Vector3f& goal) {
-  int size = path_node_positions.size();
-  bool tree_available = true;
-
-  if (size > 1) {  // path contains at least 2 points (current position and one wp)
-
-    // extend path with a node at the end in goal direction (for smoother
-    // transition to direct flight)
-    float node_distance = (path_node_positions[0] - path_node_positions[1]).norm();
-    Eigen::Vector3f dir_last_node_to_goal = (goal - path_node_positions[0]).normalized();
-    Eigen::Vector3f goal_node = path_node_positions[0] + node_distance * dir_last_node_to_goal;
-    std::vector<Eigen::Vector3f> path_node_positions_extended;
-    path_node_positions_extended.push_back(goal_node);
-    path_node_positions_extended.insert(path_node_positions_extended.end(), path_node_positions.begin(),
-                                        path_node_positions.end());
-    int size_extended = path_node_positions_extended.size();
-
-    // find path nodes between which the drone is currently located:
-    // a vector with the distances of each node to the drone is generated
-    // the indices of the nodes with smallest and next smallest distance are
-    // found
-    int min_dist_idx = 0;
-    int second_min_dist_idx = 0;
-    float min_dist = HUGE_VAL;
-    float second_min_dist = HUGE_VAL;
-    std::vector<float> distances;
-    distances.reserve(size_extended);
-
-    for (int i = 0; i < size_extended; i++) {
-      distances.push_back((position - path_node_positions_extended[i]).norm());
-      if (distances[i] < min_dist) {
-        second_min_dist_idx = min_dist_idx;
-        second_min_dist = min_dist;
-        min_dist = distances[i];
-        min_dist_idx = i;
-      } else if (distances[i] < second_min_dist) {
-        second_min_dist = distances[i];
-        second_min_dist_idx = i;
-      }
-    }
-
-    // the drone is located between the two nodes(min_dist_idx,
-    // second_min_dist_idx),
-    // wp_idx describes the node further ahead in the path
-    int wp_idx = std::min(min_dist_idx, second_min_dist_idx);
-
-    // if drone is too far away from tree or already at last node -> don't use
-    // tree
-    if (min_dist > 3.0f || wp_idx == 0) {
-      tree_available = false;
-    } else {
-      float cos_alpha = (node_distance * node_distance + distances[wp_idx] * distances[wp_idx] -
-                         distances[wp_idx + 1] * distances[wp_idx + 1]) /
-                        (2.0f * node_distance * distances[wp_idx]);
-      float l_front = distances[wp_idx] * cos_alpha;
-      float l_frac = l_front / node_distance;
-
-      Eigen::Vector3f mean_point =
-          (1.f - l_frac) * path_node_positions_extended[wp_idx - 1] + l_frac * path_node_positions_extended[wp_idx];
-
-      p_pol = cartesianToPolarHistogram(mean_point, position);
-      p_pol.r = 0.0f;
-    }
-  } else {
-    tree_available = false;
+bool getSetpointFromTree(const std::vector<Eigen::Vector3f>& tree, const ros::Time& tree_generation_time,
+                         float velocity, Eigen::Vector3f& setpoint) {
+  int i = tree.size();
+  // path contains nothing meaningful
+  if (i < 2) {
+    return false;
   }
-  return tree_available;
+
+  // step through the tree until the point where we should be if we had traveled perfectly with velocity along it
+  float distance_left = std::max(0.1, (ros::Time::now() - tree_generation_time).toSec() * velocity);
+  setpoint = tree[i - 2];
+  Eigen::Vector3f tree_segment = tree[i - 2] - tree[i - 1];
+
+  for (i = tree.size() - 2; i > 0 && distance_left > tree_segment.norm(); --i) {
+    distance_left -= tree_segment.norm();
+    tree_segment = tree[i - 1] - tree[i];
+    setpoint = tree[i - 1];
+  }
+  return true;
 }
 
 void printHistogram(Histogram& histogram) {

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -34,7 +34,7 @@ void WaypointGenerator::calculateWaypoint() {
 
     case tryPath: {
       Eigen::Vector3f setpoint = position_;
-      if (getSetpointFromTree(planner_info_.path_node_positions, planner_info_.last_path_time,
+      if (getSetpointFromPath(planner_info_.path_node_positions, planner_info_.last_path_time,
                               planner_info_.cruise_velocity, setpoint)) {
         output_.goto_position = position_ + (setpoint - position_).normalized();
         ROS_DEBUG("[WG] Using calculated tree\n");

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -33,15 +33,11 @@ void WaypointGenerator::calculateWaypoint() {
     }
 
     case tryPath: {
-      PolarPoint p_pol(0.0f, 0.0f, 0.0f);
-      bool tree_available = getDirectionFromTree(p_pol, planner_info_.path_node_positions, position_, goal_);
-
-      float dist_goal = (goal_ - position_).norm();
-      ros::Duration since_last_path = getSystemTime() - planner_info_.last_path_time;
-      if (tree_available && (planner_info_.obstacle_ahead || dist_goal > 4.0f) && since_last_path < ros::Duration(5)) {
-        ROS_DEBUG("[WG] Use calculated tree\n");
-        p_pol.r = 1.0;
-        output_.goto_position = polarHistogramToCartesian(p_pol, position_);
+      Eigen::Vector3f setpoint = position_;
+      if (getSetpointFromTree(planner_info_.path_node_positions, planner_info_.last_path_time,
+                              planner_info_.cruise_velocity, setpoint)) {
+        output_.goto_position = position_ + (setpoint - position_).normalized();
+        ROS_DEBUG("[WG] Using calculated tree\n");
       } else {
         ROS_DEBUG("[WG] No valid tree, going straight");
         output_.waypoint_type = direct;

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -151,28 +151,36 @@ TEST(PlannerFunctions, testDirectionTree) {
   Eigen::Vector3f sp1, sp2, sp3;
 
   // WHEN: we look for the best direction to fly towards
-  bool res = getSetpointFromTree(path_node_positions, t1, velocity, sp1);  // very short time should still return node 0
+  bool res = getSetpointFromTree(path_node_positions, t1, velocity, sp1);  // very short time should still return node 1
   bool res1 = getSetpointFromTree(path_node_positions, t2, velocity, sp2);
   bool res2 = getSetpointFromTree(path_node_positions, t3, velocity, sp3);  // should be second node on tree
   bool res3 = getSetpointFromTree(empty_tree, t1, velocity, sp1);
 
-  // THEN: we expect a direction in between node n1 and n2 for position, between
-  // node n3 and n4 for position1, and not to get an available tree for the
-  // position2
+  // THEN: we expect the setpoint in between node n1 and n2 for t1 and t2 between
+  // node n2 and n3 for t3, and not to get an available tree for the empty tree
   ASSERT_TRUE(res);
-  EXPECT_FLOAT_EQ(sp1.x(), n1.x());
-  EXPECT_FLOAT_EQ(sp1.y(), n1.y());
-  EXPECT_FLOAT_EQ(sp1.z(), n1.z());
+  EXPECT_GE(sp1.x(), n1.x());
+  EXPECT_LE(sp1.x(), n2.x());
+  EXPECT_GE(sp1.y(), n1.y());
+  EXPECT_LE(sp1.y(), n2.y());
+  EXPECT_GE(sp1.z(), n1.z());
+  EXPECT_LE(sp1.z(), n2.z());
 
   ASSERT_TRUE(res1);
-  EXPECT_FLOAT_EQ(sp2.x(), n1.x());
-  EXPECT_FLOAT_EQ(sp2.y(), n1.y());
-  EXPECT_FLOAT_EQ(sp2.z(), n1.z());
+  EXPECT_GE(sp2.x(), n1.x());
+  EXPECT_LE(sp2.x(), n2.x());
+  EXPECT_GE(sp2.y(), n1.y());
+  EXPECT_LE(sp2.y(), n2.y());
+  EXPECT_GE(sp2.z(), n1.z());
+  EXPECT_LE(sp2.z(), n2.z());
 
   ASSERT_TRUE(res2);
-  EXPECT_FLOAT_EQ(sp3.x(), n2.x());
-  EXPECT_FLOAT_EQ(sp3.y(), n2.y());
-  EXPECT_FLOAT_EQ(sp3.z(), n2.z());
+  EXPECT_GE(sp3.x(), n2.x());
+  EXPECT_LE(sp3.x(), n3.x());
+  EXPECT_GE(sp3.y(), n2.y());
+  EXPECT_LE(sp3.y(), n3.y());
+  EXPECT_GE(sp3.z(), n2.z());
+  EXPECT_LE(sp3.z(), n3.z());
 
   ASSERT_FALSE(res3);
 }

--- a/local_planner/test/test_planner_functions.cpp
+++ b/local_planner/test/test_planner_functions.cpp
@@ -129,8 +129,8 @@ TEST(PlannerFunctionsTests, processPointcloud) {
   EXPECT_EQ(6, processed_cloud3.size());
 }
 
-TEST(PlannerFunctions, testDirectionTree) {
-  // GIVEN: the node positions in a tree and some possible vehicle positions
+TEST(PlannerFunctions, getSetpointFromPath) {
+  // GIVEN: the node positions in a path and some possible vehicle positions
   float n1_x = 0.8f;
   float n2_x = 1.5f;
   float n3_x = 2.1f;
@@ -141,7 +141,7 @@ TEST(PlannerFunctions, testDirectionTree) {
   Eigen::Vector3f n3(n3_x, n2.y() + sqrtf(1 - powf(n3_x - n2.x(), 2)), 2.5f);
   Eigen::Vector3f n4(n4_x, n3.y() + sqrtf(1 - powf(n4_x - n3.x(), 2)), 2.5f);
   const std::vector<Eigen::Vector3f> path_node_positions = {n4, n3, n2, n1, n0};
-  const std::vector<Eigen::Vector3f> empty_tree = {};
+  const std::vector<Eigen::Vector3f> empty_path = {};
   ros::Time t1 = ros::Time::now();
   ros::Time t2 = t1 - ros::Duration(0.1);
   ros::Time t3 = t1 - ros::Duration(1.1);
@@ -151,13 +151,13 @@ TEST(PlannerFunctions, testDirectionTree) {
   Eigen::Vector3f sp1, sp2, sp3;
 
   // WHEN: we look for the best direction to fly towards
-  bool res = getSetpointFromTree(path_node_positions, t1, velocity, sp1);  // very short time should still return node 1
-  bool res1 = getSetpointFromTree(path_node_positions, t2, velocity, sp2);
-  bool res2 = getSetpointFromTree(path_node_positions, t3, velocity, sp3);  // should be second node on tree
-  bool res3 = getSetpointFromTree(empty_tree, t1, velocity, sp1);
+  bool res = getSetpointFromPath(path_node_positions, t1, velocity, sp1);  // very short time should still return node 1
+  bool res1 = getSetpointFromPath(path_node_positions, t2, velocity, sp2);
+  bool res2 = getSetpointFromPath(path_node_positions, t3, velocity, sp3);  // should be second node on path
+  bool res3 = getSetpointFromPath(empty_path, t1, velocity, sp1);
 
   // THEN: we expect the setpoint in between node n1 and n2 for t1 and t2 between
-  // node n2 and n3 for t3, and not to get an available tree for the empty tree
+  // node n2 and n3 for t3, and not to get an available path for the empty path
   ASSERT_TRUE(res);
   EXPECT_GE(sp1.x(), n1.x());
   EXPECT_LE(sp1.x(), n2.x());


### PR DESCRIPTION
This PR refactors the planner function `getDirectionFromTree`.

The old version used a complicated method to determine which tree segment we are currently on and then interpolated between the nodes to find a setpoint. This logic is not adequate for some corner cases, when the planned tree yielded an endpoint that is actually closer to the drone than the start node, it would switch to `goStraight` mode and fly directly into an obstacle.
The interpolation also doesn't make much sense, since the output is anyway taken as a unit vector which is later scaled depending on FOV and desired velocity.

The new logic simply takes the current velocity estimate and the tree generation time to determine which tree segment we are currently on, and then returns the next node in the tree as the setpoint.
The waypoint generator creates a unit vector toward this location to put into the `goto_position` to comply with the rest of the logic in the `waypoint_generator`.