### PR TITLE
Use OMPL for global path planning for global_planner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   # Install yaml-cpp ROS package
   - sudo apt-get install -y libyaml-cpp-dev
   # Install MavLink and Mavros
-  - sudo apt-get install -y ros-$ROS_DISTRO-mavlink ros-$ROS_DISTRO-mavros-msgs ros-$ROS_DISTRO-mavros ros-$ROS_DISTRO-mavros-extras
+  - sudo apt-get install -y ros-$ROS_DISTRO-mavlink ros-$ROS_DISTRO-mavros-msgs ros-$ROS_DISTRO-mavros ros-$ROS_DISTRO-mavros-extras ros-$ROS_DISTRO-ompl
   # Source environment
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Prepare rosdep

--- a/avoidance/include/avoidance/common.h
+++ b/avoidance/include/avoidance/common.h
@@ -321,6 +321,13 @@ double getAngularVelocity(float desired_yaw, float curr_yaw);
 * @brief     transforms setpoints from ROS message to MavROS message
 * @params[out] obst_avoid, setpoint in MavROS message form
 * @params[in] pose, position and attitude setpoint computed by the planner
+**/
+void transformToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry_msgs::PoseStamped pose);
+
+/**
+* @brief     transforms setpoints from ROS message to MavROS message
+* @params[out] obst_avoid, setpoint in MavROS message form
+* @params[in] pose, position and attitude setpoint computed by the planner
 * @params[in] vel, velocity setpoint computed by the planner
 **/
 void transformToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry_msgs::PoseStamped pose,

--- a/avoidance/src/common.cpp
+++ b/avoidance/src/common.cpp
@@ -278,6 +278,14 @@ double getAngularVelocity(float desired_yaw, float curr_yaw) {
   return 0.5 * static_cast<double>(vel);
 }
 
+void transformToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry_msgs::PoseStamped pose) {
+  geometry_msgs::Twist vel;
+  vel.linear.x = NAN;
+  vel.linear.y = NAN;
+  vel.linear.z = NAN;
+  transformToTrajectory(obst_avoid, pose, vel);
+}
+
 void transformToTrajectory(mavros_msgs::Trajectory& obst_avoid, geometry_msgs::PoseStamped pose,
                            geometry_msgs::Twist vel) {
   obst_avoid.header.stamp = ros::Time::now();

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(PCL 1.7 REQUIRED)
 find_package(octomap REQUIRED)
+find_package(ompl REQUIRED)
 
 if(DISABLE_SIMULATION)
   message(STATUS "Building avoidance without Gazebo Simulation")
@@ -145,7 +146,8 @@ include_directories(
   ${PCL_INCLUDE_DIRS}
   ${OCTOMAP_INCLUDE_DIRS}
   ${YAML_CPP_INCLUDE_DIR}
-)
+  ${OMPL_INCLUDE_DIR}
+  )
 link_libraries(${OCTOMAP_LIBRARIES})
 
 ## Declare a C++ library
@@ -154,6 +156,11 @@ add_library(global_planner
   src/library/cell.cpp
   src/library/global_planner.cpp
   src/nodes/global_planner_node.cpp
+  src/library/octomap_ompl_rrt.cpp
+  src/library/octomap_rrt_planner.cpp
+)
+target_link_libraries(global_planner
+  ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${YAML_CPP_LIBRARIES} ${OMPL_LIBRARIES}
 )
 
 ## Add cmake target dependencies of the library
@@ -168,6 +175,12 @@ add_executable(global_planner_node src/nodes/global_planner_node_main.cpp)
 target_link_libraries(global_planner_node
   global_planner ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${YAML_CPP_LIBRARIES}
 )
+
+add_executable(octomap_rrt_planner_node src/nodes/octomap_rrt_planner_node.cpp)
+target_link_libraries(octomap_rrt_planner_node
+  global_planner ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${YAML_CPP_LIBRARIES} ${OMPL_LIBRARIES}
+)
+
 
 #############
 ## Install ##

