### PR TITLE
Port state machine to global planner

### DIFF
--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(global_planner
   src/library/cell.cpp
   src/library/global_planner.cpp
   src/nodes/global_planner_node.cpp
+  src/nodes/waypoint_generator.cpp
 )
 
 ## Add cmake target dependencies of the library

--- a/global_planner/include/global_planner/avoidance_output.h
+++ b/global_planner/include/global_planner/avoidance_output.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ros/time.h>
+#include <Eigen/Dense>
+
+#include <vector>
+
+namespace global_planner {
+
+enum waypoint_choice { loiter, direct, navigate };
+
+struct avoidanceOutput {
+  float cruise_velocity;     // mission cruise velocity
+  ros::Time last_path_time;  // finish built time for the VFH+* tree
+
+  std::vector<Eigen::Vector3f> path_node_positions;  // array of tree nodes
+                                                     // position, each node
+                                                     // is the minimum cost
+                                                     // node for each tree
+                                                     // depth level
+};
+}

--- a/global_planner/include/global_planner/cell.h
+++ b/global_planner/include/global_planner/cell.h
@@ -6,6 +6,7 @@
 #include <tuple>
 
 #include <geometry_msgs/Point.h>
+#include <Eigen/Dense>
 
 #include "global_planner/common.h"
 
