### PR TITLE
Fix asynchonous camera transforms

### DIFF
--- a/avoidance/src/transform_buffer.cpp
+++ b/avoidance/src/transform_buffer.cpp
@@ -67,7 +67,7 @@ bool TransformBuffer::getTransform(const std::string& source_frame, const std::s
     return false;
   } else {
     if (iterator->second.back().stamp_ < time) {
-      // "TF Buffer: could not retrieve requested transform from buffer, tf has not yet arrived"
+      print(log_level::warn, "TF Buffer: could not retrieve requested transform from buffer, tf has not yet arrived");
       return false;
     } else if (iterator->second.front().stamp_ > time) {
       print(log_level::warn,

--- a/avoidance/src/transform_buffer.cpp
+++ b/avoidance/src/transform_buffer.cpp
@@ -67,7 +67,7 @@ bool TransformBuffer::getTransform(const std::string& source_frame, const std::s
     return false;
   } else {
     if (iterator->second.back().stamp_ < time) {
-      print(log_level::warn, "TF Buffer: could not retrieve requested transform from buffer, tf has not yet arrived");
+      print(log_level::debug, "TF Buffer: could not retrieve requested transform from buffer, tf has not yet arrived");
       return false;
     } else if (iterator->second.front().stamp_ > time) {
       print(log_level::warn,

--- a/local_planner/include/local_planner/local_planner_nodelet.h
+++ b/local_planner/include/local_planner/local_planner_nodelet.h
@@ -53,7 +53,6 @@ class LocalPlanner;
 class WaypointGenerator;
 
 struct cameraData {
-
   std::string topic_;
   ros::Subscriber pointcloud_sub_;
 
@@ -63,15 +62,13 @@ struct cameraData {
   pcl::PointCloud<pcl::PointXYZ> transformed_cloud_;
   bool transformed_;
 
+  std::unique_ptr<std::mutex> camera_mutex_;
+  std::unique_ptr<std::condition_variable> camera_cv_;
 
   bool transform_registered_ = false;
-  std::unique_ptr<std::mutex> camera_mutex_;
-
-  std::unique_ptr<std::mutex> camera_cv_mutex_;
-  std::unique_ptr<std::condition_variable> camera_cv_;
   std::thread transform_thread_;
-  FOV fov_fcu_frame_;
 
+  FOV fov_fcu_frame_;
 };
 
 class LocalPlannerNodelet : public nodelet::Nodelet {

--- a/local_planner/include/local_planner/local_planner_nodelet.h
+++ b/local_planner/include/local_planner/local_planner_nodelet.h
@@ -66,6 +66,9 @@ struct cameraData {
 
   bool transform_registered_ = false;
   std::unique_ptr<std::mutex> camera_mutex_;
+
+  std::unique_ptr<std::mutex> camera_cv_mutex_;
+  std::unique_ptr<std::condition_variable> camera_cv_;
   std::thread transform_thread_;
   FOV fov_fcu_frame_;
 
@@ -234,6 +237,7 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
   dynamic_reconfigure::Server<avoidance::LocalPlannerNodeConfig>* server_ = nullptr;
   tf::TransformListener* tf_listener_ = nullptr;
   avoidance::tf_buffer::TransformBuffer tf_buffer_;
+  std::condition_variable tf_buffer_cv_;
 
   std::mutex buffered_transforms_mutex_;
   std::vector<std::pair<std::string, std::string>> buffered_transforms_;

--- a/local_planner/include/local_planner/local_planner_nodelet.h
+++ b/local_planner/include/local_planner/local_planner_nodelet.h
@@ -86,8 +86,6 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
 
   std::atomic<bool> should_exit_{false};
 
-  std::vector<cameraData> cameras_;
-
   std::unique_ptr<LocalPlanner> local_planner_;
   std::unique_ptr<WaypointGenerator> wp_generator_;
   std::unique_ptr<ros::AsyncSpinner> cmdloop_spinner_;
@@ -235,6 +233,11 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
 
   std::mutex buffered_transforms_mutex_;
   std::vector<std::pair<std::string, std::string>> buffered_transforms_;
+
+  std::mutex transformed_cloud_mutex_;
+  std::condition_variable transformed_cloud_cv_;
+
+  std::vector<cameraData> cameras_;
 
   bool armed_ = false;
   bool data_ready_ = false;

--- a/local_planner/include/local_planner/local_planner_nodelet.h
+++ b/local_planner/include/local_planner/local_planner_nodelet.h
@@ -105,8 +105,6 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
   std::mutex running_mutex_;  ///< guard against concurrent access to input &
                               /// output data (point cloud, position, ...)
 
-  std::mutex data_ready_mutex_;
-  std::condition_variable data_ready_cv_;
   bool position_received_ = false;
 
   /**
@@ -118,8 +116,6 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
   * @brief     start spinners
   **/
   void startNode();
-
-  void updatePlanner();
 
   /**
   * @brief     updates the local planner agorithm with the latest pointcloud,
@@ -216,6 +212,7 @@ class LocalPlannerNodelet : public nodelet::Nodelet {
 
   bool new_goal_ = false;
 
+  std::mutex waypoints_mutex_;
   Eigen::Vector3f newest_waypoint_position_;
   Eigen::Vector3f last_waypoint_position_;
   Eigen::Vector3f newest_adapted_waypoint_position_;

--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -33,6 +33,7 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   avoidanceOutput planner_info_;
   waypointResult output_;
 
+  std::mutex running_mutex_;
   Eigen::Vector3f smoothed_goto_location_ = Eigen::Vector3f(NAN, NAN, NAN);
   Eigen::Vector3f smoothed_goto_location_velocity_ = Eigen::Vector3f::Zero();
   Eigen::Vector3f position_ = Eigen::Vector3f(NAN, NAN, NAN);
@@ -64,6 +65,7 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   float heading_at_goal_rad_ = NAN;
   float yaw_reach_height_rad_ = NAN;
   float speed_ = 1.0f;
+
   std::vector<FOV> fov_fcu_frame_;
 
   NavigationState nav_state_ = NavigationState::none;

--- a/local_planner/src/nodes/local_planner_nodelet.cpp
+++ b/local_planner/src/nodes/local_planner_nodelet.cpp
@@ -15,7 +15,7 @@
 
 namespace avoidance {
 
-LocalPlannerNodelet::LocalPlannerNodelet() : spin_dt_(0.1), tf_buffer_(5.f) {}
+LocalPlannerNodelet::LocalPlannerNodelet() : tf_buffer_(5.f), spin_dt_(0.1) {}
 
 LocalPlannerNodelet::~LocalPlannerNodelet() {
   should_exit_ = true;
@@ -25,7 +25,6 @@ LocalPlannerNodelet::~LocalPlannerNodelet() {
   if (worker_tf_listener.joinable()) worker_tf_listener.join();
 
   for (size_t i = 0; i < cameras_.size(); ++i) {
-    cameras_[i].cloud_ready_cv_->notify_all();
     if (cameras_[i].transform_thread_.joinable()) cameras_[i].transform_thread_.join();
   }
 
@@ -51,7 +50,6 @@ void LocalPlannerNodelet::onInit() {
 void LocalPlannerNodelet::InitializeNodelet() {
   nh_ = ros::NodeHandle("~");
   nh_private_ = ros::NodeHandle("");
-  const bool tf_spin_thread = true;
 
   local_planner_.reset(new LocalPlanner());
   wp_generator_.reset(new WaypointGenerator());
@@ -63,7 +61,7 @@ void LocalPlannerNodelet::InitializeNodelet() {
 
   readParams();
 
-  tf_listener_ = new tf::TransformListener(ros::Duration(tf::Transformer::DEFAULT_CACHE_TIME), tf_spin_thread);
+  tf_listener_ = new tf::TransformListener(ros::Duration(tf::Transformer::DEFAULT_CACHE_TIME), true);
 
   // initialize standard subscribers
   pose_sub_ = nh_.subscribe<const geometry_msgs::PoseStamped&>("/mavros/local_position/pose", 1,
@@ -127,63 +125,34 @@ void LocalPlannerNodelet::initializeCameraSubscribers(std::vector<std::string>& 
   cameras_.resize(camera_topics.size());
 
   for (size_t i = 0; i < camera_topics.size(); i++) {
-    cameras_[i].cloud_msg_mutex_.reset(new std::mutex);
-    cameras_[i].transformed_cloud_mutex_.reset(new std::mutex);
-    cameras_[i].cloud_ready_cv_.reset(new std::condition_variable);
+    cameras_[i].camera_mutex_.reset(new std::mutex);
+
+    cameras_[i].received_ = false;
     cameras_[i].transformed_ = false;
 
     cameras_[i].pointcloud_sub_ = nh_.subscribe<sensor_msgs::PointCloud2>(
         camera_topics[i], 1, boost::bind(&LocalPlannerNodelet::pointCloudCallback, this, _1, i));
     cameras_[i].topic_ = camera_topics[i];
-    cameras_[i].received_ = false;
     cameras_[i].transform_thread_ = std::thread(&LocalPlannerNodelet::pointCloudTransformThread, this, i);
   }
-}
-
-size_t LocalPlannerNodelet::numReceivedClouds() {
-  size_t num_received_clouds = 0;
-  for (size_t i = 0; i < cameras_.size(); i++) {
-    if (cameras_[i].received_) num_received_clouds++;
-  }
-  return num_received_clouds;
 }
 
 size_t LocalPlannerNodelet::numTransformedClouds() {
   size_t num_transformed_clouds = 0;
   for (size_t i = 0; i < cameras_.size(); i++) {
-    std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].transformed_cloud_mutex_));
+    std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].camera_mutex_));
     if (cameras_[i].transformed_) num_transformed_clouds++;
   }
   return num_transformed_clouds;
-}
-
-void LocalPlannerNodelet::updatePlanner() {
-  if (cameras_.size() == numReceivedClouds() && cameras_.size() != 0) {
-    if (cameras_.size() == numTransformedClouds()) {
-      if (running_mutex_.try_lock()) {
-        updatePlannerInfo();
-        // reset all clouds to not yet received
-        for (size_t i = 0; i < cameras_.size(); i++) {
-          cameras_[i].received_ = false;
-        }
-        wp_generator_->setPlannerInfo(local_planner_->getAvoidanceOutput());
-        running_mutex_.unlock();
-        // Wake up the planner
-        std::unique_lock<std::mutex> lck(data_ready_mutex_);
-        data_ready_ = true;
-        data_ready_cv_.notify_one();
-      }
-    }
-  }
 }
 
 void LocalPlannerNodelet::updatePlannerInfo() {
   // update the point cloud
   local_planner_->original_cloud_vector_.clear();
   for (size_t i = 0; i < cameras_.size(); ++i) {
-    std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].transformed_cloud_mutex_));
+    std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[i].camera_mutex_));
     try {
-      local_planner_->original_cloud_vector_.push_back(std::move(cameras_[i].pcl_cloud));
+      local_planner_->original_cloud_vector_.push_back(std::move(cameras_[i].transformed_cloud_));
       cameras_[i].transformed_ = false;
       local_planner_->setFOV(i, cameras_[i].fov_fcu_frame_);
       wp_generator_->setFOV(i, cameras_[i].fov_fcu_frame_);
@@ -207,6 +176,22 @@ void LocalPlannerNodelet::updatePlannerInfo() {
 
   // update last sent waypoint
   local_planner_->last_sent_waypoint_ = newest_waypoint_position_;
+}
+
+void LocalPlannerNodelet::updatePlanner() {
+  if (cameras_.size() != 0 && cameras_.size() == numTransformedClouds()) {
+    if (running_mutex_.try_lock()) {
+      updatePlannerInfo();
+      wp_generator_->setPlannerInfo(local_planner_->getAvoidanceOutput());
+      running_mutex_.unlock();
+      // Wake up the planner
+      std::lock_guard<std::mutex> lck(data_ready_mutex_);
+      data_ready_ = true;
+      data_ready_cv_.notify_one();
+    }
+  } else {
+    ROS_ERROR("Not enough transformed clouds");
+  }
 }
 
 void LocalPlannerNodelet::positionCallback(const geometry_msgs::PoseStamped& msg) {
@@ -383,29 +368,20 @@ void LocalPlannerNodelet::distanceSensorCallback(const mavros_msgs::Altitude& ms
 }
 
 void LocalPlannerNodelet::transformBufferThread() {
-  // wait until all pointclouds were received for the first time and added to the transform list
-  while (!should_exit_) {
-    bool all_tf_registered = true;
-    for (auto const& camera : cameras_) {
-      all_tf_registered = all_tf_registered && camera.transform_registered_;
-    }
-    if (all_tf_registered) {
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  }
-
   // grab transforms from tf and store them into the buffer
   while (!should_exit_) {
-    for (auto const& frame_pair : buffered_transforms_) {
-      tf::StampedTransform transform;
+    {
+      std::lock_guard<std::mutex> guard(buffered_transforms_mutex_);
+      for (auto const& frame_pair : buffered_transforms_) {
+        tf::StampedTransform transform;
 
-      if (tf_listener_->canTransform(frame_pair.second, frame_pair.first, ros::Time(0))) {
-        try {
-          tf_listener_->lookupTransform(frame_pair.second, frame_pair.first, ros::Time(0), transform);
-          tf_buffer_.insertTransform(frame_pair.first, frame_pair.second, transform);
-        } catch (tf::TransformException& ex) {
-          ROS_ERROR("Received an exception trying to transform a pointcloud: %s", ex.what());
+        if (tf_listener_->canTransform(frame_pair.second, frame_pair.first, ros::Time(0))) {
+          try {
+            tf_listener_->lookupTransform(frame_pair.second, frame_pair.first, ros::Time(0), transform);
+            tf_buffer_.insertTransform(frame_pair.first, frame_pair.second, transform);
+          } catch (tf::TransformException& ex) {
+            ROS_ERROR("Received an exception trying to get transform: %s", ex.what());
+          }
         }
       }
     }
@@ -428,17 +404,31 @@ void LocalPlannerNodelet::printPointInfo(double x, double y, double z) {
 }
 
 void LocalPlannerNodelet::pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg, int index) {
-  std::lock_guard<std::mutex> lck(*(cameras_[index].cloud_msg_mutex_));
-  cameras_[index].newest_cloud_msg_ = *msg;  // FIXME: avoid a copy
+  std::lock_guard<std::mutex> lck(*(cameras_[index].camera_mutex_));
+
+  auto timeSinceLast = [&]() -> ros::Duration {
+    ros::Time lastCloudReceived = pcl_conversions::fromPCL(cameras_[index].untransformed_cloud_.header.stamp);
+    return msg->header.stamp - lastCloudReceived;
+  };
+
+  if (cameras_[index].received_ && timeSinceLast() < ros::Duration(0.3)) {
+    return;
+  }
+
+  pcl::fromROSMsg(*msg, cameras_[index].untransformed_cloud_);
   cameras_[index].received_ = true;
+
+  // this runs once at the beginning to get the transforms
   if (!cameras_[index].transform_registered_) {
+    std::lock_guard<std::mutex> tf_list_guard(buffered_transforms_mutex_);
     std::pair<std::string, std::string> transform_frames;
     transform_frames.first = msg->header.frame_id;
     transform_frames.second = "/local_origin";
     buffered_transforms_.push_back(transform_frames);
+    transform_frames.second = "/fcu";
+    buffered_transforms_.push_back(transform_frames);
     cameras_[index].transform_registered_ = true;
   }
-  cameras_[index].cloud_ready_cv_->notify_one();
 }
 
 void LocalPlannerNodelet::dynamicReconfigureCallback(avoidance::LocalPlannerNodeConfig& config, uint32_t level) {
@@ -463,7 +453,7 @@ void LocalPlannerNodelet::publishLaserScan() const {
 
 void LocalPlannerNodelet::threadFunction() {
   while (!should_exit_) {
-    // wait for data
+    //     wait for data
     {
       std::unique_lock<std::mutex> lk(data_ready_mutex_);
       data_ready_cv_.wait(lk, [this] { return data_ready_ && !should_exit_; });
@@ -472,18 +462,16 @@ void LocalPlannerNodelet::threadFunction() {
 
     if (should_exit_) break;
 
-    {
-      std::lock_guard<std::mutex> guard(running_mutex_);
-      std::clock_t start_time_ = std::clock();
-      local_planner_->runPlanner();
-      visualizer_.visualizePlannerData(*(local_planner_.get()), newest_waypoint_position_,
-                                       newest_adapted_waypoint_position_, newest_position_, newest_orientation_);
-      publishLaserScan();
-      last_wp_time_ = ros::Time::now();
+    std::lock_guard<std::mutex> guard(running_mutex_);
+    std::clock_t start_time_ = std::clock();
+    local_planner_->runPlanner();
+    visualizer_.visualizePlannerData(*(local_planner_.get()), newest_waypoint_position_,
+                                     newest_adapted_waypoint_position_, newest_position_, newest_orientation_);
+    publishLaserScan();
+    last_wp_time_ = ros::Time::now();
 
-      ROS_DEBUG("\033[0;35m[OA]Planner calculation time: %2.2f ms \n \033[0m",
-                (std::clock() - start_time_) / (double)(CLOCKS_PER_SEC / 1000));
-    }
+    ROS_DEBUG("\033[0;35m[OA]Planner calculation time: %2.2f ms \n \033[0m",
+              (std::clock() - start_time_) / (double)(CLOCKS_PER_SEC / 1000));
   }
 }
 
@@ -493,41 +481,49 @@ void LocalPlannerNodelet::checkFailsafe(ros::Duration since_last_cloud, ros::Dur
 
 void LocalPlannerNodelet::pointCloudTransformThread(int index) {
   while (!should_exit_) {
+    bool waiting_on_transform = false;  // else, waiting on new frame
+    bool waiting_on_cloud = false;      // else, waiting on new frame
     {
-      std::unique_lock<std::mutex> cloud_msg_lock(*(cameras_[index].cloud_msg_mutex_));
-      cameras_[index].cloud_ready_cv_->wait(cloud_msg_lock);
-    }
-    while (cameras_[index].transformed_ == false) {
-      if (should_exit_) break;
+      std::lock_guard<std::mutex> camera_lock(*(cameras_[index].camera_mutex_));
 
-      std::unique_ptr<std::lock_guard<std::mutex>> cloud_msg_lock(
-          new std::lock_guard<std::mutex>(*(cameras_[index].cloud_msg_mutex_)));
+      if (cameras_[index].received_) {
+        tf::StampedTransform cloud_transform;
+        tf::StampedTransform fcu_transform;
 
-      tf::StampedTransform transform;
-      if (tf_buffer_.getTransform(cameras_[index].newest_cloud_msg_.header.frame_id, "/local_origin",
-                                  cameras_[index].newest_cloud_msg_.header.stamp, transform)) {
-        pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
-        // transform message to pcl type
-        pcl::fromROSMsg(cameras_[index].newest_cloud_msg_, pcl_cloud);
-        cloud_msg_lock.reset();
+        if (tf_buffer_.getTransform(cameras_[index].untransformed_cloud_.header.frame_id, "/local_origin",
+                                    pcl_conversions::fromPCL(cameras_[index].untransformed_cloud_.header.stamp),
+                                    cloud_transform) &&
+            tf_buffer_.getTransform(cameras_[index].untransformed_cloud_.header.frame_id, "/fcu",
+                                    pcl_conversions::fromPCL(cameras_[index].untransformed_cloud_.header.stamp),
+                                    fcu_transform)) {
+          // remove nan padding and compute fov
+          pcl::PointCloud<pcl::PointXYZ> maxima = removeNaNAndGetMaxima(cameras_[index].untransformed_cloud_);
 
-        // remove nan padding and compute fov
-        pcl::PointCloud<pcl::PointXYZ> maxima = removeNaNAndGetMaxima(pcl_cloud);
-        pcl_ros::transformPointCloud("fcu", maxima, maxima, *tf_listener_);
-        updateFOVFromMaxima(cameras_[index].fov_fcu_frame_, maxima);
+          // update point cloud FOV
+          pcl_ros::transformPointCloud(maxima, maxima, fcu_transform);
+          updateFOVFromMaxima(cameras_[index].fov_fcu_frame_, maxima);
 
-        // transform cloud to /local_origin frame
-        pcl_ros::transformPointCloud(pcl_cloud, pcl_cloud, transform);
-        pcl_cloud.header.frame_id = "/local_origin";
+          // transform cloud to /local_origin frame
+          pcl_ros::transformPointCloud(cameras_[index].untransformed_cloud_, cameras_[index].transformed_cloud_,
+                                       cloud_transform);
+          cameras_[index].transformed_cloud_.header.frame_id = "/local_origin";
+          cameras_[index].transformed_cloud_.header.stamp = cameras_[index].untransformed_cloud_.header.stamp;
 
-        std::lock_guard<std::mutex> transformed_cloud_guard(*(cameras_[index].transformed_cloud_mutex_));
-        cameras_[index].transformed_ = true;
-        cameras_[index].pcl_cloud = std::move(pcl_cloud);
-
+          cameras_[index].transformed_ = true;
+          cameras_[index].received_ = false;
+          waiting_on_cloud = true;
+        } else {
+          waiting_on_transform = true;
+        }
       } else {
-        cloud_msg_lock.reset();
-        ros::Duration(0.001).sleep();
+        waiting_on_cloud = true;
       }
+    }
+    if (waiting_on_transform) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));  // wake up on new transform
+    }
+    if (waiting_on_cloud) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));  // wake up on new point cloud
     }
   }
 }


### PR DESCRIPTION
This reworks the condition variables and mutexes around the point cloud transformation. It should now be a) safer and easier to maintain than before b) lower latency and c) lower CPU usage.

It gets rid of the poll for when new transforms arrive in the transform buffer, uses a single mutex for the each camera's point cloud instead of 2, and gets rid of all (I think) non-threadsafe access to the `camera_` vector.

Tested in SITL, needs testing on a real vehicle.