--- a/global_planner/include/global_planner/octomap_ompl_rrt.h
+++ b/global_planner/include/global_planner/octomap_ompl_rrt.h
@@ -1,0 +1,45 @@
+//  July/2018, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#ifndef OCTOMAP_OMPL_RRT_H
+#define OCTOMAP_OMPL_RRT_H
+
+#include <ros/ros.h>
+#include <ros/subscribe_options.h>
+#include <tf/transform_broadcaster.h>
+
+#include <stdio.h>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+#include <octomap/octomap.h>
+#include <Eigen/Dense>
+
+#include <global_planner/ompl_setup.h>
+
+using namespace std;
+using namespace Eigen;
+
+class OctomapOmplRrt {
+ private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ompl::OmplSetup problem_setup_;
+  octomap::OcTree* map_;
+
+  Eigen::Vector3d lower_bound_, upper_bound_;
+
+ public:
+  OctomapOmplRrt(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  virtual ~OctomapOmplRrt();
+
+  void setupProblem();
+  void setBounds(Eigen::Vector3d& lower_bound, Eigen::Vector3d& upper_bound);
+  void setMap(octomap::OcTree* map);
+  bool getPath(const Eigen::Vector3d& start, const Eigen::Vector3d& goal, std::vector<Eigen::Vector3d>* path);
+  void solutionPathToTrajectoryPoints(ompl::geometric::PathGeometric& path,
+                                      std::vector<Eigen::Vector3d>* trajectory_points) const;
+};
+
+#endif

--- a/global_planner/include/global_planner/octomap_rrt_planner.h
+++ b/global_planner/include/global_planner/octomap_rrt_planner.h
@@ -1,0 +1,105 @@
+//  June/2019, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#ifndef OCTOMAP_RRT_PLANNER_H
+#define OCTOMAP_RRT_PLANNER_H
+
+#include <stdio.h>
+#include <cstdlib>
+#include <mutex>
+#include <sstream>
+#include <string>
+
+#include <Eigen/Dense>
+
+#include <ompl/base/StateValidityChecker.h>
+#include <ompl/base/spaces/SE3StateSpace.h>
+#include <ompl/geometric/SimpleSetup.h>
+
+#include <nav_msgs/Path.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl_ros/transforms.h>
+#include <ros/ros.h>
+#include <ros/subscribe_options.h>
+#include <tf/transform_broadcaster.h>
+#include <tf/transform_listener.h>
+
+#include <mavros_msgs/Trajectory.h>
+#include <octomap/octomap.h>
+#include <octomap_msgs/Octomap.h>
+#include <octomap_msgs/conversions.h>
+
+#include <avoidance/avoidance_node.h>
+#include <global_planner/octomap_ompl_rrt.h>
+
+#ifndef DISABLE_SIMULATION
+#include <avoidance/rviz_world_loader.h>
+#endif
+
+using namespace std;
+using namespace Eigen;
+namespace ob = ompl::base;
+namespace og = ompl::geometric;
+
+struct cameraData {
+  ros::Subscriber pointcloud_sub_;
+};
+
+class OctomapRrtPlanner {
+ private:
+  std::mutex mutex_;
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ros::Publisher trajectory_pub_;
+  ros::Publisher global_path_pub_;
+  ros::Publisher pointcloud_pub_;
+
+  ros::Subscriber pose_sub_;
+  ros::Subscriber octomap_full_sub_;
+  ros::Subscriber move_base_simple_sub_;
+
+  ros::Timer cmdloop_timer_;
+  ros::Timer statusloop_timer_;
+
+  ros::Time last_wp_time_;
+  ros::Time start_time_;
+
+  double cmdloop_dt_;
+  double plannerloop_dt_;
+  bool hover_;
+  int num_octomap_msg_;
+
+  Eigen::Vector3d local_position_, local_velocity_;
+  Eigen::Vector3d goal_;
+
+  std::vector<Eigen::Vector3d> current_path_;
+  std::vector<cameraData> cameras_;
+  tf::TransformListener listener_;
+
+  octomap::OcTree* octree_ = NULL;
+
+  OctomapOmplRrt rrt_planner_;
+  avoidance::AvoidanceNode avoidance_node_;
+#ifndef DISABLE_SIMULATION
+  std::unique_ptr<avoidance::WorldVisualizer> world_visualizer_;
+#endif
+  void cmdloopCallback(const ros::TimerEvent& event);
+  void statusloopCallback(const ros::TimerEvent& event);
+  void octomapFullCallback(const octomap_msgs::Octomap& msg);
+  void positionCallback(const geometry_msgs::PoseStamped& msg);
+  void velocityCallback(const geometry_msgs::TwistStamped& msg);
+  void moveBaseSimpleCallback(const geometry_msgs::PoseStamped& msg);
+  void depthCameraCallback(const sensor_msgs::PointCloud2& msg);
+  void publishSetpoint();
+  void initializeCameraSubscribers(std::vector<std::string>& camera_topics);
+  void publishPath();
+  geometry_msgs::PoseStamped vector3d2PoseStampedMsg(Eigen::Vector3d position);
+
+ public:
+  OctomapRrtPlanner(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  virtual ~OctomapRrtPlanner();
+  void planWithSimpleSetup();
+};
+
+#endif

--- a/global_planner/include/global_planner/ompl_octomap.h
+++ b/global_planner/include/global_planner/ompl_octomap.h
@@ -1,8 +1,8 @@
 #ifndef OCTOMAP_OMPL_H
 #define OCTOMAP_OMPL_H
 
-#include <ompl/base/StateValidityChecker.h>
 #include <octomap/octomap.h>
+#include <ompl/base/StateValidityChecker.h>
 
 namespace ompl {
 
@@ -11,35 +11,36 @@ class OctomapValidityChecker : public base::StateValidityChecker {
   OctomapValidityChecker(const base::SpaceInformationPtr& space_info, octomap::OcTree* map)
       : base::StateValidityChecker(space_info), map_(map) {}
   virtual bool isValid(const base::State* state) const {
-
     Eigen::Vector3d position(state->as<ompl::base::RealVectorStateSpace::StateType>()->values[0],
-                              state->as<ompl::base::RealVectorStateSpace::StateType>()->values[1],
-                              state->as<ompl::base::RealVectorStateSpace::StateType>()->values[2]);
+                             state->as<ompl::base::RealVectorStateSpace::StateType>()->values[1],
+                             state->as<ompl::base::RealVectorStateSpace::StateType>()->values[2]);
     bool collision = checkCollision(position);
-    if(collision) return false;
-    else return true;
+    if (collision)
+      return false;
+    else
+      return true;
   }
 
   virtual bool checkCollision(Eigen::Vector3d state) const {
-
     bool collision = true;
     double occprob = 1.0;
     uint octree_depth = 16;
     double logodds;
 
-    if(map_){
+    if (map_) {
       octomap::OcTreeNode* node = map_->search(state(0), state(1), state(2), octree_depth);
       if (node)
         occprob = octomap::probability(logodds = node->getValue());
       else
         occprob = 0.5;  // Unobserved region of the map has equal chance of being occupied / unoccupied
-  
-    // Assuming a optimistic planner: Unknown space is considered as unoccupied
-    if (occprob <= 0.5) collision = false;
 
-    return collision;
+      // Assuming a optimistic planner: Unknown space is considered as unoccupied
+      if (occprob <= 0.5) collision = false;
+
+      return collision;
     }
   }
+
  protected:
   octomap::OcTree* map_;
 };

--- a/global_planner/include/global_planner/ompl_octomap.h
+++ b/global_planner/include/global_planner/ompl_octomap.h
@@ -1,0 +1,48 @@
+#ifndef OCTOMAP_OMPL_H
+#define OCTOMAP_OMPL_H
+
+#include <ompl/base/StateValidityChecker.h>
+#include <octomap/octomap.h>
+
+namespace ompl {
+
+class OctomapValidityChecker : public base::StateValidityChecker {
+ public:
+  OctomapValidityChecker(const base::SpaceInformationPtr& space_info, octomap::OcTree* map)
+      : base::StateValidityChecker(space_info), map_(map) {}
+  virtual bool isValid(const base::State* state) const {
+
+    Eigen::Vector3d position(state->as<ompl::base::RealVectorStateSpace::StateType>()->values[0],
+                              state->as<ompl::base::RealVectorStateSpace::StateType>()->values[1],
+                              state->as<ompl::base::RealVectorStateSpace::StateType>()->values[2]);
+    bool collision = checkCollision(position);
+    if(collision) return false;
+    else return true;
+  }
+
+  virtual bool checkCollision(Eigen::Vector3d state) const {
+
+    bool collision = true;
+    double occprob = 1.0;
+    uint octree_depth = 16;
+    double logodds;
+
+    if(map_){
+      octomap::OcTreeNode* node = map_->search(state(0), state(1), state(2), octree_depth);
+      if (node)
+        occprob = octomap::probability(logodds = node->getValue());
+      else
+        occprob = 0.5;  // Unobserved region of the map has equal chance of being occupied / unoccupied
+  
+    // Assuming a optimistic planner: Unknown space is considered as unoccupied
+    if (occprob <= 0.5) collision = false;
+
+    return collision;
+    }
+  }
+ protected:
+  octomap::OcTree* map_;
+};
+}  // namespace ompl
+
+#endif

--- a/global_planner/include/global_planner/ompl_setup.h
+++ b/global_planner/include/global_planner/ompl_setup.h
@@ -1,0 +1,44 @@
+#ifndef OMPL_SETUP_H
+#define OMPL_SETUP_H
+
+#include <ompl/base/objectives/PathLengthOptimizationObjective.h>
+
+#include <ompl/base/spaces/SE3StateSpace.h>
+#include <ompl/geometric/SimpleSetup.h>
+#include <ompl/geometric/planners/rrt/RRTstar.h>
+#include "ompl/base/SpaceInformation.h"
+
+#include <global_planner/ompl_octomap.h>
+
+namespace ompl {
+
+class OmplSetup : public geometric::SimpleSetup {
+ public:
+  OmplSetup() : geometric::SimpleSetup(base::StateSpacePtr(new base::RealVectorStateSpace(3))) {}
+
+  void setDefaultObjective() {
+    getProblemDefinition()->setOptimizationObjective(
+        ompl::base::OptimizationObjectivePtr(new ompl::base::PathLengthOptimizationObjective(getSpaceInformation())));
+  }
+
+  void setDefaultPlanner() { setRrtStar(); }
+
+  void setRrtStar() { setPlanner(ompl::base::PlannerPtr(new ompl::geometric::RRTstar(getSpaceInformation()))); }
+
+  const base::StateSpacePtr& getGeometricComponentStateSpace() const { return getStateSpace(); }
+
+  void setStateValidityCheckingResolution(double resolution) {
+    // This is a protected attribute, so need to wrap this function.
+    si_->setStateValidityCheckingResolution(resolution);
+  }
+
+  void setOctomapCollisionChecking(octomap::OcTree* map) {
+    std::shared_ptr<OctomapValidityChecker> validity_checker(new OctomapValidityChecker(getSpaceInformation(), map));
+
+    setStateValidityChecker(base::StateValidityCheckerPtr(validity_checker));
+  }
+};
+
+}  // namespace ompl
+
+#endif

--- a/global_planner/launch/ompl_rrt_planner_octomap.launch
+++ b/global_planner/launch/ompl_rrt_planner_octomap.launch
@@ -1,0 +1,40 @@
+<launch>
+    <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
+    <arg name="start_pos_x" default="0.5" />
+    <arg name="start_pos_y" default="0.5" />
+    <arg name="start_pos_z" default="3.5" />
+    <arg name="world_file_name"    default="simple_obstacle" />
+
+    <!-- Global Planner -->
+    <node name="global_planner_node" pkg="global_planner" type="octomap_rrt_planner_node" output="screen">
+        <param name="start_pos_x" value="$(arg start_pos_x)" />
+        <param name="start_pos_y" value="$(arg start_pos_y)" />
+        <param name="start_pos_z" value="$(arg start_pos_z)" />
+        <param name="world_name" value="$(find avoidance)/sim/worlds/$(arg world_file_name).yaml" />
+        <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
+        <param name="robot_radius" value="0.5" />
+    </node>
+
+    <!-- OctoMap Server -->
+    <node pkg="octomap_server" type="octomap_server_node" name="octomap_server">
+        <param name="resolution" value="1.0" />
+        <!-- fixed map frame (set to 'map' if SLAM or localization running!) -->
+        <param name="frame_id" type="string" value="world" />
+        <!-- maximum range to integrate (speedup!) -->
+        <param name="sensor_model/max_range" value="9.0" />
+        <param name="sensor_model/min" value="0.01" />
+        <param name="sensor_model/max" value="0.99" />
+        <param name="sensor_model/hit" value="0.9" />
+        <param name="sensor_model/miss" value="0.45" />
+        <param name="color/r" value="0.1" />
+        <param name="color/g" value="0.1" />
+        <param name="color/b" value="0.1" />
+        <param name="color/a" value="1.0" />
+        <!-- Filter out obstacles which are lower than 1 meter -->
+        <param name="occupancy_min_z" value="1.0" />
+        <param name="height_map" value="false" />
+        <param name="publish_free_space" value="false" />
+        <!-- data source to integrate (PointCloud2) -->
+        <!-- <remap from="cloud_in" to="$(arg point_cloud_topic)" /> -->
+    </node>
+</launch>

--- a/global_planner/launch/ompl_rrt_planner_stereo.launch
+++ b/global_planner/launch/ompl_rrt_planner_stereo.launch
@@ -1,0 +1,31 @@
+<launch>
+    <arg name="world_file_name"    default="simple_obstacle" />
+    <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
+    <arg name="pointcloud_topics" default="[/stereo/points2]" />
+    <arg name="start_pos_x" default="0.5" />
+    <arg name="start_pos_y" default="0.5" />
+    <arg name="start_pos_z" default="3.5" />
+
+    <!-- Ros transformation -->
+    <node pkg="tf" type="static_transform_publisher" name="tf_local_origin"
+          args="0 0 0 0 0 0 world local_origin 10"/>
+
+  <!-- Launch PX4 and mavros -->
+  <include file="$(find avoidance)/launch/avoidance_sitl_stereo.launch" >
+    <arg name="model" value="iris_stereo_camera" />
+    <arg name="world_path" value="$(arg world_path)" />
+    <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
+  </include>
+
+    <!-- Global planner -->
+    <include file="$(find global_planner)/launch/ompl_rrt_planner_octomap.launch" >
+        <arg name="start_pos_x" value="$(arg start_pos_x)" />
+        <arg name="start_pos_y" value="$(arg start_pos_y)" />
+        <arg name="start_pos_z" value="$(arg start_pos_z)" />
+        <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
+    </include>
+
+    <!-- RViz -->
+    <node pkg="rviz" type="rviz" output="screen" name="rviz" respawn="true"
+          args="-d $(find global_planner)/resource/global_planner.rviz" />
+</launch>

--- a/global_planner/src/library/octomap_ompl_rrt.cpp
+++ b/global_planner/src/library/octomap_ompl_rrt.cpp
@@ -1,0 +1,88 @@
+//  June/2019, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#include "global_planner/octomap_ompl_rrt.h"
+
+using namespace Eigen;
+using namespace std;
+// Constructor
+OctomapOmplRrt::OctomapOmplRrt(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private)
+    : nh_(nh), nh_private_(nh_private) {}
+OctomapOmplRrt::~OctomapOmplRrt() {
+  // Destructor
+}
+
+void OctomapOmplRrt::setupProblem() {
+  problem_setup_.setDefaultPlanner();
+  problem_setup_.setDefaultObjective();
+  problem_setup_.setOctomapCollisionChecking(map_);
+  ompl::base::RealVectorBounds bounds(3);
+  bounds.setLow(0, lower_bound_.x());
+  bounds.setLow(1, lower_bound_.y());
+  bounds.setLow(2, lower_bound_.z());
+
+  bounds.setHigh(0, upper_bound_.x());
+  bounds.setHigh(1, upper_bound_.y());
+  bounds.setHigh(2, upper_bound_.z());
+
+  // Define start and goal positions.
+  problem_setup_.getGeometricComponentStateSpace()->as<ompl::base::RealVectorStateSpace>()->setBounds(bounds);
+
+  problem_setup_.setStateValidityCheckingResolution(0.001);
+}
+
+void OctomapOmplRrt::setBounds(Eigen::Vector3d& lower_bound, Eigen::Vector3d& upper_bound) {
+  lower_bound_ = lower_bound;
+  upper_bound_ = upper_bound;
+}
+
+bool OctomapOmplRrt::getPath(const Eigen::Vector3d& start, const Eigen::Vector3d& goal,
+                             std::vector<Eigen::Vector3d>* path) {
+  problem_setup_.clear();
+
+  ompl::base::ScopedState<ompl::base::RealVectorStateSpace> start_ompl(problem_setup_.getSpaceInformation());
+  ompl::base::ScopedState<ompl::base::RealVectorStateSpace> goal_ompl(problem_setup_.getSpaceInformation());
+
+  start_ompl->values[0] = start(0);
+  start_ompl->values[1] = start(1);
+  start_ompl->values[2] = start(2);
+
+  goal_ompl->values[0] = goal(0);
+  goal_ompl->values[1] = goal(1);
+  goal_ompl->values[2] = goal(2);
+  problem_setup_.setStartAndGoalStates(start_ompl, goal_ompl);
+  problem_setup_.setup();
+
+  if (problem_setup_.solve(1.0)) {
+    std::cout << "Found solution:" << std::endl;
+    // problem_setup_.getSolutionPath().print(std::cout);
+    // problem_setup_.simplifySolution();
+    problem_setup_.getSolutionPath().print(std::cout);
+
+  } else {
+    std::cout << "Solution Not found" << std::endl;
+  }
+
+  if (problem_setup_.haveSolutionPath()) {
+    solutionPathToTrajectoryPoints(problem_setup_.getSolutionPath(), path);
+    return true;
+  }
+  return false;
+}
+
+void OctomapOmplRrt::setMap(octomap::OcTree* map) { map_ = map; }
+
+void OctomapOmplRrt::solutionPathToTrajectoryPoints(ompl::geometric::PathGeometric& path,
+                                                    std::vector<Eigen::Vector3d>* trajectory_points) const {
+  // trajectory_points->clear();
+  // trajectory_points->reserve(path.getStateCount());
+
+  std::vector<ompl::base::State*>& state_vector = path.getStates();
+
+  for (ompl::base::State* state_ptr : state_vector) {
+    Eigen::Vector3d position(state_ptr->as<ompl::base::RealVectorStateSpace::StateType>()->values[0],
+                             state_ptr->as<ompl::base::RealVectorStateSpace::StateType>()->values[1],
+                             state_ptr->as<ompl::base::RealVectorStateSpace::StateType>()->values[2]);
+
+    trajectory_points->emplace_back(position);
+  }
+}

--- a/global_planner/src/library/octomap_ompl_rrt.cpp
+++ b/global_planner/src/library/octomap_ompl_rrt.cpp
@@ -38,6 +38,7 @@ void OctomapOmplRrt::setBounds(Eigen::Vector3d& lower_bound, Eigen::Vector3d& up
 bool OctomapOmplRrt::getPath(const Eigen::Vector3d& start, const Eigen::Vector3d& goal,
                              std::vector<Eigen::Vector3d>* path) {
   problem_setup_.clear();
+  path->clear();
 
   ompl::base::ScopedState<ompl::base::RealVectorStateSpace> start_ompl(problem_setup_.getSpaceInformation());
   ompl::base::ScopedState<ompl::base::RealVectorStateSpace> goal_ompl(problem_setup_.getSpaceInformation());

--- a/global_planner/src/library/octomap_rrt_planner.cpp
+++ b/global_planner/src/library/octomap_rrt_planner.cpp
@@ -151,7 +151,7 @@ void OctomapRrtPlanner::moveBaseSimpleCallback(const geometry_msgs::PoseStamped&
 void OctomapRrtPlanner::publishSetpoint() {
   mavros_msgs::Trajectory msg;
   Eigen::Vector3f reference_posf = reference_pos_.cast<float>();
-  avoidance::transformPoseToTrajectory(msg, avoidance::toPoseStamped(reference_posf, reference_att_));
+  avoidance::transformToTrajectory(msg, avoidance::toPoseStamped(reference_posf, reference_att_));
   msg.header.frame_id = frame_id_;
   msg.header.stamp = ros::Time::now();
   trajectory_pub_.publish(msg);

--- a/global_planner/src/library/octomap_rrt_planner.cpp
+++ b/global_planner/src/library/octomap_rrt_planner.cpp
@@ -1,0 +1,177 @@
+//  June/2019, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#include "global_planner/octomap_rrt_planner.h"
+#include "global_planner/octomap_ompl_rrt.h"
+
+using namespace Eigen;
+using namespace std;
+namespace ob = ompl::base;
+namespace og = ompl::geometric;
+
+// Constructor
+OctomapRrtPlanner::OctomapRrtPlanner(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private)
+    : nh_(nh),
+      nh_private_(nh_private),
+      avoidance_node_(nh, nh_private),
+      cmdloop_dt_(0.1),
+      plannerloop_dt_(1.0),
+      rrt_planner_(nh, nh_private) {
+#ifndef DISABLE_SIMULATION
+  world_visualizer_.reset(new avoidance::WorldVisualizer(nh_));
+#endif
+
+  cmdloop_timer_ = nh_.createTimer(ros::Duration(cmdloop_dt_), &OctomapRrtPlanner::cmdloopCallback,
+                                   this);  // Define timer for constant loop rate
+  statusloop_timer_ = nh_.createTimer(ros::Duration(plannerloop_dt_), &OctomapRrtPlanner::statusloopCallback,
+                                      this);  // Define timer for constant loop rate
+
+  pose_sub_ = nh_.subscribe("/mavros/local_position/pose", 1, &OctomapRrtPlanner::positionCallback, this);
+  move_base_simple_sub_ = nh_.subscribe("/move_base_simple/goal", 1, &OctomapRrtPlanner::moveBaseSimpleCallback, this);
+
+  octomap_full_sub_ = nh_.subscribe("/octomap_full", 1, &OctomapRrtPlanner::octomapFullCallback, this);
+  trajectory_pub_ = nh_.advertise<mavros_msgs::Trajectory>("/mavros/trajectory/generated", 10);
+  global_path_pub_ = nh_.advertise<nav_msgs::Path>("/global_temp_path", 10);
+  pointcloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2>("/cloud_in", 10);
+
+  listener_.waitForTransform("/fcu", "/world", ros::Time(0), ros::Duration(3.0));
+  listener_.waitForTransform("/local_origin", "/world", ros::Time(0), ros::Duration(3.0));
+
+  std::vector<std::string> camera_topics;
+  nh_.getParam("pointcloud_topics", camera_topics);
+  initializeCameraSubscribers(camera_topics);
+
+  rrt_planner_.setMap(octree_);
+
+  goal_ << 0.0, 1.0, 0.0;
+}
+OctomapRrtPlanner::~OctomapRrtPlanner() {
+  // Destructor
+}
+
+void OctomapRrtPlanner::cmdloopCallback(const ros::TimerEvent& event) {
+  hover_ = false;
+
+  // Check if all information was received
+  ros::Time now = ros::Time::now();
+  last_wp_time_ = ros::Time::now();
+
+  ros::Duration since_last_cloud = now - last_wp_time_;
+  ros::Duration since_start = now - start_time_;
+
+  avoidance_node_.checkFailsafe(since_last_cloud, since_start, hover_);
+  publishSetpoint();
+}
+
+void OctomapRrtPlanner::statusloopCallback(const ros::TimerEvent& event) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  planWithSimpleSetup();
+  publishPath();
+}
+
+// Check if the current path is blocked
+void OctomapRrtPlanner::octomapFullCallback(const octomap_msgs::Octomap& msg) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (num_octomap_msg_++ % 10 > 0) {
+    return;  // We get too many of those messages. Only process 1/10 of them
+  }
+
+  if (octree_) {
+    delete octree_;
+  }
+  octree_ = dynamic_cast<octomap::OcTree*>(octomap_msgs::msgToMap(msg));
+}
+
+// Go through obstacle points and store them
+void OctomapRrtPlanner::depthCameraCallback(const sensor_msgs::PointCloud2& msg) {
+  try {
+    // Transform msg from camera frame to world frame
+    ros::Time now = ros::Time::now();
+    listener_.waitForTransform("/world", "/camera_link", now, ros::Duration(5.0));
+    tf::StampedTransform transform;
+    listener_.lookupTransform("/world", "/camera_link", now, transform);
+    sensor_msgs::PointCloud2 transformed_msg;
+    pcl_ros::transformPointCloud("/world", transform, msg, transformed_msg);
+    pcl::PointCloud<pcl::PointXYZ> cloud;  // Easier to loop through pcl::PointCloud
+    pcl::fromROSMsg(transformed_msg, cloud);
+
+    pointcloud_pub_.publish(msg);
+  } catch (tf::TransformException const& ex) {
+    ROS_DEBUG("%s", ex.what());
+    ROS_WARN("Transformation not available (/world to /camera_link");
+  }
+}
+
+void OctomapRrtPlanner::positionCallback(const geometry_msgs::PoseStamped& msg) {
+  local_position_(0) = msg.pose.position.x;
+  local_position_(1) = msg.pose.position.y;
+  local_position_(2) = msg.pose.position.z;
+}
+
+void OctomapRrtPlanner::velocityCallback(const geometry_msgs::TwistStamped& msg) {
+  local_velocity_(0) = msg.twist.linear.x;
+  local_velocity_(1) = msg.twist.linear.y;
+  local_velocity_(2) = msg.twist.linear.z;
+}
+
+void OctomapRrtPlanner::moveBaseSimpleCallback(const geometry_msgs::PoseStamped& msg) {
+  goal_(0) = msg.pose.position.x;
+  goal_(1) = msg.pose.position.y;
+  goal_(2) = 3.0;
+}
+
+void OctomapRrtPlanner::publishSetpoint() {
+  mavros_msgs::Trajectory msg;
+
+  trajectory_pub_.publish(msg);
+}
+
+void OctomapRrtPlanner::publishPath() {
+  nav_msgs::Path msg;
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "local_origin";
+
+  std::vector<geometry_msgs::PoseStamped> path;
+
+  for (int i = 0; i < current_path_.size(); i++) {
+    path.insert(path.begin(), vector3d2PoseStampedMsg(current_path_[i]));
+  }
+  std::cout << current_path_.size() << std::endl;
+  msg.poses = path;
+  global_path_pub_.publish(msg);
+}
+
+void OctomapRrtPlanner::initializeCameraSubscribers(std::vector<std::string>& camera_topics) {
+  cameras_.resize(camera_topics.size());
+
+  for (size_t i = 0; i < camera_topics.size(); i++) {
+    cameras_[i].pointcloud_sub_ = nh_.subscribe(camera_topics[i], 1, &OctomapRrtPlanner::depthCameraCallback, this);
+  }
+}
+
+geometry_msgs::PoseStamped OctomapRrtPlanner::vector3d2PoseStampedMsg(Eigen::Vector3d position) {
+  geometry_msgs::PoseStamped encode_msg;
+  encode_msg.header.stamp = ros::Time::now();
+  encode_msg.header.frame_id = "local_origin";
+  encode_msg.pose.orientation.w = 1.0;
+  encode_msg.pose.orientation.x = 0.0;
+  encode_msg.pose.orientation.y = 0.0;
+  encode_msg.pose.orientation.z = 0.0;
+  encode_msg.pose.position.x = position(0);
+  encode_msg.pose.position.y = position(1);
+  encode_msg.pose.position.z = position(2);
+
+  return encode_msg;
+}
+
+void OctomapRrtPlanner::planWithSimpleSetup() {
+  if (octree_) {
+    Eigen::Vector3d lower, upper;
+    lower << -10.0, -10.0, -10.0;
+    upper << 10.0, 10.0, 10.0;
+    rrt_planner_.setMap(octree_);
+    rrt_planner_.setBounds(lower, upper);
+    rrt_planner_.setupProblem();
+    rrt_planner_.getPath(local_position_, goal_, &current_path_);
+  }
+}

--- a/global_planner/src/nodes/octomap_rrt_planner_node.cpp
+++ b/global_planner/src/nodes/octomap_rrt_planner_node.cpp
@@ -1,0 +1,14 @@
+//  June/2019, ETHZ, Jaeyoung Lim, jalim@student.ethz.ch
+
+#include "global_planner/octomap_rrt_planner.h"
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "octomap_rrt_planner");
+  ros::NodeHandle nh("~");
+  ros::NodeHandle nh_private("");
+
+  OctomapRrtPlanner* rrt_planner = new OctomapRrtPlanner(nh, nh_private);
+
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
This PR integrates [Open Motion Planning Library](https://ompl.kavrakilab.org/) into global_planner. 

Most of the previous `global_planner` has been written from the ground up, making it quite hard to modify the planning algorithm itself.

Having OMPL as a planner backend will give more versatility to add / modify the path planning algorithm and give access to the various planners that are available in OMPL. Moreover, given that ompl do not depend on map representations, this could potentially enable the ability to use different map representations for different use cases. 

A lot have the structure has been used following https://github.com/ethz-asl/mav_voxblox_planning.

Currently depends on #452 and will rebase once merged. Was first proposed in #132 