@@ -33,6 +34,7 @@ class Cell {
   double zPos() const;
 
   geometry_msgs::Point toPoint() const;
+  Eigen::Vector3f toEigen() const;
 
   double manhattanDist(double _x, double _y, double _z) const;
   double distance2D(const Cell& b) const;

--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -20,6 +20,7 @@
 #include <global_planner/GlobalPlannerNodeConfig.h>
 #include <global_planner/PathWithRiskMsg.h>
 #include "global_planner/analysis.h"
+#include "global_planner/avoidance_output.h"
 #include "global_planner/cell.h"
 #include "global_planner/common.h"
 #include "global_planner/common_ros.h"
@@ -114,6 +115,8 @@ class GlobalPlanner {
   double getAltPrior(const Cell& cell);
   bool isOccupied(const Cell& cell);
   bool isLegal(const Node& node);
+  bool checkCollisiontoGoal(Eigen::Vector3f current_pos, Eigen::Vector3f goal);
+  bool checkCollision(Eigen::Vector3f state);
   double getRisk(const Cell& cell);
   double getRisk(const Node& node);
   double getRiskOfCurve(const std::vector<geometry_msgs::PoseStamped>& msg);
@@ -129,6 +132,8 @@ class GlobalPlanner {
   geometry_msgs::PoseStamped createPoseMsg(const Cell& cell, double yaw);
   nav_msgs::Path getPathMsg();
   nav_msgs::Path getPathMsg(const std::vector<Cell>& path);
+  std::vector<Eigen::Vector3f> getPath();
+  std::vector<Eigen::Vector3f> getPath(std::vector<Cell>& path);
   PathWithRiskMsg getPathWithRiskMsg();
   PathInfo getPathInfo(const std::vector<Cell>& path);
 
@@ -139,6 +144,8 @@ class GlobalPlanner {
   void goBack();
   void stop();
   void setRobotRadius(double radius);
+  avoidanceOutput getAvoidanceOutput();
+  bool isOctomapExists();
 
  private:
   double robot_radius_;

--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -30,6 +30,7 @@
 
 #include "avoidance/avoidance_node.h"
 #include "global_planner/global_planner.h"
+#include "global_planner/waypoint_generator.h"
 
 #ifndef DISABLE_SIMULATION
 #include <avoidance/rviz_world_loader.h>
@@ -92,10 +93,16 @@ class GlobalPlannerNode {
   dynamic_reconfigure::Server<global_planner::GlobalPlannerNodeConfig> server_;
 
   nav_msgs::Path actual_path_;
-  geometry_msgs::Point start_pos_;
   geometry_msgs::PoseStamped current_goal_;
   geometry_msgs::PoseStamped last_goal_;
   geometry_msgs::PoseStamped last_pos_;
+  Eigen::Vector3f current_position_;
+  Eigen::Vector3f current_velocity_;
+  Eigen::Quaternionf current_attitude_;
+  Eigen::Vector3f start_pos_;
+  Eigen::Vector3f goal_position_;
+  Eigen::Vector3f prev_goal_position_;
+  Eigen::Vector3f desired_velocity_;
 
   std::vector<geometry_msgs::PoseStamped> last_clicked_points;
   std::vector<geometry_msgs::PoseStamped> path_;
@@ -116,13 +123,20 @@ class GlobalPlannerNode {
   double clicked_goal_alt_;
   double clicked_goal_radius_;
   bool hover_;
+  bool is_land_waypoint_;
+  bool is_takeoff_waypoint_;
   int simplify_iterations_;
   double simplify_margin_;
 
+  avoidance::NavigationState nav_state_ = avoidance::NavigationState::none;
+
   avoidance::AvoidanceNode avoidance_node_;
+
+  std::unique_ptr<global_planner::WaypointGenerator> wp_generator_;
 #ifndef DISABLE_SIMULATION
   std::unique_ptr<avoidance::WorldVisualizer> world_visualizer_;
 #endif
+
   void readParams();
   void initializeCameraSubscribers(std::vector<std::string>& camera_topics);
   void receivePath(const nav_msgs::Path& msg);

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -22,7 +22,7 @@ struct waypointResult {
   Eigen::Quaternionf orientation_wp;
   Eigen::Vector3f linear_velocity_wp;
   Eigen::Vector3f angular_velocity_wp;
-  Eigen::Vector3f goto_position;           // correction direction, dist=1
+  Eigen::Vector3f goto_position;  // correction direction, dist=1
 };
 
 class WaypointGenerator : public usm::StateMachine<PlannerState> {

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -1,0 +1,172 @@
+#ifndef GLOBAL_PLANNER_WAYPOINT_GENERATOR_H
+#define GLOBAL_PLANNER_WAYPOINT_GENERATOR_H
+
+#include <avoidance/usm.h>
+#include <Eigen/Dense>
+#include "avoidance/common.h"
+#include "global_planner/avoidance_output.h"
+
+#include <ros/time.h>
+
+#include <string>
+#include <vector>
+
+namespace global_planner {
+
+enum class PlannerState { NAVIGATE, LOITER, DIRECT };
+// std::string toString(PlannerState state);  // for logging
+
+struct waypointResult {
+  global_planner::PlannerState waypoint_type;
+  Eigen::Vector3f position_wp;
+  Eigen::Quaternionf orientation_wp;
+  Eigen::Vector3f linear_velocity_wp;
+  Eigen::Vector3f angular_velocity_wp;
+  Eigen::Vector3f goto_position;           // correction direction, dist=1
+  Eigen::Vector3f adapted_goto_position;   // correction direction & dist
+  Eigen::Vector3f smoothed_goto_position;  // what is sent to the drone
+};
+
+class WaypointGenerator : public usm::StateMachine<PlannerState> {
+ private:
+  avoidanceOutput planner_info_;
+  waypointResult output_;
+
+  Eigen::Vector3f smoothed_goto_location_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f smoothed_goto_location_velocity_ = Eigen::Vector3f::Zero();
+  Eigen::Vector3f position_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f loiter_position_ = Eigen::Vector3f(0.0, 0.0, 3.5);
+  Eigen::Vector3f velocity_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f goal_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f prev_goal_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector2f closest_pt_ = Eigen::Vector2f(NAN, NAN);
+  Eigen::Vector3f tmp_goal_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f desired_vel_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f change_altitude_pos_ = Eigen::Vector3f(NAN, NAN, NAN);
+  Eigen::Vector3f hover_position_ = Eigen::Vector3f(NAN, NAN, NAN);
+
+  float curr_yaw_rad_ = NAN;
+  float curr_pitch_deg_ = NAN;
+  ros::Time last_time_{99999.};
+  ros::Time current_time_{99999.};
+
+  float smoothing_speed_xy_{10.f};
+  float smoothing_speed_z_{10.0f};
+
+  bool is_airborne_ = false;
+  bool is_land_waypoint_{false};
+  bool is_takeoff_waypoint_{false};
+  bool reach_altitude_offboard_{false};
+  bool auto_land_{false};
+  bool loiter_{false};
+  bool path_in_collision_{false};
+  float setpoint_yaw_rad_ = 0.0f;
+  float setpoint_yaw_velocity_ = 0.0f;
+  float heading_at_goal_rad_ = NAN;
+  float yaw_reach_height_rad_ = NAN;
+  float speed_ = 1.0f;
+  std::vector<avoidance::FOV> fov_fcu_frame_;
+
+  avoidance::NavigationState nav_state_ = avoidance::NavigationState::none;
+
+  //   // state
+  bool trigger_reset_ = false;
+  bool state_changed_ = false;
+  bool planner_path_exists = false;
+  PlannerState prev_planner_state_ = PlannerState::DIRECT;
+  usm::Transition runLoiter();
+  usm::Transition runDirect();
+  usm::Transition runNavigate();
+
+  /**
+  * @brief iterate the statemachine
+  */
+  usm::Transition runCurrentState() override final;
+
+  /**
+  * @brief the setup of the statemachine
+  */
+  PlannerState chooseNextState(PlannerState currentState, usm::Transition transition) override final;
+
+  /**
+  * @brief     computes position and velocity waypoints based on the input
+  *            waypoint_choice
+  **/
+  void calculateWaypoint();
+
+  /**
+  * @brief     smooths waypoints with a critically damped PD controller
+  * @param[in] dt, time elapsed between two cycles
+  **/
+  void smoothWaypoint(float dt);
+  /**
+  * @brief     change speed depending on the presence of obstacles, proximity to
+  *            the goal, and waypoint lying with the FOV
+  **/
+  void adaptSpeed();
+  /**
+  * @brief     adjust waypoints based on new velocity calculation, proximity to
+  *            goal, smoothing, climing to goal height. Compute waypoint
+  *            orientation
+  **/
+  void getPathMsg();
+
+  //   bool isAltitudeChange();
+
+ public:
+  /**
+  * @brief     getter method for position and velocity waypoints to be sent to
+  *            the FCU
+  * @returns   struct with position and velocity waypoints and intermediate
+  *            results
+  **/
+  waypointResult getWaypoints();
+  /**
+  * @brief     update WaypointGenerator with the latest results of the planning
+  *            algorithm
+  * @param[in] input, local_planner algorithm result
+  **/
+  void setPlannerInfo(const avoidanceOutput& input);
+
+  /**
+  * @brief update with FCU vehice states
+  * @param[in] act_pose, current vehicle position
+  * @param[in] q, current vehicle orientation
+  * @param[in] goal, current goal position
+  * @param[in] prev_goal, previous goal position
+  * @param[in] vel, current vehicle velocity
+  * @param[in] stay, true if the vehicle is loitering
+  * @param[in] is_airborne, true if the vehicle is armed and in avoidance enabled mode
+  * @param[in] nav_state, vehicle navigation state
+  * @param[in] is_land_waypoint, true if the current mission item is a land waypoint
+  * @param[in] is_takeoff_waypoint, true if the current mission item is a takeoff waypoint
+  * @param[in] desired_vel, velocity setpoint from the Firmware
+  **/
+  void updateState(const Eigen::Vector3f& act_pose, const Eigen::Quaternionf& q, const Eigen::Vector3f& goal,
+                   const Eigen::Vector3f& prev_goal, const Eigen::Vector3f& vel, bool stay, bool is_airborne,
+                   const avoidance::NavigationState& nav_state, const bool is_land_waypoint,
+                   const bool is_takeoff_waypoint, const Eigen::Vector3f& desired_vel, const bool path_in_collision);
+
+  bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
+                           float velocity, Eigen::Vector3f& setpoint);
+//   /**
+//   * @brief set the responsiveness of the smoothing
+//   * @param[in] smoothing_speed_xy, set to 0 to disable
+//   * @param[in] smoothing_speed_z, set to 0 to disable
+//   **/
+//   void setSmoothingSpeed(float smoothing_speed_xy, float smoothing_speed_z) {
+//     smoothing_speed_xy_ = smoothing_speed_xy;
+//     smoothing_speed_z_ = smoothing_speed_z;
+//   }
+
+//   /**
+//   * @brief     getter method for the system time
+//   * @returns   current ROS time
+//   **/
+//   virtual ros::Time getSystemTime();
+
+  WaypointGenerator();
+  virtual ~WaypointGenerator() = default;
+};
+}
+#endif  // GLOBAL_PLANNER_WAYPOINT_GENERATOR_H

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -140,21 +140,6 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
 
   bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
                            float velocity, Eigen::Vector3f& setpoint);
-//   /**
-//   * @brief set the responsiveness of the smoothing
-//   * @param[in] smoothing_speed_xy, set to 0 to disable
-//   * @param[in] smoothing_speed_z, set to 0 to disable
-//   **/
-//   void setSmoothingSpeed(float smoothing_speed_xy, float smoothing_speed_z) {
-//     smoothing_speed_xy_ = smoothing_speed_xy;
-//     smoothing_speed_z_ = smoothing_speed_z;
-//   }
-
-//   /**
-//   * @brief     getter method for the system time
-//   * @returns   current ROS time
-//   **/
-//   virtual ros::Time getSystemTime();
 
   WaypointGenerator();
   virtual ~WaypointGenerator() = default;

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -138,7 +138,7 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
                    const avoidance::NavigationState& nav_state, const bool is_land_waypoint,
                    const bool is_takeoff_waypoint, const Eigen::Vector3f& desired_vel, const bool path_in_collision);
 
-  bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const ros::Time& path_generation_time,
+  bool getSetpointFromPath(const std::vector<Eigen::Vector3f>& path, const float time,
                            float velocity, Eigen::Vector3f& setpoint);
 
   WaypointGenerator();

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -23,8 +23,6 @@ struct waypointResult {
   Eigen::Vector3f linear_velocity_wp;
   Eigen::Vector3f angular_velocity_wp;
   Eigen::Vector3f goto_position;           // correction direction, dist=1
-  Eigen::Vector3f adapted_goto_position;   // correction direction & dist
-  Eigen::Vector3f smoothed_goto_position;  // what is sent to the drone
 };
 
 class WaypointGenerator : public usm::StateMachine<PlannerState> {
@@ -98,12 +96,12 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   * @brief     smooths waypoints with a critically damped PD controller
   * @param[in] dt, time elapsed between two cycles
   **/
-  void smoothWaypoint(float dt);
+  Eigen::Vector3f smoothWaypoint(Eigen::Vector3f wp, float dt);
   /**
   * @brief     change speed depending on the presence of obstacles, proximity to
   *            the goal, and waypoint lying with the FOV
   **/
-  void adaptSpeed();
+  Eigen::Vector3f adaptSpeed();
   /**
   * @brief     adjust waypoints based on new velocity calculation, proximity to
   *            goal, smoothing, climing to goal height. Compute waypoint

--- a/global_planner/include/global_planner/waypoint_generator.h
+++ b/global_planner/include/global_planner/waypoint_generator.h
@@ -30,8 +30,6 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   avoidanceOutput planner_info_;
   waypointResult output_;
 
-  Eigen::Vector3f smoothed_goto_location_ = Eigen::Vector3f(NAN, NAN, NAN);
-  Eigen::Vector3f smoothed_goto_location_velocity_ = Eigen::Vector3f::Zero();
   Eigen::Vector3f position_ = Eigen::Vector3f(NAN, NAN, NAN);
   Eigen::Vector3f loiter_position_ = Eigen::Vector3f(0.0, 0.0, 3.5);
   Eigen::Vector3f velocity_ = Eigen::Vector3f(NAN, NAN, NAN);
@@ -92,11 +90,6 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   **/
   void calculateWaypoint();
 
-  /**
-  * @brief     smooths waypoints with a critically damped PD controller
-  * @param[in] dt, time elapsed between two cycles
-  **/
-  Eigen::Vector3f smoothWaypoint(Eigen::Vector3f wp, float dt);
   /**
   * @brief     change speed depending on the presence of obstacles, proximity to
   *            the goal, and waypoint lying with the FOV

--- a/global_planner/src/library/cell.cpp
+++ b/global_planner/src/library/cell.cpp
@@ -24,6 +24,8 @@ geometry_msgs::Point Cell::toPoint() const {
   return point;
 }
 
+Eigen::Vector3f Cell::toEigen() const { return Eigen::Vector3f(xPos(), yPos(), zPos()); }
+
 // Returns the Manhattan-distance from the center of the Cell
 double Cell::manhattanDist(double _x, double _y, double _z) const {
   return std::abs(xPos() - _x) + std::abs(yPos() - _y) + std::abs(zPos() - _z);

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -20,6 +20,8 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
 #endif
 
   avoidance_node_.init();
+  wp_generator_.reset(new global_planner::WaypointGenerator());
+
   // Read Ros parameters
   readParams();
 
@@ -61,7 +63,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
   plannerloop_spinner_->start();
 
   current_goal_.header.frame_id = frame_id_;
-  current_goal_.pose.position = start_pos_;
+  current_goal_.pose.position = avoidance::toPoint(start_pos_);
   current_goal_.pose.orientation = tf::createQuaternionMsgFromYaw(start_yaw_);
   last_goal_ = current_goal_;
 
@@ -75,15 +77,17 @@ GlobalPlannerNode::~GlobalPlannerNode() {}
 // Read Ros parameters
 void GlobalPlannerNode::readParams() {
   std::vector<std::string> camera_topics;
-
-  nh_.param<double>("start_pos_x", start_pos_.x, 0.5);
-  nh_.param<double>("start_pos_y", start_pos_.y, 0.5);
-  nh_.param<double>("start_pos_z", start_pos_.z, 3.5);
+  float start_pos_x, start_pos_y, start_pos_z;
+  nh_.param<float>("start_pos_x", start_pos_x, 0.5);
+  nh_.param<float>("start_pos_y", start_pos_y, 0.5);
+  nh_.param<float>("start_pos_z", start_pos_z, 3.5);
   nh_.param<std::string>("frame_id", frame_id_, "/local_origin");
   nh_.getParam("pointcloud_topics", camera_topics);
 
+  start_pos_ << start_pos_x, start_pos_y, start_pos_z;
+
   initializeCameraSubscribers(camera_topics);
-  global_planner_.goal_pos_ = GoalCell(start_pos_.x, start_pos_.y, start_pos_.z);
+  global_planner_.goal_pos_ = GoalCell(start_pos_(0), start_pos_(1), start_pos_(2));
   double robot_radius;
   nh_.param<double>("robot_radius", robot_radius, 0.5);
   global_planner_.setFrame(frame_id_);
@@ -101,6 +105,7 @@ void GlobalPlannerNode::initializeCameraSubscribers(std::vector<std::string>& ca
 // Sets a new goal, plans a path to it and publishes some info
 void GlobalPlannerNode::setNewGoal(const GoalCell& goal) {
   ROS_INFO("========== Set goal : %s ==========", goal.asString().c_str());
+  goal_position_ = goal.toEigen();
   global_planner_.setGoal(goal);
   publishGoal(goal);
 }
@@ -112,10 +117,6 @@ void GlobalPlannerNode::popNextGoal() {
     GoalCell new_goal = waypoints_.front();
     waypoints_.erase(waypoints_.begin());
     setNewGoal(new_goal);
-  } else if (global_planner_.goal_is_blocked_) {
-    // Goal is blocked but there is no other goal in waypoints_, just stop
-    ROS_INFO("  STOP  ");
-    global_planner_.stop();
   }
 }
 
@@ -190,6 +191,7 @@ void GlobalPlannerNode::dynamicReconfigureCallback(global_planner::GlobalPlanner
 }
 
 void GlobalPlannerNode::velocityCallback(const geometry_msgs::TwistStamped& msg) {
+  current_velocity_ = avoidance::toEigen(msg.twist.linear);
   global_planner_.curr_vel_ = msg.twist.linear;
 }
 
@@ -197,6 +199,8 @@ void GlobalPlannerNode::velocityCallback(const geometry_msgs::TwistStamped& msg)
 void GlobalPlannerNode::positionCallback(const geometry_msgs::PoseStamped& msg) {
   // Update position
   last_pos_ = msg;
+  current_position_ = avoidance::toEigen(msg.pose.position);
+  current_attitude_ = avoidance::toEigen(msg.pose.orientation);
   global_planner_.setPose(last_pos_);
 
   // Check if a new goal is needed
@@ -313,6 +317,8 @@ void GlobalPlannerNode::setCurrentPath(const std::vector<geometry_msgs::PoseStam
 
 void GlobalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
   hover_ = false;
+  bool is_airborne = true;
+  bool direct_path_is_collision = true;
 
   // Check if all information was received
   ros::Time now = ros::Time::now();
@@ -321,6 +327,13 @@ void GlobalPlannerNode::cmdLoopCallback(const ros::TimerEvent& event) {
   ros::Duration since_start = now - start_time_;
 
   avoidance_node_.checkFailsafe(since_last_cloud, since_start, hover_);
+  direct_path_is_collision = global_planner_.checkCollisiontoGoal(current_position_, goal_position_);
+
+  // TODO: Switch this to waypoint generator
+  wp_generator_->updateState(current_position_, current_attitude_, goal_position_, prev_goal_position_,
+                             current_velocity_, hover_, is_airborne, nav_state_, is_land_waypoint_,
+                             is_takeoff_waypoint_, desired_velocity_, direct_path_is_collision);
+
   publishSetpoint();
 }
 
@@ -330,9 +343,10 @@ void GlobalPlannerNode::plannerLoopCallback(const ros::TimerEvent& event) {
   if (is_in_goal || global_planner_.goal_is_blocked_) {
     popNextGoal();
   }
-
-  planPath();
-
+  if (global_planner_.isOctomapExists()) {
+    planPath();
+    wp_generator_->setPlannerInfo(global_planner_.getAvoidanceOutput());
+  }
   // Print and publish info
   if (is_in_goal && !waypoints_.empty()) {
     ROS_INFO("Reached current goal %s, %d goals left\n\n", global_planner_.goal_pos_.asString().c_str(),
@@ -380,29 +394,16 @@ void GlobalPlannerNode::printPointInfo(double x, double y, double z) {
 }
 
 void GlobalPlannerNode::publishSetpoint() {
-  // Vector pointing from current position to the current goal
-  tf::Vector3 vec = toTfVector3(subtractPoints(current_goal_.pose.position, last_pos_.pose.position));
-  // If we are less than 1.0 away, then we should stop at the goal
-  double new_len = vec.length() < 1.0 ? vec.length() : speed_;
-  vec.normalize();
-  vec *= new_len;
-
-  auto setpoint = current_goal_;  // The intermediate position sent to Mavros
-  setpoint.pose.position.x = last_pos_.pose.position.x + vec.getX();
-  setpoint.pose.position.y = last_pos_.pose.position.y + vec.getY();
-  setpoint.pose.position.z = last_pos_.pose.position.z + vec.getZ();
-
-  // Publish setpoint for vizualization
-  current_waypoint_publisher_.publish(setpoint);
-
-  // Publish setpoint to Mavros
-  mavros_waypoint_publisher_.publish(setpoint);
-  mavros_msgs::Trajectory obst_free_path = {};
   geometry_msgs::Twist velocity_setpoint{};
   velocity_setpoint.linear.x = NAN;
   velocity_setpoint.linear.y = NAN;
   velocity_setpoint.linear.z = NAN;
-  avoidance::transformToTrajectory(obst_free_path, setpoint, velocity_setpoint);
+
+  waypointResult result = wp_generator_->getWaypoints();
+
+  mavros_msgs::Trajectory obst_free_path = {};
+  avoidance::transformToTrajectory(obst_free_path, avoidance::toPoseStamped(result.position_wp, result.orientation_wp),
+                                   velocity_setpoint);
   mavros_obstacle_free_path_pub_.publish(obst_free_path);
 }
 

--- a/global_planner/src/nodes/waypoint_generator.cpp
+++ b/global_planner/src/nodes/waypoint_generator.cpp
@@ -162,12 +162,11 @@ void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose, const Eigen
 
   // Initialize the smoothing point to current location, if it is undefined or
   // the  vehicle is not flying autonomously yet
-  if (!is_airborne_ ) {
+  if (!is_airborne_) {
     setpoint_yaw_rad_ = curr_yaw_rad_;
     setpoint_yaw_velocity_ = 0.f;
     reach_altitude_offboard_ = false;
   }
-
 }
 
 Eigen::Vector3f WaypointGenerator::adaptSpeed() {
@@ -193,13 +192,11 @@ Eigen::Vector3f WaypointGenerator::adaptSpeed() {
 
     heading_at_goal_rad_ = NAN;
     adapted_wp = position_ + pose_to_wp;
-
   }
 
   ROS_INFO("[WG] Speed adapted WP: [%f %f %f].", adapted_wp.x(), adapted_wp.y(), adapted_wp.z());
   return adapted_wp;
 }
-
 
 // create the message that is sent to the UAV
 void WaypointGenerator::getPathMsg() {
@@ -213,8 +210,7 @@ void WaypointGenerator::getPathMsg() {
   output_.position_wp = adapted_wp;
   output_.angular_velocity_wp = Eigen::Vector3f::Zero();
 
-  avoidance::createPoseMsg(output_.position_wp, output_.orientation_wp, output_.position_wp,
-                           setpoint_yaw_rad_);
+  avoidance::createPoseMsg(output_.position_wp, output_.orientation_wp, output_.position_wp, setpoint_yaw_rad_);
 }
 
 waypointResult WaypointGenerator::getWaypoints() {

--- a/global_planner/src/nodes/waypoint_generator.cpp
+++ b/global_planner/src/nodes/waypoint_generator.cpp
@@ -1,0 +1,307 @@
+#include <ros/param.h>
+
+#include "avoidance/common.h"
+#include "global_planner/waypoint_generator.h"
+
+namespace global_planner {
+
+WaypointGenerator::WaypointGenerator() : usm::StateMachine<PlannerState>(PlannerState::LOITER) {}
+
+using global_planner::PlannerState;
+std::string toString(PlannerState state) {
+  std::string state_str = "unknown";
+  switch (state) {
+    case PlannerState::NAVIGATE:
+      state_str = "NAVIGATE";
+      break;
+    case PlannerState::LOITER:
+      state_str = "LOITER";
+      break;
+    case PlannerState::DIRECT:
+      state_str = "DIRECT";
+      break;
+  }
+  return state_str;
+}
+
+PlannerState WaypointGenerator::chooseNextState(PlannerState currentState, usm::Transition transition) {
+  prev_planner_state_ = currentState;
+  state_changed_ = true;
+
+  // clang-format off
+  USM_TABLE(
+      currentState, PlannerState::DIRECT,
+      USM_STATE(transition, PlannerState::NAVIGATE, USM_MAP(usm::Transition::NEXT1, PlannerState::DIRECT);
+         USM_MAP(usm::Transition::NEXT2, PlannerState::LOITER));
+      USM_STATE(transition, PlannerState::LOITER, USM_MAP(usm::Transition::NEXT1, PlannerState::DIRECT);
+         USM_MAP(usm::Transition::NEXT2, PlannerState::NAVIGATE));
+      USM_STATE(transition, PlannerState::DIRECT, USM_MAP(usm::Transition::NEXT1, PlannerState::NAVIGATE);
+         USM_MAP(usm::Transition::NEXT2, PlannerState::LOITER));
+            // clang-format on
+            );
+}
+
+usm::Transition WaypointGenerator::runCurrentState() {
+  if (trigger_reset_) {
+    trigger_reset_ = false;
+    return usm::Transition::ERROR;
+  }
+  usm::Transition t;
+  switch (getState()) {
+    case PlannerState::NAVIGATE:
+      t = runNavigate();
+      break;
+
+    case PlannerState::LOITER:
+      t = runLoiter();
+      break;
+
+    case PlannerState::DIRECT:
+      t = runDirect();
+      break;
+  }
+  state_changed_ = false;
+  return t;
+}
+
+usm::Transition WaypointGenerator::runLoiter() {
+  // Loiter in position when a collision free path cannot be found
+  output_.goto_position = loiter_position_;
+
+  // Escape lotier when planner comes up with a path
+  planner_path_exists = bool(planner_info_.path_node_positions.size() > 0);
+
+  getPathMsg();
+  if (planner_path_exists) {
+    if (path_in_collision_)
+      return usm::Transition::NEXT2;  // NAVIGATE
+    else
+      return usm::Transition::NEXT1;  // DIRECT
+  } else
+    return usm::Transition::REPEAT;
+}
+
+usm::Transition WaypointGenerator::runDirect() {
+  Eigen::Vector3f dir = (goal_ - position_).normalized();
+  output_.goto_position = position_ + dir;
+
+  ROS_INFO("[WG] Going straight to selected waypoint: [%f, %f, %f].", output_.goto_position.x(),
+           output_.goto_position.y(), output_.goto_position.z());
+
+  getPathMsg();
+
+  planner_path_exists = bool(planner_info_.path_node_positions.size() > 0);
+  // Update Loiter postiion
+  loiter_position_ = position_;
+  if (path_in_collision_) {
+    if (planner_path_exists) {
+      // Start navigating with path planner when there is a collision
+      return usm::Transition::NEXT1;  // NAVIGATE
+    } else {
+      return usm::Transition::NEXT2;  // Loiter
+    }
+  } else {
+    return usm::Transition::REPEAT;
+  }
+}
+
+usm::Transition WaypointGenerator::runNavigate() {
+  Eigen::Vector3f setpoint = position_;
+  const bool tree_available = getSetpointFromPath(planner_info_.path_node_positions, planner_info_.last_path_time,
+                                                  planner_info_.cruise_velocity, setpoint);
+  output_.goto_position = position_ + (setpoint - position_).normalized();
+  getPathMsg();
+  planner_path_exists = bool(planner_info_.path_node_positions.size() > 2);
+  loiter_position_ = position_;
+  if (!planner_path_exists) {
+    if (path_in_collision_)
+      return usm::Transition::NEXT2;  // Loiter
+    else
+      return usm::Transition::NEXT1;  // Direct
+  } else
+    return usm::Transition::REPEAT;
+}
+
+void WaypointGenerator::calculateWaypoint() {
+  ROS_DEBUG("\033[1;32m[WG] Generate Waypoint, current position: [%f, %f, %f].\033[0m", position_.x(), position_.y(),
+            position_.z());
+  output_.linear_velocity_wp = Eigen::Vector3f(NAN, NAN, NAN);
+
+  // Timing
+  last_time_ = current_time_;
+  current_time_ = ros::Time::now();
+
+  iterateOnce();
+  output_.waypoint_type = getState();
+  if (getState() != prev_planner_state_) {
+    std::string state_str = toString(getState());
+    ROS_DEBUG("\033[1;36m [WGN] Update to %s state \n \033[0m", state_str.c_str());
+  }
+}
+
+void WaypointGenerator::updateState(const Eigen::Vector3f& act_pose, const Eigen::Quaternionf& q,
+                                    const Eigen::Vector3f& goal, const Eigen::Vector3f& prev_goal,
+                                    const Eigen::Vector3f& vel, bool stay, bool is_airborne,
+                                    const avoidance::NavigationState& nav_state, const bool is_land_waypoint,
+                                    const bool is_takeoff_waypoint, const Eigen::Vector3f& desired_vel,
+                                    bool path_in_collision) {
+  position_ = act_pose;
+  velocity_ = vel;
+  goal_ = goal;
+  prev_goal_ = prev_goal;
+  curr_yaw_rad_ = avoidance::getYawFromQuaternion(q) * avoidance::DEG_TO_RAD;
+  curr_pitch_deg_ = avoidance::getPitchFromQuaternion(q);
+  nav_state_ = nav_state;
+  is_land_waypoint_ = is_land_waypoint;
+  is_takeoff_waypoint_ = is_takeoff_waypoint;
+  desired_vel_ = desired_vel;
+  loiter_ = stay;
+  path_in_collision_ = path_in_collision;
+
+  is_airborne_ = is_airborne;
+
+  // Initialize the smoothing point to current location, if it is undefined or
+  // the  vehicle is not flying autonomously yet
+  if (!is_airborne_ || !smoothed_goto_location_.allFinite() || !smoothed_goto_location_velocity_.allFinite()) {
+    smoothed_goto_location_ = position_;
+    smoothed_goto_location_velocity_ = Eigen::Vector3f::Zero();
+    setpoint_yaw_rad_ = curr_yaw_rad_;
+    setpoint_yaw_velocity_ = 0.f;
+    reach_altitude_offboard_ = false;
+  }
+
+  // If we're changing altitude by Firmware setpoints, keep reinitializing the smoothing
+  if (auto_land_) {
+    smoothed_goto_location_ = position_;
+    smoothed_goto_location_velocity_ = Eigen::Vector3f::Zero();
+  }
+}
+
+// void WaypointGenerator::transformPositionToVelocityWaypoint() {
+//   output_.linear_velocity_wp = output_.position_wp - position_;
+//   output_.angular_velocity_wp.x() = 0.0f;
+//   output_.angular_velocity_wp.y() = 0.0f;
+//   output_.angular_velocity_wp.z() = getAngularVelocity(setpoint_yaw_rad_, curr_yaw_rad_);
+// }
+
+void WaypointGenerator::smoothWaypoint(float dt) {
+  // If the smoothing speed is set to zero, dont smooth, aka use adapted
+  // waypoint directly
+  if (smoothing_speed_xy_ < 0.01f || smoothing_speed_z_ < 0.01f) {
+    output_.smoothed_goto_position = output_.adapted_goto_position;
+    return;
+  }
+
+  // Smooth differently in xz than in z
+  const Eigen::Array3f P_constant(smoothing_speed_xy_, smoothing_speed_xy_, smoothing_speed_z_);
+  const Eigen::Array3f D_constant = 2 * P_constant.sqrt();
+
+  const Eigen::Vector3f desired_location = output_.adapted_goto_position;
+  // Prevent overshoot when drone is close to goal
+  const Eigen::Vector3f desired_velocity =
+      (desired_location - goal_).norm() < 0.1 ? Eigen::Vector3f::Zero() : velocity_;
+
+  Eigen::Vector3f location_diff = desired_location - smoothed_goto_location_;
+  if (!location_diff.allFinite() || location_diff.norm() > 10.0) {
+    location_diff = Eigen::Vector3f::Zero();
+  }
+
+  Eigen::Vector3f velocity_diff = desired_velocity - smoothed_goto_location_velocity_;
+  if (!velocity_diff.allFinite()|| velocity_diff.norm() > 100.0) {
+    velocity_diff = Eigen::Vector3f::Zero();
+  }
+
+  const Eigen::Vector3f p = location_diff.array() * P_constant;
+  const Eigen::Vector3f d = velocity_diff.array() * D_constant;
+  smoothed_goto_location_velocity_ += (p + d) * dt;
+  smoothed_goto_location_ += smoothed_goto_location_velocity_ * dt;
+  output_.smoothed_goto_position = output_.adapted_goto_position;
+
+  ROS_DEBUG("[WG] Smoothed GoTo location: %f, %f, %f, with dt=%f", output_.smoothed_goto_position.x(),
+            output_.smoothed_goto_position.y(), output_.smoothed_goto_position.z(), dt);
+}
+
+void WaypointGenerator::adaptSpeed() {
+  speed_ = planner_info_.cruise_velocity;
+
+  // If the goal is so close, that the speed-adapted way point would overreach
+  float goal_dist = (goal_ - position_).norm();
+  if (goal_dist < 1.f) {
+    output_.adapted_goto_position = goal_;
+
+    // First time we reach this goal, remember the heading
+    if (!std::isfinite(heading_at_goal_rad_)) {
+      heading_at_goal_rad_ = curr_yaw_rad_;
+    }
+    setpoint_yaw_rad_ = heading_at_goal_rad_;
+  } else {
+    // Scale the pose_to_wp by the speed
+    Eigen::Vector3f pose_to_wp = output_.goto_position - position_;
+    if (pose_to_wp.norm() > 0.1f) pose_to_wp.normalize();
+    pose_to_wp *= std::min(speed_, goal_dist);
+
+    heading_at_goal_rad_ = NAN;
+    output_.adapted_goto_position = position_ + pose_to_wp;
+  }
+
+  ROS_INFO("[WG] Speed adapted WP: [%f %f %f].", output_.adapted_goto_position.x(), output_.adapted_goto_position.y(),
+           output_.adapted_goto_position.z());
+}
+
+// create the message that is sent to the UAV
+void WaypointGenerator::getPathMsg() {
+  output_.adapted_goto_position = output_.goto_position;
+
+  float time_diff_sec = static_cast<float>((current_time_ - last_time_).toSec());
+  float dt = time_diff_sec > 0.0f ? time_diff_sec : 0.0001f;
+
+  if (!auto_land_) {
+    // in auto_land the z is only velocity controlled. Therefore we don't run the smoothing.
+    adaptSpeed();
+    smoothWaypoint(dt);
+  }
+  output_.position_wp = output_.smoothed_goto_position;
+  output_.angular_velocity_wp = Eigen::Vector3f::Zero();
+  avoidance::createPoseMsg(output_.position_wp, output_.orientation_wp, output_.adapted_goto_position,
+                           setpoint_yaw_rad_);
+}
+
+waypointResult WaypointGenerator::getWaypoints() {
+  calculateWaypoint();
+  return output_;
+}
+
+void WaypointGenerator::setPlannerInfo(const avoidanceOutput& input) { planner_info_ = input; }
+
+bool WaypointGenerator::getSetpointFromPath(const std::vector<Eigen::Vector3f>& path,
+                                            const ros::Time& path_generation_time, float velocity,
+                                            Eigen::Vector3f& setpoint) {
+  int num_pathsegments = path.size();
+
+  // path contains nothing meaningful
+  if (num_pathsegments < 2) {
+    return false;
+  }
+
+  // path only has one segment: return end of that segment as setpoint
+  if (num_pathsegments == 2) {
+    setpoint = path[0];
+    return true;
+  }
+
+  // step through the path until the point where we should be if we had traveled perfectly with velocity along it
+  float distance_left = (ros::Time::now() - path_generation_time).toSec() * velocity;
+
+  for (int i = 1; i < num_pathsegments; i++) {
+    Eigen::Vector3f path_segment = path[i] - path[i - 1];
+
+    if (distance_left > path_segment.norm()) {
+      distance_left -= path_segment.norm();
+    } else {
+      setpoint = (distance_left / path_segment.norm()) * path_segment + path[i - 1];
+      return true;
+    }
+  }
+  return false;
+}
+}

--- a/global_planner/src/nodes/waypoint_generator.cpp.dot
+++ b/global_planner/src/nodes/waypoint_generator.cpp.dot
@@ -1,0 +1,9 @@
+digraph {
+    "NAVIGATE" -> "DIRECT" [label="NEXT1\nERROR", style="solid", weight=1]
+    "NAVIGATE" -> "LOITER" [label="NEXT2", style="solid", weight=1]
+    "LOITER" -> "DIRECT" [label="NEXT1\nERROR", style="solid", weight=1]
+    "LOITER" -> "NAVIGATE" [label="NEXT2", style="solid", weight=1]
+    "DIRECT" -> "NAVIGATE" [label="NEXT1", style="solid", weight=1]
+    "DIRECT" -> "LOITER" [label="NEXT2", style="solid", weight=1]
+    "DIRECT" -> "DIRECT" [label="ERROR", style="dotted", weight=0.1]
+}

--- a/global_planner/test/test_waypoint_generator.cpp
+++ b/global_planner/test/test_waypoint_generator.cpp
@@ -25,12 +25,32 @@ class WaypointGeneratorTests : public ::testing::Test, public WaypointGenerator 
 
 TEST_F(WaypointGeneratorTests, getSetpointFromPath) {
     const std::vector<Eigen::Vector3f> path;
-    const ros::Time path_generation_time;
-    float velocity;
+    double time;
+    float velocity = 5.0;
     Eigen::Vector3f setpoint;
     bool result;
-    
-    result = getSetpointFromPath(path, path_generation_time, velocity, setpoint);
 
+    //Empty path
+    path.clear();
+    result = getSetpointFromPath(path, time, velocity, setpoint);
     EXPECT_EQ(result, false);
+
+    //Pathsize=1 TODO: THere is a bug
+    time = 0.0;
+    path.push_back(Eigen::Vector3f(0.5, 1.0, 2.0));
+    result = getSetpointFromPath(path, time, velocity, setpoint);
+    EXPECT_EQ(result, false);
+
+
+    time = 0.0;
+    path.push_back(Eigen::Vector3f(0.5, 1.0, 2.0));
+    result = getSetpointFromPath(path, time, velocity, setpoint);
+
+    EXPECT_EQ(result, true);
+    EXPECT_EQ(path.size(), 2);
+    EXPECT_EQ(result, true);
+    EXEPCT_FLOAT_EQ(path[0].x(), setpoint.x());
+    EXEPCT_FLOAT_EQ(path[1].y(), setpoint.y());
+    EXEPCT_FLOAT_EQ(path[2].z(), setpoint.z());
+
 }

--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -126,9 +126,10 @@ void LocalPlanner::determineStrategy() {
   closest_pt_.head<2>() = prev_goal_.head<2>() + (u_prev_to_goal * u_prev_to_goal.dot(prev_to_pos));
   closest_pt_.z() = goal_.z();
 
-  // if the vehicle is less than the cruise speed away from the line, set the projection point to the goal such that
-  // the cost function doesn't pull the vehicle towards the line
-  if ((position_ - closest_pt_).head<2>().norm() < px4_.param_mpc_xy_cruise) {
+  // if the vehicle is less than the cruise speed away from the line or if prev goal is the same as goal,
+  // set the projection point to the goal such that the cost function doesn't pull the vehicle towards the line
+  if ((position_ - closest_pt_).head<2>().norm() < px4_.param_mpc_xy_cruise ||
+      (goal_ - prev_goal_).head<2>().norm() < 0.001f) {
     closest_pt_ = goal_;
   }
 

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -380,7 +380,6 @@ void WaypointGenerator::getPathMsg() {
 
   float time_diff_sec = static_cast<float>((current_time_ - last_time_).toSec());
   float dt = time_diff_sec > 0.0f ? time_diff_sec : 0.0001f;
-
   // set the yaw at the setpoint based on our smoothed location
   nextSmoothYaw(dt);
 

--- a/tools/check_state_machine_diagrams.sh
+++ b/tools/check_state_machine_diagrams.sh
@@ -4,6 +4,7 @@
 python generate_flow_diagram.py ../avoidance/test/test_usm.cpp
 python generate_flow_diagram.py ../safe_landing_planner/src/nodes/waypoint_generator.cpp
 python generate_flow_diagram.py ../local_planner/src/nodes/waypoint_generator.cpp
+python generate_flow_diagram.py ../global_planner/src/nodes/waypoint_generator.cpp
 
 # Print the diff with the remote branch (empty if no diff)
 git --no-pager diff -U0 --color


### PR DESCRIPTION
This PR adds a state machine and a waypoint generator for the global planner to handle the state of the vehicle more robustly.

The states are defined as three states, which are 
  - `DIRECT`: fly directly to the next waypoint identical to mission mode
  - `NAVIGATE`: When path in `DIRECT` state is in collision with a obstacle, uses the global planner to find a collision free path
  - `LOITER`: Fall back state where the drone should keep a designated position. This is uaually the last current position update in `NAVIGATE` or `DIRECT`

The waypoint generator creates waypoints along the path found from the global planner assuming the cruise velocity is constant along the path.