### PR TITLE
Add ros melodic to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@
 # vim:set ts=2 sw=2 et:
 language: generic
 
-- dist: xenial
-  env: ROS_DISTRO=kinetic
-- dist: bionic
-  env: ROS_DISTRO=melodic
+dist:
+  - xenial
+  - bionic
 
 sudo: required
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 # Based on https://github.com/felixduvallet/ros-travis-integration
 #
 # vim:set ts=2 sw=2 et:
-dist: xenial
-sudo: required
 language: generic
+
+matrix:
+  include:
+    - dist: xenial
+      env: ROS_DISTRO=kinetic
+    - dist: bionic
+      env: ROS_DISTRO=melodic
+sudo: required
 compiler:
   - gcc
 cache:
@@ -18,7 +24,6 @@ env:
   global:
     - ROS_CI_DESKTOP="$(lsb_release -cs)"
     - CI_SOURCE_PATH=$(pwd)
-    - ROS_DISTRO=kinetic
 
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@
 # vim:set ts=2 sw=2 et:
 language: generic
 
-matrix:
-  include:
-    - dist: xenial
-      env: ROS_DISTRO=kinetic
-    - dist: bionic
-      env: ROS_DISTRO=melodic
+- dist: xenial
+  env: ROS_DISTRO=kinetic
+- dist: bionic
+  env: ROS_DISTRO=melodic
+
 sudo: required
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,24 +64,25 @@ install:
   - chmod +x install_geographiclib_datasets.sh
   - sudo -H ./install_geographiclib_datasets.sh
 
+build:
+  script:
+    - set -e
+    - cd ~/catkin_ws
+    - catkin build
+    - source ~/catkin_ws/devel/setup.bash
+    # Check for clang format
+    - cd src/avoidance
+    - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    - (cd tools && ./check_state_machine_diagrams.sh)
+    - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
+    - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
+
 before_script:
   # Source environment
   - source /opt/ros/$ROS_DISTRO/setup.bash
 
 jobs:
   include:
-    - stage: build
-      script:
-        - set -e
-        - cd ~/catkin_ws
-        - catkin build
-        - source ~/catkin_ws/devel/setup.bash
-        # Check for clang format
-        - cd src/avoidance
-        - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-        - (cd tools && ./check_state_machine_diagrams.sh)
-        - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
-        - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
     - stage: test
       dist: xenial
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ env:
     - ROS_CI_DESKTOP="$(lsb_release -cs)"
     - CI_SOURCE_PATH=$(pwd)
 
+stages:
+  - build
+  - test
+
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
   - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
@@ -66,20 +70,28 @@ before_script:
   # Source environment
   - source /opt/ros/$ROS_DISTRO/setup.bash
 
-script:
-  - set -e
-  - cd ~/catkin_ws
-  - catkin build
-  - source ~/catkin_ws/devel/setup.bash
-  # Check for clang format
-  - cd src/avoidance
-  - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  - (cd tools && ./check_state_machine_diagrams.sh)
-  - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
-  - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
-  - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
-
-after_script:
-  - if [[ ROS_DISTRO=kinetic ]]; then  sudo apt-get install -y clang-format-3.8; fi
-  - if [[ ROS_DISTRO=kinetic ]]; then (cd tools && ./check_code_format.sh); fi
-  - if [[ ROS_DISTRO=kinetic ]]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi
+jobs:
+  include:
+    - stage: build
+      script:
+        - set -e
+        - cd ~/catkin_ws
+        - catkin build
+        - source ~/catkin_ws/devel/setup.bash
+        # Check for clang format
+        - cd src/avoidance
+        - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+        - (cd tools && ./check_state_machine_diagrams.sh)
+        - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
+        - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
+    - stage: test
+      dist: xenial
+      script:
+        - sudo apt-get install -y clang-format-3.8; fi
+        - (cd tools && ./check_code_format.sh); fi
+        - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
+        - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi
+    - stage: test
+      dist: bionic
+      script:
+        - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,11 @@ script:
   # Check for clang format
   - cd src/avoidance
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  - (cd tools && ./check_code_format.sh)
   - (cd tools && ./check_state_machine_diagrams.sh)
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
-  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status
+
+after_script:
+  - if [[ ROS_DISTRO=kinetic ]]; then (cd tools && ./check_code_format.sh); fi
+  - if [[ ROS_DISTRO=kinetic ]]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y build-essential git valgrind
   - sudo apt-get install -y python-rosinstall python-rosinstall-generator python-wstool python-catkin-tools
-  # Install clang-format 3.8
-  - sudo apt-get install -y clang-format-3.8
   # Install ROS Kinetic
   - sudo apt-get install -y ros-$ROS_DISTRO-ros-base
   # Install yaml-cpp ROS package
@@ -82,5 +80,6 @@ script:
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
 
 after_script:
+  - if [[ ROS_DISTRO=kinetic ]]; then  sudo apt-get install -y clang-format-3.8; fi
   - if [[ ROS_DISTRO=kinetic ]]; then (cd tools && ./check_code_format.sh); fi
   - if [[ ROS_DISTRO=kinetic ]]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi


### PR DESCRIPTION
Since travis now supports [ubuntu bionic](https://docs.travis-ci.com/user/reference/bionic/), this PR adds a matrix to build and test the avoidance on ros melodic.

As clang-format-3.8 is not available on bionic, the stylecheck fails. 