### PR TITLE
Improve planning repeatability

### DIFF
--- a/local_planner/include/local_planner/tree_node.h
+++ b/local_planner/include/local_planner/tree_node.h
@@ -15,6 +15,7 @@ class TreeNode {
   float heuristic_;
   int origin_;
   bool closed_;
+  int depth_;
 
   TreeNode();
   TreeNode(int from, const Eigen::Vector3f& pos, const Eigen::Vector3f& vel);

--- a/local_planner/src/nodes/tree_node.cpp
+++ b/local_planner/src/nodes/tree_node.cpp
@@ -2,13 +2,13 @@
 
 namespace avoidance {
 
-TreeNode::TreeNode() : total_cost_{0.0f}, heuristic_{0.0f}, origin_{0}, closed_{false} {
+TreeNode::TreeNode() : total_cost_{0.0f}, heuristic_{0.0f}, origin_{0}, closed_{false}, depth_(0) {
   position_ = Eigen::Vector3f::Zero();
   velocity_ = Eigen::Vector3f::Zero();
 }
 
 TreeNode::TreeNode(int from, const Eigen::Vector3f& pos, const Eigen::Vector3f& vel)
-    : total_cost_{0.0f}, heuristic_{0.0f}, origin_{from}, closed_{false} {
+    : total_cost_{0.0f}, heuristic_{0.0f}, origin_{from}, closed_{false}, depth_(0) {
   position_ = pos;
   velocity_ = vel;
 }


### PR DESCRIPTION
Use the longest A* path weighted by cost, since we don't plan all of the way to the goal.

Before, the path chosen could have been any of the green cells, right up to the point of finding the red cell.
![image](https://user-images.githubusercontent.com/1746276/73009352-ab25c700-3e10-11ea-9efa-afae76af9b4f.png)
(play around with it [here](https://qiao.github.io/PathFinding.js/visual/))

Now, it will find roughly the longest path until it actually reaches the end.

Happy for comments on what exactly we can do for a quick win here to improve the choice mechanism for the A* when it only plans partially.