### PR TITLE
don't send range invalid range message

### DIFF
--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -428,7 +428,11 @@ void LocalPlannerNode::publishLaserScan() const {
   if (!(local_planner_->px4_.param_mpc_col_prev_d < 0)) {
     sensor_msgs::LaserScan distance_data_to_fcu;
     local_planner_->getObstacleDistanceData(distance_data_to_fcu);
-    mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
+
+    // only send message if planner had a chance to fill it with valid data
+    if (distance_data_to_fcu.angle_increment > 0.f) {
+      mavros_obstacle_distance_pub_.publish(distance_data_to_fcu);
+    }
   }
 }
 


### PR DESCRIPTION
The planner is waiting for the MPC_COL_PREV_D parameter and will only fill the range message once it got that. If the node thread sends the message before it will contain an angle increment of zero. This does not only make no sense, but could lead to divisions by zero on the firmware side.