### PR TITLE
Remove hardcoded parameter namespace

### DIFF
--- a/avoidance/include/avoidance/rviz_world_loader.h
+++ b/avoidance/include/avoidance/rviz_world_loader.h
@@ -49,11 +49,12 @@ class WorldVisualizer {
   ros::Publisher drone_pub_;
 
   std::string world_path_;
+  std::string nodelet_ns_;
 
   void loopCallback(const ros::TimerEvent& event);
 
  public:
-  WorldVisualizer(const ros::NodeHandle& nh);
+  WorldVisualizer(const ros::NodeHandle& nh, const std::string& nodelet_ns);
 
   /**
   * @brief      initializes all publishers used for local planner visualization

--- a/avoidance/src/rviz_world_loader.cpp
+++ b/avoidance/src/rviz_world_loader.cpp
@@ -4,7 +4,8 @@
 
 namespace avoidance {
 
-WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
+WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh, const std::string& nodelet_ns)
+    : nh_(nh), nodelet_ns_(nodelet_ns) {
   pose_sub_ = nh_.subscribe<const geometry_msgs::PoseStamped&>("/mavros/local_position/pose", 1,
                                                                &WorldVisualizer::positionCallback, this);
 
@@ -12,7 +13,13 @@ WorldVisualizer::WorldVisualizer(const ros::NodeHandle& nh) : nh_(nh) {
   drone_pub_ = nh_.advertise<visualization_msgs::Marker>("/drone", 1);
   loop_timer_ = nh_.createTimer(ros::Duration(2.0), &WorldVisualizer::loopCallback, this);
 
-  nh_.param<std::string>("/local_planner_nodelet/world_name", world_path_, "");
+  std::string world_string;
+  if (!nodelet_ns_.empty()) {
+    world_string = nodelet_ns_ + "/world_name";
+  } else {
+    world_string = "/world_name";
+  }
+  nh_.param<std::string>(world_string, world_path_, "");
 }
 
 void WorldVisualizer::loopCallback(const ros::TimerEvent& event) {

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -16,7 +16,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
   server_.setCallback(f);
 
 #ifndef DISABLE_SIMULATION
-  world_visualizer_.reset(new avoidance::WorldVisualizer(nh_));
+  world_visualizer_.reset(new avoidance::WorldVisualizer(nh_, ros::this_node::getName()));
 #endif
 
   avoidance_node_.init();

--- a/local_planner/src/nodes/local_planner_nodelet.cpp
+++ b/local_planner/src/nodes/local_planner_nodelet.cpp
@@ -58,7 +58,7 @@ void LocalPlannerNodelet::InitializeNodelet() {
   avoidance_node_.reset(new AvoidanceNode(nh_, nh_private_));
 
 #ifndef DISABLE_SIMULATION
-  world_visualizer_.reset(new WorldVisualizer(nh_));
+  world_visualizer_.reset(new WorldVisualizer(nh_, nodelet::Nodelet::getName()));
 #endif
 
   readParams();

--- a/safe_landing_planner/src/nodes/safe_landing_planner_node.cpp
+++ b/safe_landing_planner/src/nodes/safe_landing_planner_node.cpp
@@ -8,9 +8,8 @@ SafeLandingPlannerNode::SafeLandingPlannerNode(const ros::NodeHandle &nh) : nh_(
   safe_landing_planner_.reset(new SafeLandingPlanner());
 
 #ifndef DISABLE_SIMULATION
-  world_visualizer_.reset(new avoidance::WorldVisualizer(nh_));
+  world_visualizer_.reset(new avoidance::WorldVisualizer(nh_, ros::this_node::getName()));
 #endif
-
   visualizer_.initializePublishers(nh_);
 
   std::string camera_topic;


### PR DESCRIPTION
For the nodelet PR we hardcoded the namespace of the parameter specifying the world yaml file. Therefore the world visualization wasn't correcly loaded for safe landing and global planner. This PR fixes this issue by getting the parameter namespace at runtime