### PR TITLE
Speed Adaption Rework and Cost Function Tuning

### DIFF
--- a/local_planner/include/local_planner/waypoint_generator.h
+++ b/local_planner/include/local_planner/waypoint_generator.h
@@ -64,7 +64,7 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   float setpoint_yaw_velocity_ = 0.0f;
   float heading_at_goal_rad_ = NAN;
   float yaw_reach_height_rad_ = NAN;
-  float speed_ = 1.0f;
+  float speed_ = 0.0f;
 
   std::vector<FOV> fov_fcu_frame_;
 
@@ -115,8 +115,9 @@ class WaypointGenerator : public usm::StateMachine<PlannerState> {
   /**
   * @brief     change speed depending on the presence of obstacles, proximity to
   *            the goal, and waypoint lying with the FOV
+  * @param[in] dt, time elapsed between two cycles
   **/
-  void adaptSpeed();
+  void adaptSpeed(float dt);
   /**
   * @brief     adjust waypoints based on new velocity calculation, proximity to
   *            goal, smoothing, climing to goal height. Compute waypoint

--- a/local_planner/src/nodes/waypoint_generator.cpp
+++ b/local_planner/src/nodes/waypoint_generator.cpp
@@ -418,6 +418,7 @@ waypointResult WaypointGenerator::getWaypoints() {
 bool WaypointGenerator::isAltitudeChange() {
   bool rtl_descend = false;
   bool rtl_climb = false;
+
   if (position_.z() > (goal_.z() - 0.8f)) {
     rtl_descend = false;
     rtl_climb = false;
@@ -439,7 +440,7 @@ bool WaypointGenerator::isAltitudeChange() {
   const bool need_to_change_altitude = offboard_goal_altitude_not_reached || auto_takeoff || auto_land_;
   if (need_to_change_altitude) {
     if (nav_state_ == NavigationState::offboard) {
-      if (position_.z() > goal_.z()) {
+      if (position_.z() >= goal_.z()) {
         reach_altitude_offboard_ = true;
         return false;
       }

--- a/local_planner/test/test_waypoint_generator.cpp
+++ b/local_planner/test/test_waypoint_generator.cpp
@@ -167,7 +167,7 @@ TEST_F(WaypointGeneratorTests, reachAltitudeOffboardTest) {
   ASSERT_EQ(PlannerState::ALTITUDE_CHANGE, getState());
 
   // WHEN: we generate subsequent waypoints
-  for (size_t i = 0; i < 6; i++) {
+  for (size_t i = 0; i < 20; i++) {
     // calculate new vehicle position
     time_sec += 0.03;
     time = ros::Time(time_sec);
@@ -175,6 +175,10 @@ TEST_F(WaypointGeneratorTests, reachAltitudeOffboardTest) {
                 is_takeoff_waypoint, desired_velocity);
     waypointResult result = getWaypoints();
 
+    // break the loop when done with the altitude change
+    if (PlannerState::ALTITUDE_CHANGE != getState()) {
+      break;
+    }
     ASSERT_EQ(PlannerState::ALTITUDE_CHANGE, getState());
 
     // THEN: we expect the z velocity component on the setpoint not to be set


### PR DESCRIPTION
This PR adds a lowpass filter to the speed adaption function and restructures it to get rid of discontinuities in the demanded velocity signal. The setpoint coming out of this function undergoes smoothing afterwards, so we thought the very rudimentary velocity calculation would do, but adding this simple filter improved flight behavior significantly.

The plots below show the velocity coming out of the speed adaption function on the right and the signal after smoothing on the left. The derivative shows the commanded acceleration to visualize the difference.

Also I changed the pitching cost slightly, because the drone kept arriving too high at the goal and had to turn and search its way down. Both plots show the same mission with 6 goals in SITL. On the timescale it can be seen that master takes 3:20min to complete whereas the PR takes 2min.

Flight tests pending...

current master:
![pr_old](https://user-images.githubusercontent.com/25756842/73528853-f72aca00-4415-11ea-9ef7-c1f05c818abf.png)

PR:
![pr_new](https://user-images.githubusercontent.com/25756842/73528872-fc881480-4415-11ea-8817-ee98d20a443b.png)

