### PR TITLE
Add ROS melodic to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 # Based on https://github.com/felixduvallet/ros-travis-integration
 #
 # vim:set ts=2 sw=2 et:
-dist: xenial
-sudo: required
 language: generic
+
+matrix:
+  include:
+    - dist: xenial
+      env: ROS_DISTRO=kinetic
+    - dist: bionic
+      env: ROS_DISTRO=melodic
+sudo: required
 compiler:
   - gcc
 cache:
@@ -18,7 +24,6 @@ env:
   global:
     - ROS_CI_DESKTOP="$(lsb_release -cs)"
     - CI_SOURCE_PATH=$(pwd)
-    - ROS_DISTRO=kinetic
 
 before_install:
   - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,11 @@ script:
   # Check for clang format
   - cd src/avoidance
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-  - (cd tools && ./check_code_format.sh)
   - (cd tools && ./check_state_machine_diagrams.sh)
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False -DDISABLE_SIMULATION=ON && catkin build
   - catkin config --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCATKIN_ENABLE_TESTING=True && catkin build avoidance local_planner global_planner safe_landing_planner --no-deps -v -i --catkin-make-args tests
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
-  - (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status
+
+after_script:
+  - if [[ ROS_DISTRO=kinetic ]]; then (cd tools && ./check_code_format.sh); fi
+  - if [[ ROS_DISTRO=kinetic ]]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y build-essential git valgrind
   - sudo apt-get install -y python-rosinstall python-rosinstall-generator python-wstool python-catkin-tools
-  # Install clang-format 3.8
-  - sudo apt-get install -y clang-format-3.8
   # Install ROS Kinetic
   - sudo apt-get install -y ros-$ROS_DISTRO-ros-base
   # Install yaml-cpp ROS package
@@ -82,5 +80,6 @@ script:
   - status=0 && for f in ~/catkin_ws/devel/lib/*/*-test; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 $f || status=1; done
 
 after_script:
-  - if [[ ROS_DISTRO=kinetic ]]; then (cd tools && ./check_code_format.sh); fi
-  - if [[ ROS_DISTRO=kinetic ]]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi
+  - if [ $ROS_DISTRO == kinetic ]; then  sudo apt-get install -y clang-format-3.8; fi
+  - if [ $ROS_DISTRO == kinetic ]; then (cd tools && ./check_code_format.sh); fi
+  - if [ $ROS_DISTRO == kinetic ]; then (roscore &) && for f in ~/catkin_ws/devel/lib/*/*-test-roscore; do valgrind --leak-check=full --track-origins=yes --error-exitcode=1 --suppressions=local_planner/test/valgrind_suppressions.sup $f || status=1; done && exit $status; fi


### PR DESCRIPTION
This PR adds ROS melodic to the travis CI. This will enable testing the avoidance against multiple distributions.

The style checks and roscore tests are only done in ros melodic.

This PR replaces #487 
