### PR TITLE
bug fix: NAN in closest point if goal = prev_goal (e.g. in RTL)

### DIFF
--- a/local_planner/src/nodes/local_planner.cpp
+++ b/local_planner/src/nodes/local_planner.cpp
@@ -126,9 +126,10 @@ void LocalPlanner::determineStrategy() {
   closest_pt_.head<2>() = prev_goal_.head<2>() + (u_prev_to_goal * u_prev_to_goal.dot(prev_to_pos));
   closest_pt_.z() = goal_.z();
 
-  // if the vehicle is less than the cruise speed away from the line, set the projection point to the goal such that
-  // the cost function doesn't pull the vehicle towards the line
-  if ((position_ - closest_pt_).head<2>().norm() < px4_.param_mpc_xy_cruise) {
+  // if the vehicle is less than the cruise speed away from the line or if prev goal is the same as goal,
+  // set the projection point to the goal such that the cost function doesn't pull the vehicle towards the line
+  if ((position_ - closest_pt_).head<2>().norm() < px4_.param_mpc_xy_cruise ||
+      (goal_ - prev_goal_).head<2>().norm() < 0.001f) {
     closest_pt_ = goal_;
   }
 


### PR DESCRIPTION
Sometimes e.g. if RTL is triggered twice in a row, it happens that prev_goal = goal. This case was not handled, the normalized() function returns NANs which causes the whole cost matrix to be NAN. This leads to the planner just going straight (even if there is a tree_ because all costs are the same (=NAN).