### PR TITLE
Fix rising if goal lies high up but not exactly above drone

### DIFF
--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -137,7 +137,8 @@ usm::Transition WaypointGenerator::runAltitudeChange() {
       change_altitude_pos_ = position_;
     } else {
       // Change altitude
-      output_.goto_position = goal_;
+      output_.goto_position.topRows<2>() = change_altitude_pos_.topRows<2>();
+      output_.goto_position.z() = goal_.z();
 
       if (auto_land_) {
         output_.goto_position.topRows<2>() = change_altitude_pos_.topRows<2>();


### PR DESCRIPTION
There was a bug in changeAltitude state if the goal was high up but not exactly above the drone. In this case the drone would slow down. Once it is slower than 0.5m/s in x-y velocity, the setpoint was set to the goal which led the drone to accelerate towards the goal. Now if that goal is not at the same x-y coordinat, the x-y velocity increases and once it goes above 0.5m/s the drone has to slow down again. It is stuck in that loop of accelerating and deccelerating until it has reached a height close enough.

Fix: Lock the x-y coordinate of the goal to one position and rise up straight before moving towards the goal

![20191206_094907](https://user-images.githubusercontent.com/25756842/70309845-b5631600-180e-11ea-8aa2-2bfb5f32d8d1.jpg)
