### PR TITLE
Use Eigen instead of ros_msgs for internal data passing

### DIFF
--- a/local_planner/include/local_planner/local_planner_node.h
+++ b/local_planner/include/local_planner/local_planner_node.h
@@ -204,21 +204,23 @@ class LocalPlannerNode {
   ros::Time last_wp_time_;
   ros::Time t_status_sent_;
 
-  geometry_msgs::PoseStamped hover_point_;
-  geometry_msgs::PoseStamped newest_pose_;
-  geometry_msgs::PoseStamped last_pose_;
-  geometry_msgs::Point newest_waypoint_position_;
-  geometry_msgs::Point last_waypoint_position_;
-  geometry_msgs::Point newest_adapted_waypoint_position_;
-  geometry_msgs::Point last_adapted_waypoint_position_;
-  geometry_msgs::PoseStamped goal_msg_;
-  geometry_msgs::TwistStamped vel_msg_;
-  geometry_msgs::PoseStamped prev_goal_;
-  geometry_msgs::TwistStamped desired_vel_msg_;
   geometry_msgs::PoseStamped goal_mission_item_msg_;
   mavros_msgs::Altitude ground_distance_msg_;
 
   bool new_goal_ = false;
+
+  Eigen::Vector3f newest_waypoint_position_;
+  Eigen::Vector3f last_waypoint_position_;
+  Eigen::Vector3f newest_adapted_waypoint_position_;
+  Eigen::Vector3f last_adapted_waypoint_position_;
+  Eigen::Vector3f newest_position_;
+  Eigen::Quaternionf newest_orientation_;
+  Eigen::Vector3f last_position_;
+  Eigen::Quaternionf last_orientation_;
+  Eigen::Vector3f velocity_;
+  Eigen::Vector3f desired_velocity_;
+  Eigen::Vector3f goal_position_;
+  Eigen::Vector3f prev_goal_position_;
 
   NavigationState nav_state_ = NavigationState::none;
 

--- a/local_planner/include/local_planner/local_planner_visualization.h
+++ b/local_planner/include/local_planner/local_planner_visualization.h
@@ -28,9 +28,9 @@ class LocalPlannerVisualization {
   * @params[in]  newest_adapted_waypoint_position, last caluclated waypoint
   *              (non-smoothed)
   **/
-  void visualizePlannerData(const LocalPlanner& planner, const geometry_msgs::Point& newest_waypoint_position,
-                            const geometry_msgs::Point& newest_adapted_waypoint_position,
-                            const geometry_msgs::PoseStamped& newest_pose) const;
+  void visualizePlannerData(const LocalPlanner& planner, const Eigen::Vector3f& newest_waypoint_position,
+                            const Eigen::Vector3f& newest_adapted_waypoint_position,
+                            const Eigen::Vector3f& newest_position, const Eigen::Quaternionf& newest_orientation) const;
 
   /**
   * @brief       Visualization of the calculated search tree and the best path
@@ -59,9 +59,9 @@ class LocalPlannerVisualization {
   * @params[in]  newest_pose, most recent drone pose
   **/
   void publishDataImages(const std::vector<uint8_t>& histogram_image_data, const std::vector<uint8_t>& cost_image_data,
-                         const geometry_msgs::Point& newest_waypoint_position,
-                         const geometry_msgs::Point& newest_adapted_waypoint_position,
-                         const geometry_msgs::PoseStamped& newest_pose) const;
+                         const Eigen::Vector3f& newest_waypoint_position,
+                         const Eigen::Vector3f& newest_adapted_waypoint_position,
+                         const Eigen::Vector3f& newest_position, const Eigen::Quaternionf newest_orientation) const;
 
   /**
   * @brief       Visualization of the waypoint calculation
@@ -87,9 +87,9 @@ class LocalPlannerVisualization {
   * @params[in]  newest_adapted_wp, location of the adapted waypoint at the
   *              current timestep
   **/
-  void publishPaths(const geometry_msgs::Point& last_pos, const geometry_msgs::Point& newest_pos,
-                    const geometry_msgs::Point& last_wp, const geometry_msgs::Point& newest_wp,
-                    const geometry_msgs::Point& last_adapted_wp, const geometry_msgs::Point& newest_adapted_wp);
+  void publishPaths(const Eigen::Vector3f& last_position, const Eigen::Vector3f& newest_position,
+                    const Eigen::Vector3f& last_wp, const Eigen::Vector3f& newest_wp,
+                    const Eigen::Vector3f& last_adapted_wp, const Eigen::Vector3f& newest_adapted_wp);
 
   /**
   * @brief       Visualization of the sent waypoint color coded with the mode
@@ -100,7 +100,7 @@ class LocalPlannerVisualization {
   * @params[in]  newest_pos, location of the drone at the current timestep
   **/
   void publishCurrentSetpoint(const geometry_msgs::Twist& wp, const PlannerState& waypoint_type,
-                              const geometry_msgs::Point& newest_pos) const;
+                              const Eigen::Vector3f& newest_position) const;
 
   /**
   * @brief       Visualization of the offtrack state
@@ -113,7 +113,7 @@ class LocalPlannerVisualization {
 
   void publishFOV(const std::vector<FOV>& fov, float max_range) const;
 
-  void publishRangeScan(const sensor_msgs::LaserScan& scan, const geometry_msgs::PoseStamped& newest_pose) const;
+  void publishRangeScan(const sensor_msgs::LaserScan& scan, const Eigen::Vector3f& newest_position) const;
 
  private:
   ros::Publisher local_pointcloud_pub_;

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -277,10 +277,9 @@ MAV_STATE LocalPlannerNode::getSystemStatus() { return avoidance_node_->getSyste
 void LocalPlannerNode::calculateWaypoints(bool hover) {
   bool is_airborne = armed_ && (nav_state_ != NavigationState::none);
 
-  wp_generator_->updateState(newest_position_, newest_orientation_,
-                             goal_position_, prev_goal_position_,
-                             velocity_, hover, is_airborne, nav_state_, is_land_waypoint_,
-                             is_takeoff_waypoint_, desired_velocity_);
+  wp_generator_->updateState(newest_position_, newest_orientation_, goal_position_, prev_goal_position_, velocity_,
+                             hover, is_airborne, nav_state_, is_land_waypoint_, is_takeoff_waypoint_,
+                             desired_velocity_);
   waypointResult result = wp_generator_->getWaypoints();
 
   Eigen::Vector3f closest_pt = Eigen::Vector3f(NAN, NAN, NAN);
@@ -294,9 +293,8 @@ void LocalPlannerNode::calculateWaypoints(bool hover) {
 
   // visualize waypoint topics
   visualizer_.visualizeWaypoints(result.goto_position, result.adapted_goto_position, result.smoothed_goto_position);
-  visualizer_.publishPaths(last_position_, newest_position_, last_waypoint_position_,
-                           newest_waypoint_position_, last_adapted_waypoint_position_,
-                           newest_adapted_waypoint_position_);
+  visualizer_.publishPaths(last_position_, newest_position_, last_waypoint_position_, newest_waypoint_position_,
+                           last_adapted_waypoint_position_, newest_adapted_waypoint_position_);
   visualizer_.publishCurrentSetpoint(toTwist(result.linear_velocity_wp, result.angular_velocity_wp),
                                      result.waypoint_type, newest_position_);
 

--- a/local_planner/src/nodes/local_planner_node.cpp
+++ b/local_planner/src/nodes/local_planner_node.cpp
@@ -87,18 +87,15 @@ void LocalPlannerNode::startNode() {
 
 void LocalPlannerNode::readParams() {
   // Parameter from launch file
-  float init_goal_position_x, init_goal_position_y, init_goal_position_z;
-
-  nh_.param<float>("goal_x_param", init_goal_position_x, 9.0);
-  nh_.param<float>("goal_y_param", init_goal_position_y, 13.0);
-  nh_.param<float>("goal_z_param", init_goal_position_z, 3.5);
+  nh_.param<float>("goal_x_param", goal_position_.x(), 9.0);
+  nh_.param<float>("goal_y_param", goal_position_.y(), 13.0);
+  nh_.param<float>("goal_z_param", goal_position_.z(), 3.5);
   nh_.param<bool>("accept_goal_input_topic", accept_goal_input_topic_, false);
 
   std::vector<std::string> camera_topics;
   nh_.getParam("pointcloud_topics", camera_topics);
   initializeCameraSubscribers(camera_topics);
 
-  goal_position_ << init_goal_position_x, init_goal_position_y, init_goal_position_z;
   new_goal_ = true;
 }
 
@@ -319,7 +316,7 @@ void LocalPlannerNode::clickedGoalCallback(const geometry_msgs::PoseStamped& msg
   goal_position_ = toEigen(msg.pose.position);
   /* Selecting the goal from Rviz sets x and y. Get the z coordinate set in
    * the launch file */
