### PR TITLE
Parameterize camera frame

### DIFF
--- a/global_planner/include/global_planner/global_planner_node.h
+++ b/global_planner/include/global_planner/global_planner_node.h
@@ -110,6 +110,7 @@ class GlobalPlannerNode {
   double start_yaw_;
   bool position_received_;
   std::string frame_id_;
+  std::string camera_frame_id_;
 
   // Dynamic Reconfiguration
   double clicked_goal_alt_;

--- a/global_planner/launch/global_planner_depth-camera.launch
+++ b/global_planner/launch/global_planner_depth-camera.launch
@@ -24,7 +24,7 @@
     <!-- Global planner -->
     <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
         <arg name="pointcloud_topics" value="$(arg pointcloud_topics)" />
-        <arg name="camera_frame_id" value="/$(arg camera_frame_id)" />
+        <arg name="camera_frame_id" value="$(arg camera_frame_id)" />
         <arg name="start_pos_x" value="$(arg start_pos_x)" />
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />

--- a/global_planner/launch/global_planner_depth-camera.launch
+++ b/global_planner/launch/global_planner_depth-camera.launch
@@ -3,6 +3,7 @@
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
     <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
+    <arg name="camera_frame_id" default="camera_link"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
@@ -10,7 +11,7 @@
     <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
     <!-- Ros transformation -->
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+          args="0 0 0 -1.57 0 -1.57 fcu $(arg camera_frame_id) 10"/>
 
     <!-- Launch PX4 and mavros -->
     <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
@@ -23,6 +24,7 @@
     <!-- Global planner -->
     <include file="$(find global_planner)/launch/global_planner_octomap.launch" >
         <arg name="pointcloud_topics" value="$(arg pointcloud_topics)" />
+        <arg name="camera_frame_id" value="/$(arg camera_frame_id)" />
         <arg name="start_pos_x" value="$(arg start_pos_x)" />
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -12,7 +12,7 @@
     <node name="global_planner_node" pkg="global_planner" type="global_planner_node" output="screen"
           args="$(find global_planner)/resource/random_goals"  >
         <param name="frame_id" type="string" value="$(arg frame_id)" />
-        <param name="camera_frame_id" type="string" value="$(arg camera_frame_id)" />
+        <param name="camera_frame_id" type="string" value="/$(arg camera_frame_id)" />
         <param name="start_pos_x" value="$(arg start_pos_x)" />
         <param name="start_pos_y" value="$(arg start_pos_y)" />
         <param name="start_pos_z" value="$(arg start_pos_z)" />

--- a/global_planner/launch/global_planner_octomap.launch
+++ b/global_planner/launch/global_planner_octomap.launch
@@ -1,5 +1,6 @@
 <launch>
     <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
+    <arg name="camera_frame_id" default="camera_link"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
@@ -11,6 +12,7 @@
     <node name="global_planner_node" pkg="global_planner" type="global_planner_node" output="screen"
           args="$(find global_planner)/resource/random_goals"  >
         <param name="frame_id" type="string" value="$(arg frame_id)" />
+        <param name="camera_frame_id" type="string" value="$(arg camera_frame_id)" />
         <param name="start_pos_x" value="$(arg start_pos_x)" />
         <param name="start_pos_y" value="$(arg start_pos_y)" />
         <param name="start_pos_z" value="$(arg start_pos_z)" />

--- a/global_planner/launch/global_planner_sitl_3cam.launch
+++ b/global_planner/launch/global_planner_sitl_3cam.launch
@@ -30,7 +30,7 @@
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />
         <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
-        <arg name="camera_frame_id" value="/$(arg camera_frame_id)" />
+        <arg name="camera_frame_id" value="$(arg camera_frame_id)" />
     </include>
 
     <!-- RViz -->

--- a/global_planner/launch/global_planner_sitl_3cam.launch
+++ b/global_planner/launch/global_planner_sitl_3cam.launch
@@ -3,19 +3,20 @@
     <arg name="world_file_name"    default="simple_obstacle" />
     <arg name="world_path" default="$(find avoidance)/sim/worlds/$(arg world_file_name).world" />
     <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
+    <arg name="camera_frame_id" default="camera_link"/>
     <arg name="start_pos_x" default="0.5" />
     <arg name="start_pos_y" default="0.5" />
     <arg name="start_pos_z" default="3.5" />
 
     <!-- Define a static transform from a camera internal frame to the fcu for every camera used -->
     <node pkg="tf" type="static_transform_publisher" name="tf_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+          args="0 0 0 -1.57 0 -1.57 fcu $(arg camera_frame_id) 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu front_camera_link 10"/>
+          args="0 0 0 -1.57 0 -1.57 fcu front_$(arg camera_frame_id) 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_right_camera"
-          args="0 0 0 -3.14 0 -1.57 fcu right_camera_link 10"/>
+          args="0 0 0 -3.14 0 -1.57 fcu right_$(arg camera_frame_id) 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_left_camera"
-          args="0 0 0 0 0 -1.57 fcu left_camera_link 10"/>
+          args="0 0 0 0 0 -1.57 fcu left_$(arg camera_frame_id) 10"/>
 
     <!-- Launch PX4 and mavros -->
     <include file="$(find avoidance)/launch/avoidance_sitl_mavros.launch" >
@@ -29,6 +30,7 @@
         <arg name="start_pos_y" value="$(arg start_pos_y)" />
         <arg name="start_pos_z" value="$(arg start_pos_z)" />
         <arg name="pointcloud_topics" value="$(arg pointcloud_topics)"/>
+        <arg name="camera_frame_id" value="/$(arg camera_frame_id)" />
     </include>
 
     <!-- RViz -->

--- a/global_planner/src/nodes/global_planner_node.cpp
+++ b/global_planner/src/nodes/global_planner_node.cpp
@@ -65,7 +65,7 @@ GlobalPlannerNode::GlobalPlannerNode(const ros::NodeHandle& nh, const ros::NodeH
   current_goal_.pose.orientation = tf::createQuaternionMsgFromYaw(start_yaw_);
   last_goal_ = current_goal_;
 
-  speed_ = 5.0;
+  speed_ = 2.0;
 
   start_time_ = ros::Time::now();
 }


### PR DESCRIPTION
To use global_planner with real drone system, frame transformation between fcu and camera should work well.

In current code, camera_link is set as default camera frame id but [PX4 Vision Kit](https://docs.px4.io/master/en/complete_vehicles/px4_vision_kit.html) using camera_main_map as figure below.

![PX4VisionKit-tf map](https://drive.google.com/uc?export=view&id=1XsAdoXC4Mv2PhkFHNkLcVKXmYrWyehef)

I think the camera frame should be parameterized in launch file for general use of global_planner.