### PR TITLE
Use C++ 14 instead of C++ 11 (PCL 1.10 requires C++14 as the minimum)

### DIFF
--- a/avoidance/CMakeLists.txt
+++ b/avoidance/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(avoidance)
 
-add_definitions(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(global_planner)
 
-add_definitions(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(local_planner)
 
-add_definitions(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
 ## Find catkin macros and libraries

--- a/safe_landing_planner/CMakeLists.txt
+++ b/safe_landing_planner/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(safe_landing_planner)
 
-add_definitions(-std=c++11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
catkin build error in Focal ( Ubuntu 20.04 ) due to PCL dependancy
Latest PCL (1.10) requires C++14 as the minimum