-  goal_position_(2) = local_planner_->getGoal().z();
+  goal_position_.z() = local_planner_->getGoal().z();
 }
 
 void LocalPlannerNode::updateGoalCallback(const visualization_msgs::MarkerArray& msg) {

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -33,9 +33,11 @@ void LocalPlannerVisualization::initializePublishers(ros::NodeHandle& nh) {
   range_scan_pub_ = nh.advertise<visualization_msgs::Marker>("/range_scan", 1);
 }
 
-void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner, const Eigen::Vector3f& newest_waypoint_position,
+void LocalPlannerVisualization::visualizePlannerData(const LocalPlanner& planner,
+                                                     const Eigen::Vector3f& newest_waypoint_position,
                                                      const Eigen::Vector3f& newest_adapted_waypoint_position,
-                                                     const Eigen::Vector3f& newest_position, const Eigen::Quaternionf& newest_orientation) const {
+                                                     const Eigen::Vector3f& newest_position,
+                                                     const Eigen::Quaternionf& newest_orientation) const {
   // visualize clouds
   local_pointcloud_pub_.publish(planner.getPointcloud());
   pointcloud_size_pub_.publish(static_cast<uint32_t>(planner.getPointcloud().size()));
@@ -264,7 +266,8 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
                                                   const std::vector<uint8_t>& cost_image_data,
                                                   const Eigen::Vector3f& newest_waypoint_position,
                                                   const Eigen::Vector3f& newest_adapted_waypoint_position,
-                                                  const Eigen::Vector3f& newest_position, const Eigen::Quaternionf newest_orientation) const {
+                                                  const Eigen::Vector3f& newest_position,
+                                                  const Eigen::Quaternionf newest_orientation) const {
   sensor_msgs::Image cost_img;
   cost_img.header.stamp = ros::Time::now();
   cost_img.height = GRID_LENGTH_E;
@@ -281,11 +284,9 @@ void LocalPlannerVisualization::publishDataImages(const std::vector<uint8_t>& hi
   Eigen::Vector2i heading_index = polarToHistogramIndex(heading_pol, ALPHA_RES);
 
   // current setpoint
-  PolarPoint waypoint_pol =
-      cartesianToPolarHistogram(newest_waypoint_position, newest_position);
+  PolarPoint waypoint_pol = cartesianToPolarHistogram(newest_waypoint_position, newest_position);
   Eigen::Vector2i waypoint_index = polarToHistogramIndex(waypoint_pol, ALPHA_RES);
-  PolarPoint adapted_waypoint_pol =
-      cartesianToPolarHistogram(newest_adapted_waypoint_position, newest_position);
+  PolarPoint adapted_waypoint_pol = cartesianToPolarHistogram(newest_adapted_waypoint_position, newest_position);
   Eigen::Vector2i adapted_waypoint_index = polarToHistogramIndex(adapted_waypoint_pol, ALPHA_RES);
 
   // color in the image
@@ -386,9 +387,8 @@ void LocalPlannerVisualization::visualizeWaypoints(const Eigen::Vector3f& goto_p
 }
 
 void LocalPlannerVisualization::publishPaths(const Eigen::Vector3f& last_position,
-                                             const Eigen::Vector3f& newest_position,
-                                             const Eigen::Vector3f& last_wp, const Eigen::Vector3f& newest_wp,
-                                             const Eigen::Vector3f& last_adapted_wp,
+                                             const Eigen::Vector3f& newest_position, const Eigen::Vector3f& last_wp,
+                                             const Eigen::Vector3f& newest_wp, const Eigen::Vector3f& last_adapted_wp,
                                              const Eigen::Vector3f& newest_adapted_wp) {
   // publish actual path
   visualization_msgs::Marker path_actual_marker;

--- a/local_planner/src/nodes/local_planner_visualization.cpp
+++ b/local_planner/src/nodes/local_planner_visualization.cpp
@@ -152,9 +152,7 @@ void LocalPlannerVisualization::publishRangeScan(const sensor_msgs::LaserScan& s
     m.colors.push_back(c);
 
     // side 1
-    geometry_msgs::Point newest_position_msg;
-    newest_position_msg = toPoint(newest_position);
-    m.points.push_back(newest_position_msg);
+    m.points.push_back(toPoint(newest_position));
     m.points.push_back(toPoint(polarHistogramToCartesian(p1, newest_position)));
     m.points.push_back(toPoint(polarHistogramToCartesian(p2, newest_position)));
   }
@@ -404,16 +402,8 @@ void LocalPlannerVisualization::publishPaths(const Eigen::Vector3f& last_positio
   path_actual_marker.color.g = 1.0;
   path_actual_marker.color.b = 0.0;
 
-  geometry_msgs::Point last_pos;
-  last_pos.x = last_position(0);
-  last_pos.y = last_position(1);
-  last_pos.z = last_position(2);
-  path_actual_marker.points.push_back(last_pos);
-  geometry_msgs::Point newest_pos;
-  newest_pos.x = newest_position(0);
-  newest_pos.y = newest_position(1);
-  newest_pos.z = newest_position(2);
-  path_actual_marker.points.push_back(newest_pos);
+  path_actual_marker.points.push_back(toPoint(last_position));
+  path_actual_marker.points.push_back(toPoint(newest_position));
   path_actual_pub_.publish(path_actual_marker);
 
   // publish path set by calculated waypoints
@@ -430,11 +420,8 @@ void LocalPlannerVisualization::publishPaths(const Eigen::Vector3f& last_positio
   path_waypoint_marker.color.g = 0.0;
   path_waypoint_marker.color.b = 0.0;
 
-  geometry_msgs::Point last_wp_msg, newest_wp_msg;
-  last_wp_msg = toPoint(last_wp);
-  newest_wp_msg = toPoint(newest_wp);
-  path_waypoint_marker.points.push_back(last_wp_msg);
-  path_waypoint_marker.points.push_back(newest_wp_msg);
+  path_waypoint_marker.points.push_back(toPoint(last_wp));
+  path_waypoint_marker.points.push_back(toPoint(newest_wp));
   path_waypoint_pub_.publish(path_waypoint_marker);
 
   // publish path set by calculated waypoints
@@ -451,11 +438,8 @@ void LocalPlannerVisualization::publishPaths(const Eigen::Vector3f& last_positio
   path_adapted_waypoint_marker.color.g = 0.0;
   path_adapted_waypoint_marker.color.b = 1.0;
 
-  geometry_msgs::Point last_adapted_wp_msg, newest_adapted_wp_msg;
-  last_adapted_wp_msg = toPoint(last_adapted_wp);
-  newest_adapted_wp_msg = toPoint(newest_adapted_wp);
-  path_adapted_waypoint_marker.points.push_back(last_adapted_wp_msg);
-  path_adapted_waypoint_marker.points.push_back(newest_adapted_wp_msg);
+  path_adapted_waypoint_marker.points.push_back(toPoint(last_adapted_wp));
+  path_adapted_waypoint_marker.points.push_back(toPoint(newest_adapted_wp));
   path_adapted_waypoint_pub_.publish(path_adapted_waypoint_marker);
 
   path_length_++;


### PR DESCRIPTION
A lot of the data that were using `geometry_msgs::PoseStamped` or `geometry_msgs::TwistStamped` were using only the position or linear velocity field in the messages. 

This PR refactors local_planner_node, where ros `msg` formats were used for internal data processing. the ros `msg` format is used only during the callback of the message and when publishing the message itself. 

- Improves the readability of the code as we don't need to look for data inside the messages
- Removes unnecessary calls to `toEigen` or `toPoint` frequently for internal data passing

Tested in SITL
