### PR TITLE
initialize values correctly

### DIFF
--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -92,9 +92,9 @@ class LocalPlanner {
   std::vector<uint8_t> cost_image_data_;
   bool currently_armed_ = false;
 
-  double timeout_startup_;
-  double timeout_critical_;
-  double timeout_termination_;
+  double timeout_startup_ = 20.0;
+  double timeout_critical_ = 0.5;
+  double timeout_termination_ = 20.0;
   float speed_ = 1.0f;
   float mission_item_speed_ = NAN;
 

--- a/local_planner/src/nodes/local_planner_nodelet.cpp
+++ b/local_planner/src/nodes/local_planner_nodelet.cpp
@@ -245,6 +245,7 @@ void LocalPlannerNodelet::cmdLoopCallback(const ros::TimerEvent& event) {
 
   // Process callbacks & wait for a position update
   ros::Time start_query_position = ros::Time::now();
+
   while (!position_received_ && ros::ok()) {
     ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
     ros::Duration since_query = ros::Time::now() - start_query_position;
@@ -252,7 +253,7 @@ void LocalPlannerNodelet::cmdLoopCallback(const ros::TimerEvent& event) {
       setSystemStatus(MAV_STATE::MAV_STATE_FLIGHT_TERMINATION);
       if (!position_not_received_error_sent_) {
         // clang-format off
-        ROS_WARN("\033[1;33m Planner abort: missing required data \n \033[0m");
+        ROS_WARN("\033[1;33m Planner abort: missing required data from FCU \n \033[0m");
         ROS_WARN("----------------------------- Debugging Info -----------------------------");
         ROS_WARN("Local planner has not received a position from FCU, check the following: ");
         ROS_WARN("1. Check cables connecting PX4 autopilot with onboard computer");


### PR DESCRIPTION
This caused issues on one of the boards, because the the timeout was initialized at zero and if the command loop was faster than the reconfigure (increasing the timeout to the correct value) the planner would abort immediately