### PR TITLE
Fix histogram compression

### DIFF
--- a/local_planner/include/local_planner/planner_functions.h
+++ b/local_planner/include/local_planner/planner_functions.h
@@ -52,7 +52,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
 * @param[out] new_hist, compressed elevation histogram
 * @param[in] input_hist, original histogram
 **/
-void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist);
+void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist, const Eigen::Vector3f& position);
 
 /**
 * @brief      calculates each histogram bin cost and stores it in a cost matrix

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -88,7 +88,7 @@ void LocalPlanner::create2DObstacleRepresentation(const bool send_to_fcu) {
   generateNewHistogram(new_histogram, final_cloud_, position_);
 
   if (send_to_fcu) {
-    compressHistogramElevation(to_fcu_histogram_, new_histogram);
+    compressHistogramElevation(to_fcu_histogram_, new_histogram, position_);
     updateObstacleDistanceMsg(to_fcu_histogram_);
   }
   polar_histogram_ = new_histogram;

--- a/local_planner/src/nodes/planner_functions.cpp
+++ b/local_planner/src/nodes/planner_functions.cpp
@@ -102,7 +102,7 @@ void generateNewHistogram(Histogram& polar_histogram, const pcl::PointCloud<pcl:
   }
 }
 
-void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist) {
+void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist, const Eigen::Vector3f& position) {
   float vertical_FOV_range_sensor = 20.0;
   float vertical_cap = 1.0f;  // ignore obstacles, which are more than that above or below the drone.
   PolarPoint p_pol_lower(-1.0f * vertical_FOV_range_sensor / 2.0f, 0.0f, 0.0f);
@@ -115,8 +115,8 @@ void compressHistogramElevation(Histogram& new_hist, const Histogram& input_hist
       if (input_hist.get_dist(e, z) > 0) {
         // check if inside vertical range
         PolarPoint obstacle = histogramIndexToPolar(e, z, ALPHA_RES, input_hist.get_dist(e, z));
-        float ceil_angle = DEG_TO_RAD * (std::abs(obstacle.e) + ALPHA_RES / 2);
-        float height_difference = std::abs(input_hist.get_dist(e, z) * std::sin(ceil_angle));
+        Eigen::Vector3f obstacle_cartesian = polarHistogramToCartesian(obstacle, position);
+        float height_difference = std::abs(position.z() - obstacle_cartesian.z());
         if (height_difference < vertical_cap &&
             (input_hist.get_dist(e, z) < new_hist.get_dist(0, z) || new_hist.get_dist(0, z) == 0.f))
           new_hist.set_dist(0, z, input_hist.get_dist(e, z));


### PR DESCRIPTION
There was a bug in the histogram compression code. This function compresses the histogram to 1D to send it out as a laser scan to the FCU. The histogram data is cropped if it lies too far above or below the drone. There was a mistake in that logic which also made data points on the same height disappear which led to the drone detecting obstacles really late and collision prevention failing