### PR TITLE
Fix global planner not arming

### DIFF
--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -19,6 +19,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
   world_visualizer_.reset(new avoidance::WorldVisualizer(nh_));
 #endif
 
+  avoidance_node_.init();
   // Read Ros parameters
   readParams();
 


### PR DESCRIPTION
This PR fixes the problem raised by #486 where the `global_planner` is not able to arm.

The regression was caused by #434 as the implementation requires the `avoidance_node` to be explicitly initialized.

Tested in SITL