### PR TITLE
 [Global Planner] Fix Alt Prior handling

### DIFF
--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -161,8 +161,21 @@ double GlobalPlanner::getSingleCellRisk(const Cell& cell) {
 }
 
 double GlobalPlanner::getAltPrior(const Cell& cell) {
-  // return alt_prior_[cell.zIndex()];
-  return alt_prior_[std::round(cell.zPos())];
+    
+    int index = std::round(cell.zPos());
+
+    if (index > alt_prior_.size() - 1)
+    {
+        return alt_prior_.back();
+    }
+    else if (index < 0)
+    {
+        return alt_prior_.front();
+    }
+    else
+    {
+        return alt_prior_.at(index);
+    }
 }
 
 bool GlobalPlanner::isOccupied(const Cell& cell) { return getSingleCellRisk(cell) > 0.5; }

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -161,21 +161,15 @@ double GlobalPlanner::getSingleCellRisk(const Cell& cell) {
 }
 
 double GlobalPlanner::getAltPrior(const Cell& cell) {
-    
-    int index = std::round(cell.zPos());
+  int index = std::round(cell.zPos());
 
-    if (index > alt_prior_.size() - 1)
-    {
-        return alt_prior_.back();
-    }
-    else if (index < 0)
-    {
-        return alt_prior_.front();
-    }
-    else
-    {
-        return alt_prior_.at(index);
-    }
+  if (index > alt_prior_.size() - 1) {
+    return alt_prior_.back();
+  } else if (index < 0) {
+    return alt_prior_.front();
+  } else {
+    return alt_prior_.at(index);
+  }
 }
 
 bool GlobalPlanner::isOccupied(const Cell& cell) { return getSingleCellRisk(cell) > 0.5; }


### PR DESCRIPTION
alt_prior_ is pre-defined & limited length std::vector (currently 25 elements are defined)
Accessing out of index of this vector for path finding can cause path finder to fail, thus high altitude RTL is not available in current status.
This would allow high altitude RTL to work in current master, tested in SITL.