### PR TITLE
range value no obstacle

### DIFF
--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -149,7 +149,7 @@ void LocalPlanner::updateObstacleDistanceMsg(Histogram hist) {
 
     // is bin inside FOV?
     if (histogramIndexYawInsideFOV(fov_fcu_frame_, j, position_, yaw_fcu_frame_deg_)) {
-      msg.ranges.push_back(dist > min_sensor_range_ ? dist : max_sensor_range_ + 1.0f);
+      msg.ranges.push_back(dist > min_sensor_range_ ? dist : max_sensor_range_ + 0.01f);
     } else {
       msg.ranges.push_back(NAN);
     }


### PR DESCRIPTION
The values for "no obstacle" are now used in the firmware to limit the max speed by sensor range. To get this correct, the value in a bin without obstacle needs to be just slightly above the max range. Therefore, set range value inside the FOV for no data, just slightly outside the range and not by an entire meter