### PR TITLE
Port LocalPlannerNode to nodelets

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -34,6 +34,7 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <Eigen/Core>
 #include <boost/bind.hpp>
+#include <nodelet/nodelet.h>
 
 #include <avoidance/common.h>
 #include <dynamic_reconfigure/server.h>
@@ -69,10 +70,11 @@ struct cameraData {
   bool transform_registered_ = false;
 };
 
-class LocalPlannerNode {
+class LocalPlannerNode : public nodelet::Nodelet{
  public:
-  LocalPlannerNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private, const bool tf_spin_thread = true);
+  LocalPlannerNode();
   ~LocalPlannerNode();
+  virtual void onInit();
 
   std::atomic<bool> should_exit_{false};
 
@@ -81,6 +83,9 @@ class LocalPlannerNode {
   std::unique_ptr<LocalPlanner> local_planner_;
   std::unique_ptr<WaypointGenerator> wp_generator_;
   std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
+
+  std::thread worker;
+  std::thread worker_tf_listener;
 
   LocalPlannerVisualization visualizer_;
   std::unique_ptr<avoidance::AvoidanceNode> avoidance_node_;

--- a/local_planner/nodelets.xml
+++ b/local_planner/nodelets.xml
@@ -1,0 +1,8 @@
+<library path="lib/liblocal_planner">
+    <class name="LocalPlannerNode" type="local_planner::LocalPlannerNode" base_class_type="nodelet::Nodelet">
+        <description>
+            Local planner nodelet
+        </description>
+    </class>
+
+</library>

--- a/local_planner/package.xml
+++ b/local_planner/package.xml
@@ -54,6 +54,7 @@
   <build_depend>mavros_extras</build_depend>
   <build_depend>mavros_msgs</build_depend>
   <build_depend>avoidance</build_depend>
+  <build_depend>nodelet</build_depend>
 
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>message_runtime</run_depend>
@@ -69,9 +70,10 @@
   <run_depend>mavros_extras</run_depend>
   <run_depend>mavros_msgs</run_depend>
   <run_depend>avoidance</run_depend>
+  <run_depend>nodelet</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
+    <nodelet plugin="${prefix}/nodelets.xml" />
   </export>
 </package>

--- a/local_planner/src/nodes/local_planner_node_main.cpp
+++ b/local_planner/src/nodes/local_planner_node_main.cpp
@@ -1,25 +1,15 @@
-#include "local_planner/local_planner_node.h"
+#include <ros/ros.h>
+#include <nodelet/loader.h>
 
-using namespace avoidance;
-
-int main(int argc, char** argv) {
+int main(int argc, char **argv){
   ros::init(argc, argv, "local_planner_node");
-  ros::NodeHandle nh("~");
-  ros::NodeHandle nh_private("");
 
-  LocalPlannerNode Node(nh, nh_private, true);
-  Node.startNode();
-
-  std::thread worker(&LocalPlannerNode::threadFunction, &Node);
-  std::thread worker_tf_buffer(&LocalPlannerNode::transformBufferThread, &Node);
-
-  worker.join();
-  worker_tf_buffer.join();
-
-  for (size_t i = 0; i < Node.cameras_.size(); ++i) {
-    Node.cameras_[i].cloud_ready_cv_->notify_all();
-    Node.cameras_[i].transform_thread_.join();
-  }
+  nodelet::Loader nodelet;
+  nodelet::M_string remap(ros::names::getRemappings());
+  nodelet::V_string nargv;
+  std::string nodelet_name = ros::this_node::getName();
+  nodelet.load(nodelet_name, "local_planner/LocalPlannerNode", remap, nargv);
+  ros::spin();
 
   return 0;
 }


### PR DESCRIPTION
This PR ports local planner to be able to run as [nodelets](http://wiki.ros.org/nodelet)

Nodelets enables us to run local_planner in platforms which has limited computational resources. The computational benefits come from Nodelets not serializing/deserializing pointclouds to a TCP protocol but sharing the messages via a shared_ptr.

An executable is also added as a node so that the planner can still run as a standalone node. @mrivi 