### PR TITLE
Fix build warnings

### DIFF
--- a/global_planner/include/global_planner/global_planner.h
+++ b/global_planner/include/global_planner/global_planner.h
@@ -64,11 +64,6 @@ class GlobalPlanner {
   GoalCell goal_pos_ = GoalCell(0.5, 0.5, 3.5);
   bool going_back_ = true;  // we start by just finding the start position
 
-  double overestimate_factor_ = max_overestimate_factor_;
-  std::vector<Cell> curr_path_;
-  PathInfo curr_path_info_;
-  SearchVisitor<std::unordered_set<Cell>, std::unordered_map<Cell, double> > visitor_;
-
   // Dynamic reconfigure parameters
   int min_altitude_ = 1;
   int max_altitude_ = 10;
@@ -93,6 +88,11 @@ class GlobalPlanner {
   bool use_speedup_heuristics_ = true;
   std::string default_node_type_ = "SpeedNode";
   std::string frame_id_ = "world";
+
+  double overestimate_factor_ = max_overestimate_factor_;
+  std::vector<Cell> curr_path_;
+  PathInfo curr_path_info_;
+  SearchVisitor<std::unordered_set<Cell>, std::unordered_map<Cell, double> > visitor_;
 
   GlobalPlanner();
   ~GlobalPlanner();

--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -106,8 +106,7 @@ class GlobalPlannerNode {
   double cmdloop_dt_;
   double plannerloop_dt_;
   double mapupdate_dt_;
-  double min_speed_;
-  double speed_ = min_speed_;
+  double speed_;
   double start_yaw_;
   bool position_received_;
   std::string frame_id_;

--- a/global_planner/src/library/global_planner.cpp
+++ b/global_planner/src/library/global_planner.cpp
@@ -405,6 +405,8 @@ NodePtr GlobalPlanner::getStartNode(const Cell& start, const Cell& parent, const
   }
   if (type == "SpeedNode") {
     return NodePtr(new SpeedNode(start, parent));
+  } else {
+    return NodePtr(new Node(start, parent));
   }
 }
 

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -292,7 +292,7 @@ void GlobalPlannerNode::depthCameraCallback(const sensor_msgs::PointCloud2& msg)
     pointcloud_pub_.publish(msg);
   } catch (tf::TransformException const& ex) {
     ROS_DEBUG("%s", ex.what());
-    ROS_WARN("Transformation not available (%s to /camera_link", frame_id_);
+    ROS_WARN("Transformation not available (%s to /camera_link)", frame_id_.c_str());
   }
 }
 


### PR DESCRIPTION
I tried to build the avoidance repo just now, and the build failed
with clang. The error in clang is just a warning in gcc, so gcc builds,
but with warnings. I've taken the warnings reported by both clang and
gcc, and tried to fix them.

The issues were

* assigning from an uninitialized variable,
* reaching the end of a non-void function, and
* passing a std::string to a "%s" specifier (expects char*).