### PR TITLE
[GlobalPlanner] Improve octomap update dropouts

### DIFF
--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -95,6 +95,7 @@ class GlobalPlanner {
   bool use_risk_heuristics_ = true;
   bool use_speedup_heuristics_ = true;
   std::string default_node_type_ = "SpeedNode";
+  std::string frame_id_ = "world";
 
   GlobalPlanner();
   ~GlobalPlanner();
@@ -104,6 +105,7 @@ class GlobalPlanner {
   void setPose(const geometry_msgs::PoseStamped& new_pose);
   void setGoal(const GoalCell& goal);
   void setPath(const std::vector<Cell>& path);
+  void setFrame(std::string frame_id);
 
   bool updateFullOctomap(const octomap_msgs::Octomap& msg);
 

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -17,7 +17,6 @@
 #include <octomap/OcTree.h>
 #include <octomap/octomap.h>
 
-
 #include <global_planner/GlobalPlannerNodeConfig.h>
 #include <global_planner/PathWithRiskMsg.h>
 #include "global_planner/analysis.h"

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -106,7 +106,7 @@ class GlobalPlanner {
   void setPath(const std::vector<Cell>& path);
   void setFrame(std::string frame_id);
 
-  bool updateFullOctomap(octomap::AbstractOcTree* tree);
+  void updateFullOctomap(octomap::AbstractOcTree* tree);
 
   void getOpenNeighbors(const Cell& cell, std::vector<CellDistancePair>& neighbors, bool is_3D);
   bool isNearWall(const Cell& cell);

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -16,8 +16,7 @@
 
 #include <octomap/OcTree.h>
 #include <octomap/octomap.h>
-#include <octomap_msgs/Octomap.h>
-#include <octomap_msgs/conversions.h>
+
 
 #include <global_planner/GlobalPlannerNodeConfig.h>
 #include <global_planner/PathWithRiskMsg.h>
@@ -107,7 +106,7 @@ class GlobalPlanner {
   void setPath(const std::vector<Cell>& path);
   void setFrame(std::string frame_id);
 
-  bool updateFullOctomap(const octomap_msgs::Octomap& msg);
+  bool updateFullOctomap(octomap::AbstractOcTree* tree);
 
   void getOpenNeighbors(const Cell& cell, std::vector<CellDistancePair>& neighbors, bool is_3D);
   bool isNearWall(const Cell& cell);

--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -112,6 +112,7 @@ class GlobalPlannerNode {
   int num_pos_msg_ = 0;
   double cmdloop_dt_;
   double plannerloop_dt_;
+  double mapupdate_dt_;
   double min_speed_;
   double speed_ = min_speed_;
   double start_yaw_;

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -61,9 +61,7 @@ void GlobalPlanner::setPath(const std::vector<Cell>& path) {
   }
 }
 
-void GlobalPlanner::setFrame(std::string frame_id){
-  frame_id_ = frame_id;
-}
+void GlobalPlanner::setFrame(std::string frame_id) { frame_id_ = frame_id; }
 
 // Returns false iff current path has an obstacle
 // Going through the octomap can take more than 50 ms for 100m x 100m explored

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -61,6 +61,10 @@ void GlobalPlanner::setPath(const std::vector<Cell>& path) {
   }
 }
 
+void GlobalPlanner::setFrame(std::string frame_id){
+  frame_id_ = frame_id;
+}
+
 // Returns false iff current path has an obstacle
 // Going through the octomap can take more than 50 ms for 100m x 100m explored
 // map
@@ -336,7 +340,7 @@ double GlobalPlanner::getHeuristic(const Node& u, const Cell& goal) {
 
 geometry_msgs::PoseStamped GlobalPlanner::createPoseMsg(const Cell& cell, double yaw) {
   geometry_msgs::PoseStamped pose_msg;
-  pose_msg.header.frame_id = "/world";
+  pose_msg.header.frame_id = frame_id_;
   pose_msg.pose.position = cell.toPoint();
   pose_msg.pose.orientation = tf::createQuaternionMsgFromYaw(yaw);
   return pose_msg;
@@ -346,7 +350,7 @@ nav_msgs::Path GlobalPlanner::getPathMsg() { return getPathMsg(curr_path_); }
 
 nav_msgs::Path GlobalPlanner::getPathMsg(const std::vector<Cell>& path) {
   nav_msgs::Path path_msg;
-  path_msg.header.frame_id = "/world";
+  path_msg.header.frame_id = frame_id_;
 
   if (path.size() == 0) {
     return path_msg;

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -68,23 +68,13 @@ void GlobalPlanner::setFrame(std::string frame_id){
 // Returns false iff current path has an obstacle
 // Going through the octomap can take more than 50 ms for 100m x 100m explored
 // map
-bool GlobalPlanner::updateFullOctomap(octomap::AbstractOcTree* tree) {
+void GlobalPlanner::updateFullOctomap(octomap::AbstractOcTree* tree) {
   risk_cache_.clear();
   if (octree_) {
     delete octree_;
   }
   octree_ = dynamic_cast<octomap::OcTree*>(tree);
   octree_resolution_ = octree_->getResolution();
-
-  // Check if the risk of the current path has increased
-  if (!curr_path_.empty()) {
-    PathInfo new_info = getPathInfo(curr_path_);
-    if (new_info.is_blocked || new_info.risk > curr_path_info_.risk + 10) {
-      ROS_INFO("Risk increase");
-      return false;
-    }
-  }
-  return true;
 }
 
 // TODO: simplify and return neighbors

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -68,9 +68,8 @@ void GlobalPlanner::setFrame(std::string frame_id){
 // Returns false iff current path has an obstacle
 // Going through the octomap can take more than 50 ms for 100m x 100m explored
 // map
-bool GlobalPlanner::updateFullOctomap(const octomap_msgs::Octomap& msg) {
+bool GlobalPlanner::updateFullOctomap(octomap::AbstractOcTree* tree) {
   risk_cache_.clear();
-  octomap::AbstractOcTree* tree = octomap_msgs::msgToMap(msg);
   if (octree_) {
     delete octree_;
   }

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -254,7 +254,7 @@ void GlobalPlannerNode::fcuInputGoalCallback(const mavros_msgs::Trajectory& msg)
 // Check if the current path is blocked
 void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
   std::lock_guard<std::mutex> lock(mutex_);
-  
+
   ros::Time current = ros::Time::now();
   // Update map at a fixed rate. This is useful on setting replanning rates for the planner.
   if ((current - last_wp_time_).toSec() < mapupdate_dt_) {

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -256,8 +256,9 @@ void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
     return;  // We get too many of those messages. Only process 1/10 of them
   }
   std::lock_guard<std::mutex> lock(mutex_);
+  octomap::AbstractOcTree* tree = octomap_msgs::msgToMap(msg);
 
-  bool current_path_is_ok = global_planner_.updateFullOctomap(msg);
+  bool current_path_is_ok = global_planner_.updateFullOctomap(tree);
 }
 
 // Go through obstacle points and store them

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -84,6 +84,7 @@ void GlobalPlannerNode::readParams() {
   global_planner_.goal_pos_ = GoalCell(start_pos_.x, start_pos_.y, start_pos_.z);
   double robot_radius;
   nh_.param<double>("robot_radius", robot_radius, 0.5);
+  global_planner_.setFrame(frame_id_);
   global_planner_.setRobotRadius(robot_radius);
 }
 

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -63,7 +63,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
   current_goal_.pose.orientation = tf::createQuaternionMsgFromYaw(start_yaw_);
   last_goal_ = current_goal_;
 
-  speed_ = 2.0;
+  speed_ = 5.0;
 
   start_time_ = ros::Time::now();
 }
@@ -252,13 +252,18 @@ void GlobalPlannerNode::fcuInputGoalCallback(const mavros_msgs::Trajectory& msg)
 
 // Check if the current path is blocked
 void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
-  if (num_octomap_msg_++ % 10 > 0) {
-    return;  // We get too many of those messages. Only process 1/10 of them
-  }
   std::lock_guard<std::mutex> lock(mutex_);
+  
+  ros::Time current = ros::Time::now();
+  // Update map at a fixed rate. This is useful on setting replanning rates for the planner.
+  if ((current - last_wp_time_).toSec() < 0.1) {
+    return;
+  }
+  last_wp_time_ = ros::Time::now();
+
   octomap::AbstractOcTree* tree = octomap_msgs::msgToMap(msg);
 
-  bool current_path_is_ok = global_planner_.updateFullOctomap(tree);
+  global_planner_.updateFullOctomap(tree);
 }
 
 // Go through obstacle points and store them
@@ -309,7 +314,6 @@ void GlobalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
 
   // Check if all information was received
   ros::Time now = ros::Time::now();
-  last_wp_time_ = ros::Time::now();
 
   ros::Duration since_last_cloud = now - last_wp_time_;
   ros::Duration since_start = now - start_time_;

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -8,6 +8,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
       avoidance_node_(nh, nh_private),
       cmdloop_dt_(0.1),
       plannerloop_dt_(1.0),
+      mapupdate_dt_(0.2),
       start_yaw_(0.0) {
   // Set up Dynamic Reconfigure Server
   dynamic_reconfigure::Server<global_planner::GlobalPlannerNodeConfig>::CallbackType f;
@@ -256,7 +257,7 @@ void GlobalPlannerNode::octomapFullCallback(const octomap_msgs::Octomap& msg) {
   
   ros::Time current = ros::Time::now();
   // Update map at a fixed rate. This is useful on setting replanning rates for the planner.
-  if ((current - last_wp_time_).toSec() < 0.1) {
+  if ((current - last_wp_time_).toSec() < mapupdate_dt_) {
     return;
   }
   last_wp_time_ = ros::Time::now();


### PR DESCRIPTION
This PR is necessary in running global_planner onboard a real drone

Previously, octomap messages were being dropped and only one out of ten messages were being used.  This was done to prevent updating the map too frequently when the map is streamed at a high rate. However, there is no notion of update rates as the dropout depends on the rate the map is streamed. This will lead to drastically different performance depending on how powerful the compute platform is onboard the drone.

This PR switches to updating the map based on time. This information can be useful in defining the optimal replanning rate and maximum speed of the planner. The timeout is simply unblocking the trigger, and not necessarily making the update happen at a fixed rate.

A few clean ups were made on the way too
- Define the global_planner frame as configured from parameters
- When updating the octomap, checking if the planner imporved is no longer done. This was only useful when replanning was triggered by events. Currently the planner will replan on a fixed time interval, therefore this check is no longer applicable. 
- Speed when passing trajectory has been increased to solve the decrepancy between offboard mode
Tested in SITL 